### PR TITLE
Add cloud run-layer operations guides and job templates

### DIFF
--- a/docs/PROJECT_DOCUMENTATION.md
+++ b/docs/PROJECT_DOCUMENTATION.md
@@ -44,6 +44,12 @@ Este documento centraliza la arquitectura, módulos, configuraciones, ejecución
 - Notebooks:
   - `docs/01_pipeline_explicacion.ipynb`: flujo E2E con Quick Start (`USE_QS`), métricas por etapa y verificación.
   - `docs/01_pipeline_explicacion_min.ipynb`: validación rápida de PySpark y Parquet.
+- Operación en plataformas cloud:
+  - `docs/run/databricks.md`: wheel tasks de Databricks Jobs con ejemplos `dry-run` y dependencia por capa.
+  - `docs/run/aws.md`: despliegue en AWS Glue + Step Functions.
+  - `docs/run/gcp.md`: workflows de Dataproc con templates parametrizados.
+  - `docs/run/azure.md`: ejecución en Synapse Spark job definitions.
+  - `docs/run/jobs/`: artefactos JSON/YAML listos para importar (Jobs, Workflows, Step Functions).
 
 ## Ingesta Multi-Fuente
 

--- a/docs/run/aws.md
+++ b/docs/run/aws.md
@@ -1,0 +1,98 @@
+# Ejecución de `prodi run-layer` en AWS Glue
+
+Esta guía describe cómo orquestar el pipeline de capas (raw → bronze → silver →
+gold) en AWS Glue utilizando jobs basados en wheel y comandos `prodi run-layer`.
+
+## 1. Empaquetar y publicar el wheel
+
+1. Construye el wheel del proyecto:
+   ```bash
+   poetry build -f wheel
+   ```
+2. Carga el artefacto a un bucket S3 accesible desde Glue:
+   ```bash
+   aws s3 cp dist/prodi-1.4.0-py3-none-any.whl s3://datalake-artifacts/prodi/
+   ```
+
+## 2. Configurar el Job de Glue
+
+Crea un Job de tipo Python shell 3.9 o Spark (según la capa) y define como script
+principal el entrypoint del wheel usando `--additional-python-modules`.
+
+```bash
+aws glue create-job \
+  --name prodi-layer-raw \
+  --role AWSGlueServiceRoleDefault \
+  --command '{
+    "Name": "glueetl",
+    "PythonVersion": "3",
+    "ScriptLocation": "s3://datalake-artifacts/scripts/prodi_glue_entry.py"
+  }' \
+  --default-arguments '{
+    "--additional-python-modules": "s3://datalake-artifacts/prodi/prodi-1.4.0-py3-none-any.whl",
+    "--extra-py-files": "s3://datalake-artifacts/config/cfg.zip",
+    "--layer": "raw",
+    "--config": "s3://datalake-artifacts/cfg/run/raw.yml"
+  }'
+```
+
+El script `prodi_glue_entry.py` expone la invocación al entrypoint:
+
+```python
+import prodi.cli
+
+if __name__ == "__main__":
+    prodi.cli.main(["run-layer"])
+```
+
+### Encadenar capas
+
+Define un job por capa y utiliza Workflows de Glue o Step Functions para
+ejecutarlos secuencialmente:
+
+```json
+{
+  "Comment": "Cadena prodi",
+  "StartAt": "raw",
+  "States": {
+    "raw": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {"JobName": "prodi-layer-raw"},
+      "Next": "bronze"
+    },
+    "bronze": {"Type": "Task", "Resource": "arn:aws:states:::glue:startJobRun.sync", "Parameters": {"JobName": "prodi-layer-bronze"}, "Next": "silver"},
+    "silver": {"Type": "Task", "Resource": "arn:aws:states:::glue:startJobRun.sync", "Parameters": {"JobName": "prodi-layer-silver"}, "Next": "gold"},
+    "gold": {"Type": "Task", "Resource": "arn:aws:states:::glue:startJobRun.sync", "Parameters": {"JobName": "prodi-layer-gold"}, "End": true}
+  }
+}
+```
+
+Consulta definiciones listas para usar en [`docs/run/jobs/`](jobs/).
+
+## 3. Validación `dry-run`
+
+Ejecuta pruebas en modo validación agregando el argumento `--dry-run`:
+
+```bash
+aws glue start-job-run --job-name prodi-layer-raw --arguments '{"--dry-run":"true"}'
+```
+
+En entornos de QA puedes forzar el flag desde la definición del job en
+`--default-arguments` y sobreescribirlo en producción.
+
+## 4. Parámetros dinámicos
+
+* Define parámetros globales en el Workflow y pásalos a cada job como
+  `--env=prod` o `--date=2024-03-31`.
+* Usa AWS Secrets Manager para credenciales y recupéralos en tiempo de ejecución
+  con `boto3` antes de invocar `prodi run-layer`.
+
+## 5. Observabilidad
+
+* Activa CloudWatch Logs para cada job y configura métricas de error.
+* Exporta el catálogo de datasets actualizado tras cada ejecución a S3 para
+  trazabilidad.
+
+Siguiendo estos pasos puedes ejecutar las cuatro capas de manera modular y
+reprocesar sólo la capa afectada ante incidentes.

--- a/docs/run/azure.md
+++ b/docs/run/azure.md
@@ -1,0 +1,111 @@
+# Ejecución de `prodi run-layer` en Azure Synapse
+
+Esta guía cubre la ejecución del pipeline por capas en Synapse Pipelines con
+notebooks o actividades de Spark que consumen el wheel de `prodi`.
+
+## 1. Publicar el wheel en un workspace
+
+1. Construye el wheel localmente:
+   ```bash
+   poetry build -f wheel
+   ```
+2. Carga el artefacto al almacenamiento ligado al workspace (por ejemplo ADLS):
+   ```bash
+   az storage blob upload \
+     --account-name datalake \
+     --container-name artifacts \
+     --file dist/prodi-1.4.0-py3-none-any.whl \
+     --name libs/prodi-1.4.0-py3-none-any.whl
+   ```
+
+## 2. Configurar un Spark job definition
+
+Crea una [Spark job definition](https://learn.microsoft.com/azure/synapse-analytics/spark/spark-job-definitions)
+que invoque el entrypoint de `prodi`.
+
+```json
+{
+  "name": "prodi-layer-raw",
+  "type": "SparkJobDefinition",
+  "properties": {
+    "file": "abfss://artifacts@datalake.dfs.core.windows.net/scripts/prodi_synapse_entry.py",
+    "className": "",
+    "args": ["--layer", "raw", "--config", "abfss://artifacts@datalake.dfs.core.windows.net/cfg/run/raw.yml"],
+    "packages": ["abfss://artifacts@datalake.dfs.core.windows.net/libs/prodi-1.4.0-py3-none-any.whl"],
+    "driverMemory": "8g",
+    "executorMemory": "8g",
+    "executorCores": 4
+  }
+}
+```
+
+Replica la definición para bronze, silver y gold cambiando `args` y el nombre.
+
+## 3. Orquestar con Synapse Pipelines
+
+Dentro de una pipeline usa actividades **Execute Spark job** con dependencias
+secuenciales:
+
+```yaml
+activities:
+  - name: raw
+    type: SynapseNotebook
+    dependsOn: []
+    typeProperties:
+      sparkJob: prodi-layer-raw
+  - name: bronze
+    dependsOn:
+      - activity: raw
+        dependencyConditions: [Succeeded]
+    type: SynapseNotebook
+    typeProperties:
+      sparkJob: prodi-layer-bronze
+  - name: silver
+    dependsOn:
+      - activity: bronze
+        dependencyConditions: [Succeeded]
+    type: SynapseNotebook
+    typeProperties:
+      sparkJob: prodi-layer-silver
+  - name: gold
+    dependsOn:
+      - activity: silver
+        dependencyConditions: [Succeeded]
+    type: SynapseNotebook
+    typeProperties:
+      sparkJob: prodi-layer-gold
+```
+
+Revisa configuraciones listas para importar en [`docs/run/jobs/`](jobs/).
+
+## 4. Script de entrada y parámetros
+
+El script `prodi_synapse_entry.py` debe reenviar los argumentos recibidos:
+
+```python
+import sys
+from prodi.cli import main
+
+if __name__ == "__main__":
+    main(["run-layer", *sys.argv[1:]])
+```
+
+Pasa parámetros a nivel de pipeline (por ejemplo `executionDate`) y sustitúyelos
+en los argumentos con `@{pipeline().parameters.executionDate}`.
+
+## 5. Validación `dry-run`
+
+* Ejecuta el Spark job con `args`: `["--layer", "raw", "--config", "...", "--dry-run"]`
+  para validar sin procesar datos.
+* Crea un trigger separado (por ejemplo `ManualDryRun`) que fije el parámetro
+  `dryRun=true` y lo concatene como argumento adicional.
+
+## 6. Observabilidad
+
+* Habilita [Apache Spark application monitoring](https://learn.microsoft.com/azure/synapse-analytics/spark/apache-spark-monitor-application)
+  para seguir el progreso por capa.
+* Enruta los logs de `stdout` a Log Analytics mediante la integración nativa de
+  Synapse.
+
+Estas prácticas permiten reiniciar capas específicas y reproducir la cadena
+completa cuando se despliegan nuevas configuraciones.

--- a/docs/run/databricks.md
+++ b/docs/run/databricks.md
@@ -1,0 +1,93 @@
+# Ejecución de `prodi run-layer` en Databricks
+
+Esta guía orienta a los equipos de operaciones para ejecutar pipelines de `prodi`
+utilizando Jobs de Databricks respaldados por wheel tasks. El flujo cubre la
+preparación del artefacto, la configuración del job y comandos de verificación
+(`dry-run`).
+
+## 1. Empaquetar el proyecto como wheel
+
+1. Construye el paquete desde la raíz del repositorio:
+   ```bash
+   poetry build -f wheel
+   ```
+2. Publica el wheel (`dist/prodi-<version>-py3-none-any.whl`) en DBFS o en un
+   repositorio de artefactos accesible desde Databricks:
+   ```bash
+   databricks fs cp dist/prodi-1.4.0-py3-none-any.whl dbfs:/libs/prodi-1.4.0.whl
+   ```
+
+## 2. Definir la tarea tipo wheel
+
+Dentro de un Job multipaso se recomienda una tarea por capa. Cada tarea reutiliza
+el mismo wheel y varía los parámetros del comando `prodi run-layer`.
+
+```json
+{
+  "name": "prodi-layer-raw",
+  "task_key": "raw",
+  "job_cluster_key": "shared_cluster",
+  "wheel_task": {
+    "package_name": "prodi",
+    "entry_point": "run-layer",
+    "parameters": [
+      "--layer", "raw",
+      "--config", "dbfs:/cfg/run/raw.yml"
+    ]
+  },
+  "libraries": [
+    { "whl": "dbfs:/libs/prodi-1.4.0.whl" }
+  ]
+}
+```
+
+### Secuencia completa raw → bronze → silver → gold
+
+Replica la definición anterior ajustando `task_key`, `--layer` y la ruta del
+YAML para cada capa. Encadena las tareas estableciendo dependencias:
+
+```json
+{
+  "tasks": [
+    { "task_key": "raw", ... },
+    { "task_key": "bronze", "depends_on": [{"task_key": "raw"}], ... },
+    { "task_key": "silver", "depends_on": [{"task_key": "bronze"}], ... },
+    { "task_key": "gold", "depends_on": [{"task_key": "silver"}], ... }
+  ]
+}
+```
+
+Consulta ejemplos más completos en [`docs/run/jobs/`](jobs/).
+
+## 3. Ejecutar en modo `dry-run`
+
+Antes de calendarizar el job, valida el pipeline ejecutando una corrida de
+prueba que sólo evalúa la configuración:
+
+```bash
+prodi run-layer --layer raw --config cfg/run/raw.yml --dry-run
+prodi run-layer --layer bronze --config cfg/run/bronze.yml --dry-run
+```
+
+Para tareas en Databricks, agrega `"parameters": ["--dry-run", ...]` a la tarea
+`wheel_task`. El job se detendrá al primer error de validación sin tocar datos.
+
+## 4. Variables y secretos operativos
+
+* Usa `job_parameters` o [task parameters](https://docs.databricks.com/jobs/jobs-parameterization.html)
+  para inyectar rutas de configuración o flags como `--env prod`.
+* Gestiona credenciales mediante [Databricks Secrets](https://docs.databricks.com/security/secrets/index.html)
+  y refiérelas dentro de los YAML con `{{secrets/<scope>/<key>}}`.
+* Registra el build del wheel junto con la versión de configuración aplicada
+  para reproducibilidad.
+
+## 5. Monitoreo y recuperación
+
+* Activa [Job run notifications](https://docs.databricks.com/workflows/jobs/jobs-notifications.html)
+  para avisos de fallos entre capas.
+* Consolida los logs de `prodi` (stdout) en Lakehouse escribiendo desde Databricks
+  a un `delta` controlado, o envíalos a observabilidad centralizada (Datadog,
+  Splunk).
+
+Con esta estructura cada capa se mantiene desacoplada, lo que facilita repetir
+un eslabón específico (por ejemplo `silver`) ante un fallo aguas abajo.

--- a/docs/run/gcp.md
+++ b/docs/run/gcp.md
@@ -1,0 +1,100 @@
+# Ejecución de `prodi run-layer` en Google Cloud Dataproc
+
+Esta guía explica cómo desplegar la cadena raw → bronze → silver → gold en
+Dataproc utilizando jobs de tipo PySpark que consumen el wheel de `prodi`.
+
+## 1. Preparar el wheel y subirlo a GCS
+
+1. Construye el paquete:
+   ```bash
+   poetry build -f wheel
+   ```
+2. Publica el wheel y configuraciones en un bucket regional:
+   ```bash
+   gsutil cp dist/prodi-1.4.0-py3-none-any.whl gs://datalake-artifacts/libs/
+   gsutil cp -r cfg/run gs://datalake-artifacts/cfg/run
+   ```
+
+## 2. Definir un workflow template
+
+Crea un [Dataproc Workflow Template](https://cloud.google.com/dataproc/docs/concepts/workflows/overview)
+con un paso por capa. Cada paso invoca `prodi run-layer` mediante
+`gcloud dataproc jobs submit pyspark` usando el wheel como archivo extra.
+
+```yaml
+jobs:
+  - step-id: raw
+    pyspark-job:
+      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python-file-uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args: ["--layer", "raw", "--config", "gs://datalake-artifacts/cfg/run/raw.yml"]
+  - step-id: bronze
+    prerequisite-step-ids: [raw]
+    pyspark-job:
+      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python-file-uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args: ["--layer", "bronze", "--config", "gs://datalake-artifacts/cfg/run/bronze.yml"]
+  - step-id: silver
+    prerequisite-step-ids: [bronze]
+    pyspark-job:
+      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python-file-uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args: ["--layer", "silver", "--config", "gs://datalake-artifacts/cfg/run/silver.yml"]
+  - step-id: gold
+    prerequisite-step-ids: [silver]
+    pyspark-job:
+      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python-file-uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args: ["--layer", "gold", "--config", "gs://datalake-artifacts/cfg/run/gold.yml"]
+cluster-selector:
+  zone: us-central1-a
+  cluster-labels:
+    env: prod
+
+## 3. Script de entrada
+
+El archivo `prodi_dataproc_entry.py` debe residir en el mismo bucket y delegar en
+el CLI de `prodi`:
+
+```python
+import sys
+from prodi.cli import main
+
+if __name__ == "__main__":
+    main(["run-layer", *sys.argv[1:]])
+```
+
+## 4. Validación `dry-run`
+
+Antes de ejecutar el workflow completo, lanza un job aislado con el flag
+`--dry-run` para validar la configuración de la capa:
+
+```bash
+gcloud dataproc jobs submit pyspark gs://datalake-artifacts/scripts/prodi_dataproc_entry.py \
+  --cluster=dp-ops-validation \
+  --region=us-central1 \
+  --jars=gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl \
+  -- \
+  --layer raw \
+  --config gs://datalake-artifacts/cfg/run/raw.yml \
+  --dry-run
+```
+
+Puedes repetir el comando para cada capa, o bien crear una versión alternativa
+del template que fije `args: [..., "--dry-run"]` para entornos de QA.
+
+## 5. Buenas prácticas operativas
+
+* Activa [diagnostic logs](https://cloud.google.com/dataproc/docs/guides/logging) y
+  envía los logs de `stdout` a Cloud Logging con filtros por `task-id`.
+* Usa variables de plantilla (`{{execution_date}}`) al parametrizar rutas de
+  entrada/salida en los YAML.
+* Desactiva el cluster tras la ejecución utilizando Workflow Templates sin
+  clúster preexistente o [Dataproc Serverless](https://cloud.google.com/dataproc-serverless/docs).
+
+Consulta plantillas adicionales en [`docs/run/jobs/`](jobs/) para integrarlas con
+Cloud Composer u orquestadores externos.

--- a/docs/run/jobs/aws_stepfunctions.json
+++ b/docs/run/jobs/aws_stepfunctions.json
@@ -1,0 +1,54 @@
+{
+  "Comment": "Orquestación secuencial de capas prodi en Step Functions",
+  "StartAt": "raw",
+  "States": {
+    "raw": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-raw",
+        "Arguments": {
+          "--config.$": "$.config.raw",
+          "--env.$": "$.env"
+        }
+      },
+      "Next": "bronze"
+    },
+    "bronze": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-bronze",
+        "Arguments": {
+          "--config.$": "$.config.bronze",
+          "--env.$": "$.env"
+        }
+      },
+      "Next": "silver"
+    },
+    "silver": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-silver",
+        "Arguments": {
+          "--config.$": "$.config.silver",
+          "--env.$": "$.env"
+        }
+      },
+      "Next": "gold"
+    },
+    "gold": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-gold",
+        "Arguments": {
+          "--config.$": "$.config.gold",
+          "--env.$": "$.env"
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/docs/run/jobs/databricks_job.json
+++ b/docs/run/jobs/databricks_job.json
@@ -1,0 +1,84 @@
+{
+  "name": "prodi-layered-pipeline",
+  "job_clusters": [
+    {
+      "job_cluster_key": "shared_cluster",
+      "new_cluster": {
+        "spark_version": "13.3.x-scala2.12",
+        "num_workers": 2,
+        "node_type_id": "Standard_DS3_v2"
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "task_key": "raw",
+      "description": "Ingesta inicial",
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/prodi-1.4.0.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "raw",
+          "--config", "dbfs:/cfg/run/raw.yml",
+          "--env", "prod"
+        ]
+      }
+    },
+    {
+      "task_key": "bronze",
+      "depends_on": [{ "task_key": "raw" }],
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/prodi-1.4.0.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "bronze",
+          "--config", "dbfs:/cfg/run/bronze.yml",
+          "--env", "prod"
+        ]
+      }
+    },
+    {
+      "task_key": "silver",
+      "depends_on": [{ "task_key": "bronze" }],
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/prodi-1.4.0.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "silver",
+          "--config", "dbfs:/cfg/run/silver.yml",
+          "--env", "prod"
+        ]
+      }
+    },
+    {
+      "task_key": "gold",
+      "depends_on": [{ "task_key": "silver" }],
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/prodi-1.4.0.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "gold",
+          "--config", "dbfs:/cfg/run/gold.yml",
+          "--env", "prod"
+        ]
+      }
+    }
+  ],
+  "format": "MULTI_TASK"
+}

--- a/docs/run/jobs/dataproc_workflow.yaml
+++ b/docs/run/jobs/dataproc_workflow.yaml
@@ -1,0 +1,54 @@
+# Plantilla de Workflow Template para ejecutar la cadena completa en Dataproc
+id: prodi-layered-pipeline
+placement:
+  managed_cluster:
+    cluster_name: prodi-etl-managed
+    config:
+      gce_cluster_config:
+        zone_uri: us-central1-a
+      software_config:
+        image_version: 2.1-debian11
+jobs:
+  - step_id: raw
+    pyspark_job:
+      main_python_file_uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python_file_uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args:
+        - --layer
+        - raw
+        - --config
+        - gs://datalake-artifacts/cfg/run/raw.yml
+  - step_id: bronze
+    prerequisite_step_ids: [raw]
+    pyspark_job:
+      main_python_file_uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python_file_uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args:
+        - --layer
+        - bronze
+        - --config
+        - gs://datalake-artifacts/cfg/run/bronze.yml
+  - step_id: silver
+    prerequisite_step_ids: [bronze]
+    pyspark_job:
+      main_python_file_uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python_file_uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args:
+        - --layer
+        - silver
+        - --config
+        - gs://datalake-artifacts/cfg/run/silver.yml
+  - step_id: gold
+    prerequisite_step_ids: [silver]
+    pyspark_job:
+      main_python_file_uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
+      python_file_uris:
+        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
+      args:
+        - --layer
+        - gold
+        - --config
+        - gs://datalake-artifacts/cfg/run/gold.yml


### PR DESCRIPTION
## Summary
- add Databricks, AWS Glue, Dataproc and Synapse run-layer guides with dry-run usage
- provide ready-to-import JSON/YAML job examples chaining raw→bronze→silver→gold
- reference the new run guides from the main project documentation for operations teams

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc2969900c8320812aa1bd67360ca0