### PR TITLE
Add fsspec-backed IO adapters

### DIFF
--- a/pipelines/io/reader.py
+++ b/pipelines/io/reader.py
@@ -1,18 +1,38 @@
-from typing import Dict
+from typing import Any, Dict, Optional
+
 from pyspark.sql import SparkSession, DataFrame
 from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
 
+from datacore.io.fs import read_df, storage_options_from_env
 from pipelines.utils.logger import get_logger
 
 
 logger = get_logger("io.reader")
 
 
-@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), before_sleep=before_sleep_log(logger, level=30))
-def read_parquet(spark: SparkSession, path: str) -> DataFrame:
-    """Read Parquet dataset with simple retry policy."""
-    logger.info("reading parquet", extra={"path": path})
-    return spark.read.parquet(path)
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    before_sleep=before_sleep_log(logger, level=30),
+)
+def read_parquet(
+    spark: SparkSession,
+    path: str,
+    *,
+    env: Optional[Dict[str, str]] = None,
+    reader_options: Optional[Dict[str, Any]] = None,
+) -> DataFrame:
+    """Read a Parquet dataset using the shared filesystem adapters."""
+
+    storage_opts = storage_options_from_env(path, env or {}) if path else {}
+    logger.info("reading parquet", extra={"path": path, "storage_options": bool(storage_opts)})
+    return read_df(
+        path,
+        "parquet",
+        spark=spark,
+        storage_options=storage_opts,
+        reader_options=reader_options or {},
+    )
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), before_sleep=before_sleep_log(logger, level=30))

--- a/pipelines/io/writer.py
+++ b/pipelines/io/writer.py
@@ -1,33 +1,52 @@
-from typing import Optional, Sequence
-from pyspark.sql import DataFrame
+from typing import Any, Dict, Optional, Sequence
+
 from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
 
+from datacore.io.fs import storage_options_from_env, write_df
 from pipelines.utils.logger import get_logger
 
 
 logger = get_logger("io.writer")
 
 
-@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), before_sleep=before_sleep_log(logger, level=30))
-def write_parquet(df: DataFrame, path: str, mode: str = "overwrite", partition_by: Optional[Sequence[str]] = None, coalesce: Optional[int] = None, repartition: Optional[int] = None) -> None:
-    """Write a DataFrame to Parquet with optional partitioning and basic optimizations.
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    before_sleep=before_sleep_log(logger, level=30),
+)
+def write_parquet(
+    df: Any,
+    path: str,
+    *,
+    mode: str = "overwrite",
+    partition_by: Optional[Sequence[str]] = None,
+    coalesce: Optional[int] = None,
+    repartition: Optional[int] = None,
+    env: Optional[Dict[str, str]] = None,
+    writer_options: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Write a DataFrame to Parquet using the shared filesystem adapters."""
 
-    Args:
-        df: Spark DataFrame a escribir.
-        path: Ruta destino (local o s3a://...).
-        mode: Política de escritura (overwrite/append).
-        partition_by: Columnas para particionar.
-        coalesce: Número de particiones para coalesce antes de escribir.
-        repartition: Número de particiones para repartition antes de escribir.
-    """
-    tmp = df
-    if repartition and repartition > 0:
-        tmp = tmp.repartition(repartition)
-    if coalesce and coalesce > 0:
-        tmp = tmp.coalesce(coalesce)
-
-    writer = tmp.write.mode(mode)
-    if partition_by:
-        writer = writer.partitionBy(*partition_by)
-    logger.info("writing parquet", extra={"path": path, "mode": mode, "partition_by": partition_by, "coalesce": coalesce, "repartition": repartition})
-    writer.parquet(path)
+    storage_opts = storage_options_from_env(path, env or {}) if path else {}
+    logger.info(
+        "writing parquet",
+        extra={
+            "path": path,
+            "mode": mode,
+            "partition_by": partition_by,
+            "coalesce": coalesce,
+            "repartition": repartition,
+            "storage_options": bool(storage_opts),
+        },
+    )
+    write_df(
+        df,
+        path,
+        "parquet",
+        mode=mode,
+        partition_by=partition_by,
+        coalesce=coalesce,
+        repartition=repartition,
+        storage_options=storage_opts,
+        writer_options=writer_options or {},
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ click==8.1.7
 pyyaml==6.0.2
 jsonschema==4.23.0
 pyspark==3.5.1
+fsspec>=2024.2.0
+s3fs>=2024.2.0
+adlfs>=2024.2.0
+gcsfs>=2024.2.0
 pyarrow>=14.0.0
 pandas>=2.0.0
 requests>=2.31.0

--- a/src/datacore/io/__init__.py
+++ b/src/datacore/io/__init__.py
@@ -1,0 +1,5 @@
+"""IO adapters bridging Spark and fsspec-backed filesystems."""
+
+from .fs import read_df, write_df, storage_options_from_env
+
+__all__ = ["read_df", "write_df", "storage_options_from_env"]

--- a/src/datacore/io/fs.py
+++ b/src/datacore/io/fs.py
@@ -1,0 +1,470 @@
+"""Filesystem-backed DataFrame IO utilities.
+
+This module provides high-level helpers to read and write tabular data stored on
+filesystems supported by ``fsspec``. It favors Apache Spark when available, but
+also supports pandas and polars as fallbacks. Remote URI schemes (``s3://``,
+``s3a://``, ``abfss://``, ``gs://``) are normalized to the appropriate fsspec
+filesystem implementation and credentials can be injected using the project
+``env`` configuration.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import tempfile
+import weakref
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+import fsspec
+
+try:  # Optional dependency
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas is optional for tests
+    pd = None  # type: ignore
+
+try:  # Optional dependency
+    import polars as pl
+except Exception:  # pragma: no cover - polars is optional for tests
+    pl = None  # type: ignore
+
+
+_SPARK_DF_TYPE = None
+try:  # pragma: no cover - Spark may not be installed in tests
+    from pyspark.sql import DataFrame as _SparkDataFrame  # type: ignore
+
+    _SPARK_DF_TYPE = _SparkDataFrame
+except Exception:  # pragma: no cover - keep optional dependency optional
+    _SPARK_DF_TYPE = None
+
+
+@dataclass
+class _StagedData:
+    """Represents a local staging area for remote files."""
+
+    path: str
+    cleanup: Callable[[], None]
+
+
+def _normalize_protocol(protocol: Optional[str]) -> str:
+    if not protocol:
+        return "file"
+    if protocol == "s3a":
+        return "s3"
+    return protocol
+
+
+def _split_uri(uri: str) -> Tuple[str, str]:
+    protocol, path = fsspec.core.split_protocol(uri)
+    protocol = _normalize_protocol(protocol)
+    if path.startswith("//"):
+        # fsspec returns paths like //bucket/key for some schemes
+        path = path[2:]
+    return protocol, path
+
+
+def _boolish(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _load_env_value(env_cfg: Dict[str, Any], key: str, default_env_var: str) -> Optional[str]:
+    env_var_name = env_cfg.get(key)
+    if env_var_name:
+        return os.environ.get(env_var_name)
+    return os.environ.get(default_env_var)
+
+
+def storage_options_from_env(uri: str, env_cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Build fsspec storage options using the existing env configuration."""
+
+    env_cfg = env_cfg or {}
+    protocol, _ = _split_uri(uri)
+    opts: Dict[str, Any] = {}
+
+    if protocol == "s3":
+        access_key = _load_env_value(env_cfg, "s3a_access_key_env", "AWS_ACCESS_KEY_ID")
+        secret_key = _load_env_value(env_cfg, "s3a_secret_key_env", "AWS_SECRET_ACCESS_KEY")
+        session_token = _load_env_value(env_cfg, "s3a_session_token_env", "AWS_SESSION_TOKEN")
+        endpoint = env_cfg.get("s3a_endpoint") or os.environ.get("AWS_ENDPOINT_URL")
+
+        if access_key:
+            opts["key"] = access_key
+        if secret_key:
+            opts["secret"] = secret_key
+        if session_token:
+            opts["token"] = session_token
+
+        client_kwargs: Dict[str, Any] = {}
+        if endpoint:
+            client_kwargs["endpoint_url"] = endpoint
+
+        disable_ssl = env_cfg.get("s3a_disable_ssl") or os.environ.get("S3A_DISABLE_SSL")
+        if disable_ssl is not None:
+            client_kwargs["use_ssl"] = not _boolish(disable_ssl)
+
+        if client_kwargs:
+            opts["client_kwargs"] = client_kwargs
+
+    return opts
+
+
+def _filesystem(uri: str, storage_options: Optional[Dict[str, Any]] = None):
+    protocol, path = _split_uri(uri)
+    fs = fsspec.filesystem(protocol, **(storage_options or {}))
+    return fs, path
+
+
+def _stage_to_local(fs, path: str) -> _StagedData:
+    temp_dir = tempfile.mkdtemp(prefix="dcfs-")
+
+    def cleanup() -> None:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    local_target: Optional[str] = None
+    try:
+        if hasattr(fs, "isdir") and fs.isdir(path):
+            local_target = os.path.join(temp_dir, "data")
+            os.makedirs(local_target, exist_ok=True)
+            fs.get(path, local_target, recursive=True)
+        else:
+            matches: List[str] = []
+            if hasattr(fs, "glob"):
+                matches = fs.glob(path)
+            if matches:
+                local_target = os.path.join(temp_dir, "data")
+                os.makedirs(local_target, exist_ok=True)
+                for remote in matches:
+                    basename = os.path.basename(remote.rstrip("/"))
+                    if not basename:
+                        basename = "part"
+                    dest = os.path.join(local_target, basename)
+                    fs.get(remote, dest)
+            elif hasattr(fs, "exists") and fs.exists(path):
+                basename = os.path.basename(path.rstrip("/")) or "part"
+                local_target = os.path.join(temp_dir, basename)
+                fs.get(path, local_target)
+            else:
+                raise FileNotFoundError(f"No data found at {path}")
+    except Exception:
+        cleanup()
+        raise
+
+    return _StagedData(local_target or temp_dir, cleanup)
+
+
+def _spark_df_like(df: Any) -> bool:
+    if _SPARK_DF_TYPE is not None and isinstance(df, _SPARK_DF_TYPE):
+        return True
+    return hasattr(df, "write") and hasattr(df, "repartition")
+
+
+def _spark_reader(spark, fmt: str, path: str, options: Dict[str, Any]):
+    reader = spark.read
+    if options:
+        reader = reader.options(**options)
+    fmt_norm = fmt.lower()
+    if fmt_norm == "parquet":
+        return reader.parquet(path)
+    if fmt_norm == "csv":
+        return reader.csv(path)
+    if fmt_norm in {"json", "jsonl"}:
+        return reader.json(path)
+    raise ValueError(f"Unsupported format for Spark reader: {fmt}")
+
+
+def _iter_local_files(local_path: str) -> List[str]:
+    if os.path.isdir(local_path):
+        pattern = os.path.join(local_path, "**", "*")
+        return [p for p in glob.glob(pattern, recursive=True) if os.path.isfile(p)]
+    return [local_path]
+
+
+def _filter_reader_options(fmt: str, options: Dict[str, Any]) -> Dict[str, Any]:
+    fmt_norm = fmt.lower()
+    filtered: Dict[str, Any] = {}
+    for key, value in options.items():
+        if fmt_norm == "csv":
+            if key == "sep":
+                filtered["sep"] = value
+            elif key == "header":
+                filtered["header"] = 0 if _boolish(value) else None
+            elif key == "encoding":
+                filtered["encoding"] = value
+        elif fmt_norm in {"json", "jsonl"}:
+            if key == "multiline":
+                filtered["lines"] = not _boolish(value)
+            elif key == "encoding":
+                filtered["encoding"] = value
+        elif fmt_norm == "parquet":
+            filtered[key] = value
+    if fmt_norm == "jsonl":
+        filtered.setdefault("lines", True)
+    return filtered
+
+
+def _pandas_reader(fmt: str, files: Iterable[str], options: Dict[str, Any]):
+    if pd is None:
+        raise RuntimeError("pandas is not available")
+
+    fmt_norm = fmt.lower()
+    frames: List["pd.DataFrame"] = []
+    for file_path in files:
+        if fmt_norm == "parquet":
+            frames.append(pd.read_parquet(file_path, **options))
+        elif fmt_norm == "csv":
+            frames.append(pd.read_csv(file_path, **options))
+        elif fmt_norm in {"json", "jsonl"}:
+            frames.append(pd.read_json(file_path, **options))
+        else:
+            raise ValueError(f"Unsupported format for pandas reader: {fmt}")
+    if not frames:
+        return pd.DataFrame()
+    if len(frames) == 1:
+        return frames[0]
+    return pd.concat(frames, ignore_index=True)
+
+
+def _polars_reader(fmt: str, files: Iterable[str], options: Dict[str, Any]):
+    if pl is None:
+        raise RuntimeError("polars is not available")
+
+    fmt_norm = fmt.lower()
+    frames: List["pl.DataFrame"] = []
+    for file_path in files:
+        if fmt_norm == "parquet":
+            frames.append(pl.read_parquet(file_path, **options))
+        elif fmt_norm == "csv":
+            frames.append(pl.read_csv(file_path, **options))
+        elif fmt_norm in {"json", "jsonl"}:
+            frames.append(pl.read_json(file_path, **options))
+        else:
+            raise ValueError(f"Unsupported format for polars reader: {fmt}")
+    if not frames:
+        return pl.DataFrame()
+    if len(frames) == 1:
+        return frames[0]
+    return pl.concat(frames)
+
+
+def read_df(
+    uri: str,
+    fmt: str,
+    *,
+    spark=None,
+    engine: str = "auto",
+    storage_options: Optional[Dict[str, Any]] = None,
+    reader_options: Optional[Dict[str, Any]] = None,
+):
+    """Read a dataset from the given URI and return a DataFrame."""
+
+    reader_options = dict(reader_options or {})
+    fs, path = _filesystem(uri, storage_options)
+    fmt_norm = fmt.lower()
+
+    last_error: Optional[Exception] = None
+
+    if engine in {"spark", "auto"} and spark is not None:
+        staged = None
+        try:
+            staged = _stage_to_local(fs, path)
+            df = _spark_reader(spark, fmt_norm, staged.path, reader_options)
+            weakref.finalize(df, staged.cleanup)
+            return df
+        except Exception as exc:
+            if staged:
+                staged.cleanup()
+            if engine == "spark":
+                raise
+            last_error = exc
+
+    staged = _stage_to_local(fs, path)
+    local_files = _iter_local_files(staged.path)
+    local_options = _filter_reader_options(fmt_norm, reader_options)
+
+    if engine in {"auto", "pandas"}:
+        try:
+            pdf = _pandas_reader(fmt_norm, local_files, local_options)
+            if spark is not None:
+                return spark.createDataFrame(pdf)
+            staged.cleanup()
+            return pdf
+        except Exception as exc:
+            last_error = exc
+    if engine in {"auto", "polars"}:
+        try:
+            pldf = _polars_reader(fmt_norm, local_files, local_options)
+            if spark is not None:
+                pdf = pldf.to_pandas()
+                return spark.createDataFrame(pdf)
+            staged.cleanup()
+            return pldf
+        except Exception as exc:
+            last_error = exc
+
+    staged.cleanup()
+    if last_error:
+        raise RuntimeError(f"Failed to read {uri}: {last_error}")
+    raise RuntimeError(f"Failed to read {uri}: unknown error")
+
+
+def _ensure_directory(fs, path: str) -> None:
+    if not path:
+        return
+    dirname = os.path.dirname(path)
+    if dirname and hasattr(fs, "makedirs"):
+        fs.makedirs(dirname, exist_ok=True)
+
+
+def _spark_writer(
+    df: Any,
+    fmt: str,
+    path: str,
+    fs,
+    mode: str,
+    partition_by: Optional[Iterable[str]],
+    writer_options: Dict[str, Any],
+    coalesce: Optional[int],
+    repartition: Optional[int],
+) -> None:
+    temp_dir = tempfile.mkdtemp(prefix="dcfs-write-")
+    local_path = os.path.join(temp_dir, "data")
+    os.makedirs(local_path, exist_ok=True)
+    try:
+        tmp_df = df
+        if repartition:
+            tmp_df = tmp_df.repartition(repartition)
+        if coalesce:
+            tmp_df = tmp_df.coalesce(coalesce)
+
+        writer = tmp_df.write.mode(mode)
+        if writer_options:
+            writer = writer.options(**writer_options)
+        if partition_by:
+            writer = writer.partitionBy(*partition_by)
+
+        fmt_norm = fmt.lower()
+        if fmt_norm == "parquet":
+            writer.parquet(local_path)
+        elif fmt_norm == "csv":
+            writer.csv(local_path)
+        elif fmt_norm in {"json", "jsonl"}:
+            writer.json(local_path)
+        else:
+            raise ValueError(f"Unsupported format for Spark writer: {fmt}")
+
+        if mode == "overwrite" and hasattr(fs, "exists") and fs.exists(path):
+            fs.rm(path, recursive=True)
+        fs.put(local_path, path, recursive=True)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _choose_file_name(path: str, fmt: str) -> str:
+    if path.endswith("/"):
+        ext = {
+            "parquet": ".parquet",
+            "csv": ".csv",
+            "json": ".json",
+            "jsonl": ".jsonl",
+        }.get(fmt.lower(), "")
+        return path + f"part-0000{ext}"
+    return path
+
+
+def _pandas_writer(df: "pd.DataFrame", fmt: str, fs, path: str, mode: str, writer_options: Dict[str, Any]) -> None:
+    fmt_norm = fmt.lower()
+    target = _choose_file_name(path, fmt_norm)
+    if mode == "overwrite" and hasattr(fs, "exists") and fs.exists(target):
+        fs.rm(target)
+    _ensure_directory(fs, target)
+
+    if fmt_norm == "parquet":
+        with fs.open(target, "wb") as handle:
+            df.to_parquet(handle, index=False, **writer_options)
+    elif fmt_norm == "csv":
+        with fs.open(target, "w", newline="") as handle:
+            df.to_csv(handle, index=False, **writer_options)
+    elif fmt_norm in {"json", "jsonl"}:
+        lines = fmt_norm == "jsonl"
+        with fs.open(target, "w") as handle:
+            df.to_json(handle, orient="records", lines=lines, **writer_options)
+    else:
+        raise ValueError(f"Unsupported format for pandas writer: {fmt}")
+
+
+def _polars_writer(df: "pl.DataFrame", fmt: str, fs, path: str, mode: str, writer_options: Dict[str, Any]) -> None:
+    fmt_norm = fmt.lower()
+    target = _choose_file_name(path, fmt_norm)
+    if mode == "overwrite" and hasattr(fs, "exists") and fs.exists(target):
+        fs.rm(target)
+    _ensure_directory(fs, target)
+
+    if fmt_norm == "parquet":
+        with fs.open(target, "wb") as handle:
+            df.write_parquet(handle, **writer_options)
+    elif fmt_norm == "csv":
+        with fs.open(target, "w", newline="") as handle:
+            df.write_csv(handle, **writer_options)
+    elif fmt_norm in {"json", "jsonl"}:
+        if pd is not None:
+            _pandas_writer(df.to_pandas(), fmt, fs, path, mode, writer_options)
+        else:
+            raise ValueError("polars JSON writing requires pandas as dependency")
+    else:
+        raise ValueError(f"Unsupported format for polars writer: {fmt}")
+
+
+def write_df(
+    df: Any,
+    uri: str,
+    fmt: str,
+    *,
+    mode: str = "overwrite",
+    partition_by: Optional[Iterable[str]] = None,
+    coalesce: Optional[int] = None,
+    repartition: Optional[int] = None,
+    engine: str = "auto",
+    storage_options: Optional[Dict[str, Any]] = None,
+    writer_options: Optional[Dict[str, Any]] = None,
+):
+    """Write a DataFrame to a filesystem-backed destination."""
+
+    writer_options = dict(writer_options or {})
+    fs, path = _filesystem(uri, storage_options)
+    fmt_norm = fmt.lower()
+
+    last_error: Optional[Exception] = None
+
+    if engine in {"spark", "auto"} and _spark_df_like(df):
+        try:
+            _spark_writer(df, fmt_norm, path, fs, mode, partition_by, writer_options, coalesce, repartition)
+            return
+        except Exception as exc:
+            if engine == "spark":
+                raise
+            last_error = exc
+
+    if pd is not None and isinstance(df, pd.DataFrame) and engine in {"auto", "pandas"}:
+        _pandas_writer(df, fmt_norm, fs, path, mode, writer_options)
+        return
+
+    if pl is not None and isinstance(df, pl.DataFrame) and engine in {"auto", "polars"}:
+        _polars_writer(df, fmt_norm, fs, path, mode, writer_options)
+        return
+
+    if last_error:
+        raise RuntimeError(f"Failed to write {uri}: {last_error}")
+    raise RuntimeError("Unsupported DataFrame type for write_df")
+
+
+__all__ = [
+    "read_df",
+    "write_df",
+    "storage_options_from_env",
+]

--- a/tests/test_io_fs.py
+++ b/tests/test_io_fs.py
@@ -1,0 +1,253 @@
+import glob
+import os
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import pytest
+
+from datacore.io import fs as fs_mod
+from datacore.io.fs import read_df, write_df, storage_options_from_env
+
+
+class DummyFS:
+    def __init__(self, base_dir: Path):
+        self.base_dir = Path(base_dir)
+
+    def _normalize(self, path: str) -> Path:
+        cleaned = (path or "").lstrip("/")
+        if not cleaned:
+            return self.base_dir
+        return self.base_dir / cleaned.replace("/", os.sep)
+
+    def open(self, path: str, mode: str = "r", newline=None):
+        full = self._normalize(path)
+        full.parent.mkdir(parents=True, exist_ok=True)
+        return open(full, mode, newline=newline)
+
+    def glob(self, pattern: str) -> List[str]:
+        full_pattern = self.base_dir / pattern.replace("/", os.sep)
+        matches = glob.glob(str(full_pattern), recursive=True)
+        return [str(Path(m).relative_to(self.base_dir)).replace(os.sep, "/") for m in matches]
+
+    def isdir(self, path: str) -> bool:
+        return self._normalize(path).is_dir()
+
+    def exists(self, path: str) -> bool:
+        return self._normalize(path).exists()
+
+    def get(self, path: str, dest: str, recursive: bool = False):
+        src = self._normalize(path)
+        dest_path = Path(dest)
+        if src.is_dir():
+            if recursive:
+                if dest_path.exists():
+                    shutil.rmtree(dest_path, ignore_errors=True)
+                shutil.copytree(src, dest_path)
+            else:
+                shutil.copy(src, dest_path)
+        else:
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest_path)
+
+    def put(self, local: str, dest: str, recursive: bool = False):
+        src_path = Path(local)
+        dest_path = self._normalize(dest)
+        if recursive and src_path.is_dir():
+            if dest_path.exists():
+                shutil.rmtree(dest_path, ignore_errors=True)
+            shutil.copytree(src_path, dest_path)
+        else:
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_path, dest_path)
+
+    def rm(self, path: str, recursive: bool = False):
+        target = self._normalize(path)
+        if target.is_dir():
+            shutil.rmtree(target, ignore_errors=True)
+        elif target.exists():
+            target.unlink()
+
+    def makedirs(self, path: str, exist_ok: bool = False):
+        self._normalize(path).mkdir(parents=True, exist_ok=exist_ok)
+
+
+class DummySparkDataFrame:
+    def __init__(self, pdf: pd.DataFrame):
+        self._pdf = pdf
+
+    def repartition(self, _parts: int):
+        return self
+
+    def coalesce(self, _parts: int):
+        return self
+
+    @property
+    def write(self):
+        return DummySparkWriter(self._pdf)
+
+
+class DummySparkWriter:
+    def __init__(self, pdf: pd.DataFrame):
+        self.pdf = pdf
+
+    def mode(self, _mode: str):
+        return self
+
+    def options(self, **_opts: Dict[str, str]):
+        return self
+
+    def partitionBy(self, *_cols: str):
+        return self
+
+    def parquet(self, path: str):
+        os.makedirs(path, exist_ok=True)
+        self.pdf.to_csv(os.path.join(path, "part-0000.parquet"), index=False)
+
+    def csv(self, path: str):
+        os.makedirs(path, exist_ok=True)
+        self.pdf.to_csv(os.path.join(path, "part-0000.csv"), index=False)
+
+    def json(self, path: str):
+        os.makedirs(path, exist_ok=True)
+        self.pdf.to_json(os.path.join(path, "part-0000.json"), orient="records", lines=True)
+
+
+class DummySparkReader:
+    def __init__(self):
+        self.options_dict: Dict[str, str] = {}
+
+    def options(self, **opts: Dict[str, str]):
+        self.options_dict.update(opts)
+        return self
+
+    def _resolve_files(self, path: str) -> List[str]:
+        if os.path.isdir(path):
+            pattern = os.path.join(path, "**", "*")
+            return [p for p in glob.glob(pattern, recursive=True) if os.path.isfile(p)]
+        return [path]
+
+    def csv(self, path: str):
+        header_opt = self.options_dict.get("header")
+        use_header = str(header_opt).lower() not in {"false", "0"}
+        encoding = self.options_dict.get("encoding")
+        sep = self.options_dict.get("sep")
+        frames = [
+            pd.read_csv(
+                f,
+                header=0 if use_header else None,
+                encoding=encoding,
+                sep=sep,
+                engine="python",
+            )
+            for f in self._resolve_files(path)
+        ]
+        return DummySparkDataFrame(pd.concat(frames, ignore_index=True))
+
+    def json(self, path: str):
+        multiline = self.options_dict.get("multiline")
+        lines = not (str(multiline).lower() in {"true", "1"})
+        encoding = self.options_dict.get("encoding")
+        frames = [
+            pd.read_json(f, lines=lines, encoding=encoding)
+            for f in self._resolve_files(path)
+        ]
+        return DummySparkDataFrame(pd.concat(frames, ignore_index=True))
+
+    def parquet(self, path: str):
+        frames = [pd.read_csv(f) for f in self._resolve_files(path)]
+        return DummySparkDataFrame(pd.concat(frames, ignore_index=True))
+
+
+class DummySparkSession:
+    def __init__(self):
+        self._reader = DummySparkReader()
+
+    @property
+    def read(self):
+        self._reader = DummySparkReader()
+        return self._reader
+
+    def createDataFrame(self, pdf: pd.DataFrame):
+        return DummySparkDataFrame(pdf)
+
+
+def _strip_protocol(uri: str) -> str:
+    return uri.split("://", 1)[1]
+
+
+@pytest.mark.parametrize(
+    "uri, protocol",
+    [
+        ("s3a://bucket/data/sample.csv", "s3"),
+        ("abfss://container/data/sample.csv", "abfss"),
+        ("gs://bucket/data/sample.csv", "gs"),
+    ],
+)
+def test_read_and_write_roundtrip(monkeypatch, tmp_path, uri, protocol):
+    base_dir = tmp_path / protocol
+    base_dir.mkdir()
+    fs_stub = DummyFS(base_dir)
+
+    def fake_filesystem(requested: str, **_opts):
+        assert requested == protocol
+        return fs_stub
+
+    monkeypatch.setattr(fs_mod.fsspec, "filesystem", fake_filesystem)
+
+    remote_path = _strip_protocol(uri)
+    with fs_stub.open(remote_path, "w") as handle:
+        handle.write("id,value\n1,foo\n2,bar\n")
+
+    spark = DummySparkSession()
+
+    df = read_df(uri, "csv", spark=spark, storage_options={})
+    assert isinstance(df, DummySparkDataFrame)
+    assert df._pdf.shape == (2, 2)
+
+    out_uri = uri.replace("sample.csv", "output/")
+    write_df(df, out_uri, "parquet", storage_options={})
+
+    out_path = _strip_protocol(out_uri)
+    parquet_files = [p for p in fs_stub.glob(f"{out_path}**") if p.endswith(".parquet")]
+    assert parquet_files
+
+    df_back = read_df(out_uri, "parquet", spark=spark, storage_options={})
+    assert df_back._pdf.equals(df._pdf)
+
+
+def test_read_with_wildcard(monkeypatch, tmp_path):
+    base_dir = tmp_path / "s3"
+    base_dir.mkdir()
+    fs_stub = DummyFS(base_dir)
+
+    def fake_filesystem(requested: str, **_opts):
+        assert requested == "s3"
+        return fs_stub
+
+    monkeypatch.setattr(fs_mod.fsspec, "filesystem", fake_filesystem)
+
+    with fs_stub.open("bucket/data/part1.csv", "w") as handle:
+        handle.write("id,value\n1,a\n")
+    with fs_stub.open("bucket/data/part2.csv", "w") as handle:
+        handle.write("id,value\n2,b\n")
+
+    spark = DummySparkSession()
+    df = read_df("s3a://bucket/data/*.csv", "csv", spark=spark, storage_options={})
+    assert df._pdf.shape == (2, 2)
+
+
+def test_storage_options_from_env(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA123")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "token")
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://example.com")
+    monkeypatch.setenv("S3A_DISABLE_SSL", "false")
+
+    opts = storage_options_from_env("s3a://bucket/data", {})
+    assert opts["key"] == "AKIA123"
+    assert opts["secret"] == "secret"
+    assert opts["token"] == "token"
+    assert opts["client_kwargs"]["endpoint_url"] == "https://example.com"
+    assert "use_ssl" in opts["client_kwargs"]


### PR DESCRIPTION
## Summary
- add a datacore.io filesystem module that stages remote data via fsspec with Spark-first semantics and pandas/polars fallbacks
- refactor the parquet reader/writer helpers and dataset source loading to delegate URI handling to the new adapters
- cover the new module with filesystem-mocked tests for s3, abfss, and gcs plus document fsspec dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fbb55b4d788320abcf05d5be4394fe