### PR TITLE
Fix Databricks run-layer docs CLI usage

### DIFF
--- a/docs/run/jobs/databricks_job.json
+++ b/docs/run/jobs/databricks_job.json
@@ -22,9 +22,8 @@
         "package_name": "prodi",
         "entry_point": "run-layer",
         "parameters": [
-          "--layer", "raw",
-          "--config", "dbfs:/cfg/run/raw.yml",
-          "--env", "prod"
+          "raw",
+          "-c", "dbfs:/cfg/run/raw.yml"
         ]
       }
     },
@@ -39,9 +38,8 @@
         "package_name": "prodi",
         "entry_point": "run-layer",
         "parameters": [
-          "--layer", "bronze",
-          "--config", "dbfs:/cfg/run/bronze.yml",
-          "--env", "prod"
+          "bronze",
+          "-c", "dbfs:/cfg/run/bronze.yml"
         ]
       }
     },
@@ -56,9 +54,8 @@
         "package_name": "prodi",
         "entry_point": "run-layer",
         "parameters": [
-          "--layer", "silver",
-          "--config", "dbfs:/cfg/run/silver.yml",
-          "--env", "prod"
+          "silver",
+          "-c", "dbfs:/cfg/run/silver.yml"
         ]
       }
     },
@@ -73,9 +70,8 @@
         "package_name": "prodi",
         "entry_point": "run-layer",
         "parameters": [
-          "--layer", "gold",
-          "--config", "dbfs:/cfg/run/gold.yml",
-          "--env", "prod"
+          "gold",
+          "-c", "dbfs:/cfg/run/gold.yml"
         ]
       }
     }


### PR DESCRIPTION
## Summary
- update the Databricks run-layer guide to reflect the actual CLI parameters and configuration-based dry-run usage
- align the Databricks JSON job template with the positional layer argument and config flag supported by the CLI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc2c6b2c9883208dd385e3bfb769eb