### PR TITLE
Add build-and-test CI workflow with coverage thresholds

### DIFF
--- a/ci/build-test.yml
+++ b/ci/build-test.yml
@@ -1,0 +1,43 @@
+name: Build & Test
+
+on:
+  push:
+    branches:
+      - feature/main-codex
+  pull_request:
+    branches:
+      - feature/main-codex
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install build
+
+      - name: Build wheel
+        run: python -m build
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvp-config-driven-${{ matrix.python-version }}-wheel
+          path: dist/*.whl
+
+      - name: Run tests with coverage
+        env:
+          PYTHONPATH: src
+        run: pytest --cov=src/datacore --cov-report=term-missing

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    branches:
+      - main
 
 jobs:
   lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,14 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 addopts = "-q"
 pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["src/datacore"]
+
+[tool.coverage.report]
+fail_under = 60
+include = [
+    "src/datacore/layers/*",
+    "src/datacore/pipeline/*",
+]


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build wheels, upload artifacts, and run tests across Python 3.10–3.12
- configure coverage.py to require at least 60% coverage for datacore layers and pipeline modules
- scope the existing lint workflow to only run on pull requests against main so feature/main-codex relies on the new flow

## Testing
- pytest --cov=src/datacore --cov-report=term-missing *(fails: missing optional dependency pydantic in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc1ee9056c8320839e292aded82117