### PR TITLE
Add cleanup audit tooling and reports

### DIFF
--- a/docs/CLEANUP_REPORT.md
+++ b/docs/CLEANUP_REPORT.md
@@ -1,0 +1,1348 @@
+# Cleanup Audit Report
+
+_Generated on 2025-10-25T02:12:43.911203Z_
+
+## Resumen ejecutivo
+
+| Clasificación | Conteo |
+| --- | ---: |
+| REMOVE | 1 |
+| QUARANTINE | 4 |
+| KEEP | 128 |
+
+**Ahorro estimado**: 0.02 MB si se aplica REMOVE + QUARANTINE.
+
+## Tabla maestra
+
+| Path | Tipo | Tamaño (KB) | Último commit | # refs | Clasificación | Motivo | Riesgo | Acción |
+| --- | --- | ---: | --- | ---: | --- | --- | --- | --- |
+| .env | other | 0.48 | 2025-09-28 | 16 | KEEP | Referenced or recently modified. | medium | keep |
+| .env.example | other | 0.55 | 2025-10-06 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| .gitignore | other | 6.04 | 2025-10-24 | 6 | KEEP | Referenced or recently modified. | medium | keep |
+| .mc/config.json | config | 0.69 | 2025-09-29 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| .mc/config.json.old | other | 0.69 | 2025-09-29 | 5 | REMOVE | Archivo de respaldo antiguo de MinIO; reemplazado por config.json | low | delete |
+| .mc/share/downloads.json | config | 0.03 | 2025-09-29 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| .mc/share/uploads.json | config | 0.03 | 2025-09-29 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| .pre-commit-config.yaml | config | 0.34 | 2025-10-21 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| README.md | doc | 1.93 | 2025-10-24 | 9 | KEEP | Governance or generated artifact | low | keep |
+| cfg/bronze/template.yml | config | 0.52 | 2025-10-24 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| cfg/gold/template.yml | config | 0.51 | 2025-10-24 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| cfg/raw/template.yml | config | 0.51 | 2025-10-24 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| cfg/silver/template.yml | config | 0.52 | 2025-10-24 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| ci/build-test.yml | config | 0.97 | 2025-10-24 | 5 | KEEP | Referenced or recently modified. | medium | keep |
+| ci/check_config.sh | ci | 0.25 | 2025-09-28 | 9 | KEEP | Referenced or recently modified. | medium | keep |
+| ci/docker-compose.override.yml | config | 0.10 | 2025-10-08 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| ci/lint.yml | config | 0.34 | 2025-10-24 | 7 | KEEP | Referenced or recently modified. | medium | keep |
+| ci/test_dataset.yml | config | 0.34 | 2025-09-28 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| config/database.yml | config | 1.93 | 2025-10-09 | 22 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/events_multiformat.yml | config | 3.88 | 2025-10-24 | 9 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/events_multiformat_expectations.yml | config | 7.29 | 2025-10-16 | 5 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/events_multiformat_schema.json | config | 2.14 | 2025-10-24 | 5 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/events_multiformat_transforms.yml | config | 0.85 | 2025-10-16 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/payments_high_volume.yml | config | 2.96 | 2025-10-24 | 12 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/payments_high_volume_expectations.yml | config | 5.62 | 2025-10-09 | 5 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/casos_uso/payments_high_volume_schema.json | config | 2.42 | 2025-10-24 | 5 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_db_only/dataset.yml | config | 2.28 | 2025-10-24 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_db_only/expectations.yml | config | 0.46 | 2025-10-20 | 19 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_db_only/schema.yml | config | 0.69 | 2025-10-20 | 12 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_db_only/transforms.yml | config | 1.16 | 2025-10-20 | 17 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_multi/dataset.yml | config | 1.65 | 2025-10-20 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v1/dataset.yml | config | 2.15 | 2025-10-24 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v1/expectations.yml | config | 0.79 | 2025-10-08 | 19 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v1/schema.json | config | 1.79 | 2025-10-15 | 19 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v1/transforms.yml | config | 0.40 | 2025-10-13 | 17 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v2/dataset.yml | config | 1.69 | 2025-10-24 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v2/expectations.yml | config | 0.79 | 2025-10-06 | 19 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v2/schema.json | config | 0.47 | 2025-10-08 | 19 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v3/dataset.yml | config | 2.82 | 2025-10-24 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v3/dataset_api.yml | config | 4.19 | 2025-10-24 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v3/expectations.yml | config | 0.46 | 2025-10-16 | 19 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v3/schema.yml | config | 0.70 | 2025-10-16 | 12 | KEEP | Referenced or recently modified. | medium | keep |
+| config/datasets/finanzas/payments_v3/transforms.yml | config | 1.36 | 2025-10-20 | 17 | KEEP | Referenced or recently modified. | medium | keep |
+| config/env.yml | config | 0.65 | 2025-10-24 | 21 | KEEP | Referenced or recently modified. | medium | keep |
+| config/schema_mapping.yml | config | 1.89 | 2025-10-08 | 6 | KEEP | Referenced or recently modified. | medium | keep |
+| data/casos-uso/multi-format/events_batch_001.json | other | 5709.05 | 2025-10-24 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| data/output/.gitkeep | other | 0.14 | 2025-10-08 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| data/processed/.gitkeep | other | 0.16 | 2025-10-08 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| data/raw/.gitkeep | other | 0.15 | 2025-10-08 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| data/raw/payments/sample.csv | other | 0.64 | 2025-10-15 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| data/s3a-staging/finanzas/payments/raw/sample.jsonl | other | 0.31 | 2025-10-20 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| data/s3a-staging/raw/casos-uso/payments-high-volume/payments-high-volume/payments_batch_001.csv | other | 588.43 | 2025-10-24 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| data/s3a-staging/raw/casos-uso/payments-high-volume/payments-high-volume/payments_batch_002.csv | other | 588.26 | 2025-10-24 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| data/s3a-staging/raw/payments_v3/sample.csv | other | 0.34 | 2025-10-24 | 13 | KEEP | Referenced or recently modified. | medium | keep |
+| docker/spark-pandas-udf/Dockerfile | docker | 0.34 | 2025-10-13 | 7 | KEEP | Referenced or recently modified. | medium | keep |
+| docker-compose.yml | config | 3.98 | 2025-10-13 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/CLEANUP_REPORT.md | doc | 110.83 | - | 10 | KEEP | Governance or generated artifact | low | keep |
+| docs/PROJECT_DOCUMENTATION.md | doc | 5.29 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/REPORT.md | doc | 12.38 | 2025-10-24 | 11 | QUARANTINE | Reporte legacy previo a la documentación modular. | medium | move_to_legacy |
+| docs/cleanup.json | doc | 135.98 | - | 10 | KEEP | Governance or generated artifact | low | keep |
+| docs/diagrams/dependencies.md | doc | 1.24 | 2025-10-24 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/diagrams/deps_cleanup.md | doc | 0.64 | - | 9 | KEEP | Governance or generated artifact | low | keep |
+| docs/diagrams/pipeline_flow.md | doc | 1.17 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/policies/DEP-001-legacy-removal.md | doc | 2.08 | - | 4 | KEEP | Governance or generated artifact | low | keep |
+| docs/report.json | doc | 5.92 | 2025-10-24 | 9 | QUARANTINE | Export JSON antiguo duplicando reportes actuales. | medium | move_to_legacy |
+| docs/run/aws.md | doc | 3.11 | 2025-10-24 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/azure.md | doc | 3.28 | 2025-10-24 | 6 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/configs.md | doc | 2.69 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/databricks.md | doc | 3.15 | 2025-10-24 | 7 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/gcp.md | doc | 3.61 | 2025-10-24 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/jobs/aws_stepfunctions.json | doc | 1.28 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/jobs/databricks_job.json | doc | 2.03 | 2025-10-24 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| docs/run/jobs/dataproc_workflow.yaml | config | 1.68 | 2025-10-24 | 4 | QUARANTINE | Plantilla Dataproc sin referencias en CI/CD. | medium | move_to_legacy |
+| docs/tools/list_io.py | code | 2.94 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/__init__.py | code | 0.16 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/common.py | code | 4.32 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/config/__init__.py | code | 0.05 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/config/loader.py | code | 0.75 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/database/__init__.py | code | 0.06 | 2025-10-08 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/database/db_manager.py | code | 29.79 | 2025-10-15 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/database/schema_mapper.py | code | 18.59 | 2025-10-09 | 9 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/io/__init__.py | code | 0.06 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/io/reader.py | code | 1.48 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/io/s3a.py | code | 0.48 | 2025-10-24 | 6 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/io/writer.py | code | 1.42 | 2025-10-24 | 7 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/sources.py | code | 13.96 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/spark_job.py | code | 11.51 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/spark_job_with_db.py | code | 2.11 | 2025-10-24 | 16 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/transforms/__init__.py | code | 0.05 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/transforms/apply.py | code | 4.82 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/transforms/tests/__init__.py | code | 0.03 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/transforms/tests/test_apply.py | code | 1.23 | 2025-10-21 | 7 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/udf_catalog.py | code | 4.79 | 2025-10-13 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/utils/__init__.py | code | 0.06 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/utils/logger.py | code | 1.16 | 2025-10-21 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/utils/parallel.py | code | 0.95 | 2025-10-21 | 6 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/validation/__init__.py | code | 0.08 | 2025-10-21 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pipelines/validation/quality.py | code | 4.31 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| pyproject.toml | config | 0.81 | 2025-10-24 | 6 | KEEP | Governance or generated artifact | low | keep |
+| requirements.txt | other | 0.68 | 2025-10-24 | 11 | KEEP | Governance or generated artifact | low | keep |
+| scripts/db/init.sql | other | 1.67 | 2025-10-08 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| scripts/generate_big_payments.py | code | 1.27 | 2025-09-29 | 9 | QUARANTINE | Script de generación legacy reemplazado por generate_synthetic_data.py. | medium | move_to_legacy |
+| scripts/generate_synthetic_data.py | code | 34.54 | 2025-10-24 | 16 | KEEP | Referenced or recently modified. | medium | keep |
+| scripts/run_high_volume_case.py | code | 8.63 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| scripts/run_multiformat_case.py | code | 15.11 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| scripts/runner.sh | other | 4.07 | 2025-10-24 | 10 | KEEP | Referenced or recently modified. | medium | keep |
+| scripts/runner_with_db.sh | other | 3.03 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/__init__.py | code | 0.32 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/cli.py | code | 4.91 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/config/schema.py | code | 8.37 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/context.py | code | 6.29 | 2025-10-24 | 7 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/io/__init__.py | code | 0.31 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/io/adapters.py | code | 3.37 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/io/fs.py | code | 19.87 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/__init__.py | code | 0.00 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/bronze/__init__.py | code | 0.00 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/bronze/main.py | code | 6.72 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/gold/__init__.py | code | 0.00 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/gold/main.py | code | 6.58 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/raw/__init__.py | code | 0.00 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/raw/main.py | code | 0.62 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/silver/__init__.py | code | 0.00 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/layers/silver/main.py | code | 6.17 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/pipeline/__init__.py | code | 0.00 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| src/datacore/pipeline/utils.py | code | 24.75 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| tests/test_cli_smoke.py | code | 2.76 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| tests/test_config_schema.py | code | 2.22 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| tests/test_io_adapters.py | code | 1.88 | 2025-10-24 | 4 | KEEP | Referenced or recently modified. | medium | keep |
+| tests/test_io_fs.py | code | 7.97 | 2025-10-24 | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| tests/test_layers_config.py | code | 2.24 | 2025-10-24 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| tests/test_security.py | code | 0.95 | 2025-10-24 | 3 | KEEP | Referenced or recently modified. | medium | keep |
+| tools/audit_cleanup.py | code | 20.54 | - | 8 | KEEP | Referenced or recently modified. | medium | keep |
+| tools/list_io.py | code | 3.18 | - | 8 | KEEP | Referenced or recently modified. | medium | keep |
+
+## Evidencia por elemento
+
+### .env
+
+Referencias detectadas:
+
+- **code**: scripts/run_high_volume_case.py:29, scripts/run_high_volume_case.py:30, scripts/run_high_volume_case.py:31, scripts/run_high_volume_case.py:39, scripts/run_multiformat_case.py:38, scripts/run_multiformat_case.py:39, scripts/run_multiformat_case.py:40, scripts/run_multiformat_case.py:44
+- **docs**: docs/report.json:174, docs/report.json:175, docs/report.json:176, docs/report.json:177, docs/run/jobs/aws_stepfunctions.json:12, docs/run/jobs/aws_stepfunctions.json:24, docs/run/jobs/aws_stepfunctions.json:36, docs/run/jobs/aws_stepfunctions.json:48
+- Clasificación: KEEP
+
+### .env.example
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:53, docs/CLEANUP_REPORT.md:20, docs/CLEANUP_REPORT.md:163
+- Clasificación: KEEP
+
+### .gitignore
+
+Referencias detectadas:
+
+- **code**: data/output/.gitkeep:2, data/processed/.gitkeep:2, data/raw/.gitkeep:2
+- **docs**: docs/cleanup.json:75, docs/CLEANUP_REPORT.md:21, docs/CLEANUP_REPORT.md:170
+- Clasificación: KEEP
+
+### .mc/config.json
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:26, tools/audit_cleanup.py:28
+- **docs**: docs/diagrams/deps_cleanup.md:11, docs/cleanup.json:101, docs/cleanup.json:131, docs/cleanup.json:150, docs/CLEANUP_REPORT.md:22, docs/CLEANUP_REPORT.md:23, docs/CLEANUP_REPORT.md:178, docs/CLEANUP_REPORT.md:186
+- Clasificación: KEEP
+
+### .mc/config.json.old
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:26
+- **docs**: docs/diagrams/deps_cleanup.md:11, docs/cleanup.json:131, docs/CLEANUP_REPORT.md:23, docs/CLEANUP_REPORT.md:186
+- Notas: No se usa en CI ni en scripts actuales.
+- Clasificación: REMOVE
+
+### .mc/share/downloads.json
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:156, docs/CLEANUP_REPORT.md:24, docs/CLEANUP_REPORT.md:195
+- Clasificación: KEEP
+
+### .mc/share/uploads.json
+
+Referencias detectadas:
+
+- **docs**: docs/CLEANUP_REPORT.md:25, docs/CLEANUP_REPORT.md:202, docs/cleanup.json:178
+- Clasificación: KEEP
+
+### .pre-commit-config.yaml
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:91, docs/cleanup.json:200, docs/CLEANUP_REPORT.md:26, docs/CLEANUP_REPORT.md:209
+- Clasificación: KEEP
+
+### README.md
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:210
+- **docs**: docs/PROJECT_DOCUMENTATION.md:107, docs/cleanup.json:223, docs/cleanup.json:525, docs/cleanup.json:1376, docs/cleanup.json:1377, docs/cleanup.json:1378, docs/cleanup.json:1751, docs/cleanup.json:2169
+- Clasificación: KEEP
+
+### cfg/bronze/template.yml
+
+Referencias detectadas:
+
+- **code**: tests/test_cli_smoke.py:20, tests/test_cli_smoke.py:27
+- **docs**: docs/cleanup.json:252, docs/cleanup.json:282, docs/cleanup.json:312, docs/cleanup.json:342, docs/cleanup.json:1369, docs/cleanup.json:1370, docs/cleanup.json:1371, docs/cleanup.json:1372
+- Clasificación: KEEP
+
+### cfg/gold/template.yml
+
+Referencias detectadas:
+
+- **code**: tests/test_cli_smoke.py:20, tests/test_cli_smoke.py:27
+- **docs**: docs/cleanup.json:252, docs/cleanup.json:282, docs/cleanup.json:312, docs/cleanup.json:342, docs/cleanup.json:1369, docs/cleanup.json:1370, docs/cleanup.json:1371, docs/cleanup.json:1372
+- Clasificación: KEEP
+
+### cfg/raw/template.yml
+
+Referencias detectadas:
+
+- **code**: tests/test_cli_smoke.py:20, tests/test_cli_smoke.py:27
+- **docs**: docs/cleanup.json:252, docs/cleanup.json:282, docs/cleanup.json:312, docs/cleanup.json:342, docs/cleanup.json:1369, docs/cleanup.json:1370, docs/cleanup.json:1371, docs/cleanup.json:1372
+- Clasificación: KEEP
+
+### cfg/silver/template.yml
+
+Referencias detectadas:
+
+- **code**: tests/test_cli_smoke.py:20, tests/test_cli_smoke.py:27
+- **docs**: docs/cleanup.json:252, docs/cleanup.json:282, docs/cleanup.json:312, docs/cleanup.json:342, docs/cleanup.json:1369, docs/cleanup.json:1370, docs/cleanup.json:1371, docs/cleanup.json:1372
+- Clasificación: KEEP
+
+### ci/build-test.yml
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:372, docs/cleanup.json:2862, docs/CLEANUP_REPORT.md:32, docs/CLEANUP_REPORT.md:256, docs/CLEANUP_REPORT.md:933
+- Clasificación: KEEP
+
+### ci/check_config.sh
+
+Referencias detectadas:
+
+- **configs**: ci/lint.yml:18
+- **docs**: docs/cleanup.json:396, docs/cleanup.json:1004, docs/cleanup.json:1157, docs/CLEANUP_REPORT.md:33, docs/CLEANUP_REPORT.md:263, docs/CLEANUP_REPORT.md:429, docs/CLEANUP_REPORT.md:466, docs/REPORT.md:114
+- Clasificación: KEEP
+
+### ci/docker-compose.override.yml
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:425, docs/CLEANUP_REPORT.md:34, docs/CLEANUP_REPORT.md:271
+- Clasificación: KEEP
+
+### ci/lint.yml
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:403, docs/cleanup.json:447, docs/CLEANUP_REPORT.md:35, docs/CLEANUP_REPORT.md:267, docs/CLEANUP_REPORT.md:278, docs/REPORT.md:114, docs/REPORT.md:128
+- Clasificación: KEEP
+
+### ci/test_dataset.yml
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:473, docs/cleanup.json:1001, docs/cleanup.json:1154, docs/cleanup.json:1537, docs/cleanup.json:1637, docs/CLEANUP_REPORT.md:36, docs/CLEANUP_REPORT.md:285, docs/CLEANUP_REPORT.md:428
+- Clasificación: KEEP
+
+### config/database.yml
+
+Referencias detectadas:
+
+- **code**: scripts/run_high_volume_case.py:79, scripts/runner.sh:7, scripts/runner_with_db.sh:7, scripts/generate_synthetic_data.py:580, scripts/generate_synthetic_data.py:639, scripts/run_multiformat_case.py:104
+- **configs**: config/datasets/finanzas/payments_v2/dataset.yml:44, config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset.yml:78, config/datasets/finanzas/payments_v3/dataset_api.yml:5, config/datasets/finanzas/payments_v3/dataset_api.yml:83, config/datasets/finanzas/payments_v1/dataset.yml:49, config/datasets/casos_uso/payments_high_volume.yml:69, config/datasets/casos_uso/events_multiformat.yml:71
+- **docs**: README.md:13, docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:31, docs/PROJECT_DOCUMENTATION.md:40, docs/run/configs.md:22, docs/run/configs.md:57, docs/cleanup.json:500, docs/CLEANUP_REPORT.md:37
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/events_multiformat.yml
+
+Referencias detectadas:
+
+- **code**: scripts/run_multiformat_case.py:102
+- **docs**: docs/cleanup.json:521, docs/cleanup.json:543, docs/cleanup.json:581, docs/cleanup.json:607, docs/cleanup.json:631, docs/cleanup.json:854, docs/cleanup.json:1000, docs/cleanup.json:1041
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/events_multiformat_expectations.yml
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:624
+- **configs**: config/datasets/casos_uso/events_multiformat.yml:42
+- **docs**: docs/cleanup.json:572, docs/CLEANUP_REPORT.md:39, docs/CLEANUP_REPORT.md:309
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/events_multiformat_schema.json
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:621
+- **configs**: config/datasets/casos_uso/events_multiformat.yml:46
+- **docs**: docs/cleanup.json:598, docs/CLEANUP_REPORT.md:40, docs/CLEANUP_REPORT.md:318
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/events_multiformat_transforms.yml
+
+Referencias detectadas:
+
+- **configs**: config/datasets/casos_uso/events_multiformat.yml:50
+- **docs**: docs/cleanup.json:624, docs/CLEANUP_REPORT.md:41, docs/CLEANUP_REPORT.md:327
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/payments_high_volume.yml
+
+Referencias detectadas:
+
+- **code**: scripts/run_high_volume_case.py:77, scripts/generate_synthetic_data.py:599, scripts/generate_synthetic_data.py:603, scripts/generate_synthetic_data.py:782
+- **docs**: docs/cleanup.json:520, docs/cleanup.json:648, docs/cleanup.json:689, docs/cleanup.json:715, docs/cleanup.json:784, docs/cleanup.json:962, docs/cleanup.json:999, docs/cleanup.json:1115
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/payments_high_volume_expectations.yml
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:562
+- **configs**: config/datasets/casos_uso/payments_high_volume.yml:45
+- **docs**: docs/cleanup.json:680, docs/CLEANUP_REPORT.md:43, docs/CLEANUP_REPORT.md:343
+- Clasificación: KEEP
+
+### config/datasets/casos_uso/payments_high_volume_schema.json
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:566
+- **configs**: config/datasets/casos_uso/payments_high_volume.yml:49
+- **docs**: docs/cleanup.json:706, docs/CLEANUP_REPORT.md:44, docs/CLEANUP_REPORT.md:352
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_db_only/dataset.yml
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:5, scripts/runner_with_db.sh:5
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:5, config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset.yml:90
+- **docs**: docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:24, docs/cleanup.json:473, docs/cleanup.json:514, docs/cleanup.json:515, docs/cleanup.json:516, docs/cleanup.json:519, docs/cleanup.json:732
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_db_only/expectations.yml
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:562, scripts/generate_synthetic_data.py:624, tests/test_config_schema.py:30
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:74, config/datasets/finanzas/payments_v2/dataset.yml:29, config/datasets/finanzas/payments_db_only/dataset.yml:54, config/datasets/finanzas/payments_v3/dataset.yml:63, config/datasets/finanzas/payments_v3/dataset_api.yml:69, config/datasets/finanzas/payments_v3/dataset_api.yml:150, config/datasets/finanzas/payments_v1/dataset.yml:30, config/datasets/casos_uso/payments_high_volume.yml:45
+- **docs**: docs/run/configs.md:52, docs/cleanup.json:572, docs/cleanup.json:680, docs/cleanup.json:766, docs/cleanup.json:944, docs/cleanup.json:1097, docs/cleanup.json:1242, docs/CLEANUP_REPORT.md:39
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_db_only/schema.yml
+
+Referencias detectadas:
+
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:34, config/datasets/finanzas/payments_db_only/dataset.yml:47, config/datasets/finanzas/payments_v3/dataset.yml:2, config/datasets/finanzas/payments_v3/dataset.yml:56, config/datasets/finanzas/payments_v3/dataset_api.yml:2, config/datasets/finanzas/payments_v3/dataset_api.yml:63
+- **docs**: docs/CLEANUP_REPORT.md:47, docs/CLEANUP_REPORT.md:60, docs/CLEANUP_REPORT.md:379, docs/CLEANUP_REPORT.md:496, docs/cleanup.json:806, docs/cleanup.json:1282
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_db_only/transforms.yml
+
+Referencias detectadas:
+
+- **code**: pipelines/transforms/apply.py:10
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:77, config/datasets/finanzas/payments_db_only/dataset.yml:51, config/datasets/finanzas/payments_v3/dataset.yml:2, config/datasets/finanzas/payments_v3/dataset.yml:60, config/datasets/finanzas/payments_v3/dataset_api.yml:2, config/datasets/finanzas/payments_v3/dataset_api.yml:66, config/datasets/finanzas/payments_v1/dataset.yml:11, config/datasets/casos_uso/events_multiformat.yml:50
+- **docs**: docs/PROJECT_DOCUMENTATION.md:28, docs/cleanup.json:624, docs/cleanup.json:838, docs/cleanup.json:1025, docs/cleanup.json:1314, docs/CLEANUP_REPORT.md:41, docs/CLEANUP_REPORT.md:48, docs/CLEANUP_REPORT.md:53
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_multi/dataset.yml
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:5, scripts/runner_with_db.sh:5
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:5, config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset.yml:90
+- **docs**: docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:24, docs/cleanup.json:473, docs/cleanup.json:514, docs/cleanup.json:515, docs/cleanup.json:516, docs/cleanup.json:519, docs/cleanup.json:732
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v1/dataset.yml
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:5, scripts/runner_with_db.sh:5
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:5, config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset.yml:90
+- **docs**: docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:24, docs/cleanup.json:473, docs/cleanup.json:514, docs/cleanup.json:515, docs/cleanup.json:516, docs/cleanup.json:519, docs/cleanup.json:732
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v1/expectations.yml
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:562, scripts/generate_synthetic_data.py:624, tests/test_config_schema.py:30
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:74, config/datasets/finanzas/payments_v2/dataset.yml:29, config/datasets/finanzas/payments_db_only/dataset.yml:54, config/datasets/finanzas/payments_v3/dataset.yml:63, config/datasets/finanzas/payments_v3/dataset_api.yml:69, config/datasets/finanzas/payments_v3/dataset_api.yml:150, config/datasets/finanzas/payments_v1/dataset.yml:30, config/datasets/casos_uso/payments_high_volume.yml:45
+- **docs**: docs/run/configs.md:52, docs/cleanup.json:572, docs/cleanup.json:680, docs/cleanup.json:766, docs/cleanup.json:944, docs/cleanup.json:1097, docs/cleanup.json:1242, docs/CLEANUP_REPORT.md:39
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v1/schema.json
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:566, scripts/generate_synthetic_data.py:621, pipelines/database/db_manager.py:706, pipelines/database/__init__.py:1, pipelines/database/schema_mapper.py:428
+- **configs**: config/datasets/finanzas/payments_v2/dataset.yml:25, config/datasets/finanzas/payments_v1/dataset.yml:34, config/datasets/casos_uso/payments_high_volume.yml:49, config/datasets/casos_uso/events_multiformat.yml:46, ci/test_dataset.yml:9
+- **ci**: ci/check_config.sh:6
+- **docs**: docs/cleanup.json:598, docs/cleanup.json:706, docs/cleanup.json:984, docs/cleanup.json:1137, docs/CLEANUP_REPORT.md:40, docs/CLEANUP_REPORT.md:44, docs/CLEANUP_REPORT.md:52, docs/CLEANUP_REPORT.md:56
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v1/transforms.yml
+
+Referencias detectadas:
+
+- **code**: pipelines/transforms/apply.py:10
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:77, config/datasets/finanzas/payments_db_only/dataset.yml:51, config/datasets/finanzas/payments_v3/dataset.yml:2, config/datasets/finanzas/payments_v3/dataset.yml:60, config/datasets/finanzas/payments_v3/dataset_api.yml:2, config/datasets/finanzas/payments_v3/dataset_api.yml:66, config/datasets/finanzas/payments_v1/dataset.yml:11, config/datasets/casos_uso/events_multiformat.yml:50
+- **docs**: docs/PROJECT_DOCUMENTATION.md:28, docs/cleanup.json:624, docs/cleanup.json:838, docs/cleanup.json:1025, docs/cleanup.json:1314, docs/CLEANUP_REPORT.md:41, docs/CLEANUP_REPORT.md:48, docs/CLEANUP_REPORT.md:53
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v2/dataset.yml
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:5, scripts/runner_with_db.sh:5
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:5, config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset.yml:90
+- **docs**: docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:24, docs/CLEANUP_REPORT.md:36, docs/CLEANUP_REPORT.md:45, docs/CLEANUP_REPORT.md:49, docs/CLEANUP_REPORT.md:50, docs/CLEANUP_REPORT.md:54, docs/CLEANUP_REPORT.md:57
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v2/expectations.yml
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:562, scripts/generate_synthetic_data.py:624, tests/test_config_schema.py:30
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:74, config/datasets/finanzas/payments_v2/dataset.yml:29, config/datasets/finanzas/payments_db_only/dataset.yml:54, config/datasets/finanzas/payments_v3/dataset.yml:63, config/datasets/finanzas/payments_v3/dataset_api.yml:69, config/datasets/finanzas/payments_v3/dataset_api.yml:150, config/datasets/finanzas/payments_v1/dataset.yml:30, config/datasets/casos_uso/payments_high_volume.yml:45
+- **docs**: docs/run/configs.md:52, docs/cleanup.json:572, docs/cleanup.json:680, docs/cleanup.json:766, docs/cleanup.json:944, docs/cleanup.json:1097, docs/cleanup.json:1242, docs/CLEANUP_REPORT.md:39
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v2/schema.json
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:566, scripts/generate_synthetic_data.py:621, pipelines/database/db_manager.py:706, pipelines/database/__init__.py:1, pipelines/database/schema_mapper.py:428
+- **configs**: config/datasets/finanzas/payments_v2/dataset.yml:25, config/datasets/finanzas/payments_v1/dataset.yml:34, config/datasets/casos_uso/payments_high_volume.yml:49, config/datasets/casos_uso/events_multiformat.yml:46, ci/test_dataset.yml:9
+- **ci**: ci/check_config.sh:6
+- **docs**: docs/cleanup.json:598, docs/cleanup.json:706, docs/cleanup.json:984, docs/cleanup.json:1137, docs/CLEANUP_REPORT.md:40, docs/CLEANUP_REPORT.md:44, docs/CLEANUP_REPORT.md:52, docs/CLEANUP_REPORT.md:56
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v3/dataset.yml
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:5, scripts/runner_with_db.sh:5
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:5, config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset.yml:90
+- **docs**: docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:24, docs/cleanup.json:473, docs/cleanup.json:514, docs/cleanup.json:515, docs/cleanup.json:516, docs/cleanup.json:519, docs/cleanup.json:732
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v3/dataset_api.yml
+
+Referencias detectadas:
+
+- **configs**: config/datasets/finanzas/payments_v3/dataset_api.yml:4, config/datasets/finanzas/payments_v3/dataset_api.yml:5
+- **docs**: docs/cleanup.json:517, docs/cleanup.json:518, docs/cleanup.json:781, docs/cleanup.json:782, docs/cleanup.json:817, docs/cleanup.json:818, docs/cleanup.json:851, docs/cleanup.json:852
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v3/expectations.yml
+
+Referencias detectadas:
+
+- **code**: scripts/generate_synthetic_data.py:562, scripts/generate_synthetic_data.py:624, tests/test_config_schema.py:30
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:74, config/datasets/finanzas/payments_v2/dataset.yml:29, config/datasets/finanzas/payments_db_only/dataset.yml:54, config/datasets/finanzas/payments_v3/dataset.yml:63, config/datasets/finanzas/payments_v3/dataset_api.yml:69, config/datasets/finanzas/payments_v3/dataset_api.yml:150, config/datasets/finanzas/payments_v1/dataset.yml:30, config/datasets/casos_uso/payments_high_volume.yml:45
+- **docs**: docs/run/configs.md:52, docs/cleanup.json:572, docs/cleanup.json:680, docs/cleanup.json:766, docs/cleanup.json:944, docs/cleanup.json:1097, docs/cleanup.json:1242, docs/CLEANUP_REPORT.md:39
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v3/schema.yml
+
+Referencias detectadas:
+
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:34, config/datasets/finanzas/payments_db_only/dataset.yml:47, config/datasets/finanzas/payments_v3/dataset.yml:2, config/datasets/finanzas/payments_v3/dataset.yml:56, config/datasets/finanzas/payments_v3/dataset_api.yml:2, config/datasets/finanzas/payments_v3/dataset_api.yml:63
+- **docs**: docs/cleanup.json:806, docs/cleanup.json:1282, docs/CLEANUP_REPORT.md:47, docs/CLEANUP_REPORT.md:60, docs/CLEANUP_REPORT.md:379, docs/CLEANUP_REPORT.md:496
+- Clasificación: KEEP
+
+### config/datasets/finanzas/payments_v3/transforms.yml
+
+Referencias detectadas:
+
+- **code**: pipelines/transforms/apply.py:10
+- **configs**: config/datasets/finanzas/payments_multi/dataset.yml:77, config/datasets/finanzas/payments_db_only/dataset.yml:51, config/datasets/finanzas/payments_v3/dataset.yml:2, config/datasets/finanzas/payments_v3/dataset.yml:60, config/datasets/finanzas/payments_v3/dataset_api.yml:2, config/datasets/finanzas/payments_v3/dataset_api.yml:66, config/datasets/finanzas/payments_v1/dataset.yml:11, config/datasets/casos_uso/events_multiformat.yml:50
+- **docs**: docs/PROJECT_DOCUMENTATION.md:28, docs/cleanup.json:624, docs/cleanup.json:838, docs/cleanup.json:1025, docs/cleanup.json:1314, docs/CLEANUP_REPORT.md:41, docs/CLEANUP_REPORT.md:48, docs/CLEANUP_REPORT.md:53
+- Clasificación: KEEP
+
+### config/env.yml
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:6, scripts/runner_with_db.sh:6, pipelines/sources.py:113, pipelines/sources.py:117, src/datacore/io/adapters.py:63
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset_api.yml:5, config/datasets/finanzas/payments_v3/dataset_api.yml:15, config/datasets/finanzas/payments_v3/dataset_api.yml:103, cfg/raw/template.yml:7, cfg/gold/template.yml:7, cfg/silver/template.yml:7, cfg/bronze/template.yml:7
+- **docs**: README.md:13, README.md:15, README.md:38, docs/PROJECT_DOCUMENTATION.md:10, docs/PROJECT_DOCUMENTATION.md:22, docs/PROJECT_DOCUMENTATION.md:40, docs/PROJECT_DOCUMENTATION.md:42, docs/run/configs.md:20
+- Clasificación: KEEP
+
+### config/schema_mapping.yml
+
+Referencias detectadas:
+
+- **code**: pipelines/database/schema_mapper.py:48
+- **docs**: docs/CLEANUP_REPORT.md:63, docs/CLEANUP_REPORT.md:522, docs/CLEANUP_REPORT.md:795, docs/cleanup.json:1394, docs/cleanup.json:2354
+- Clasificación: KEEP
+
+### data/casos-uso/multi-format/events_batch_001.json
+
+Referencias detectadas:
+
+- **docs**: docs/CLEANUP_REPORT.md:64, docs/CLEANUP_REPORT.md:530, docs/cleanup.json:1420
+- Clasificación: KEEP
+
+### data/output/.gitkeep
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:81, docs/cleanup.json:82, docs/cleanup.json:83, docs/cleanup.json:1442, docs/cleanup.json:1469, docs/cleanup.json:1496, docs/CLEANUP_REPORT.md:65, docs/CLEANUP_REPORT.md:66
+- Clasificación: KEEP
+
+### data/processed/.gitkeep
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:81, docs/cleanup.json:82, docs/cleanup.json:83, docs/cleanup.json:1442, docs/cleanup.json:1469, docs/cleanup.json:1496, docs/CLEANUP_REPORT.md:65, docs/CLEANUP_REPORT.md:66
+- Clasificación: KEEP
+
+### data/raw/.gitkeep
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:81, docs/cleanup.json:82, docs/cleanup.json:83, docs/cleanup.json:1442, docs/cleanup.json:1469, docs/cleanup.json:1496, docs/CLEANUP_REPORT.md:65, docs/CLEANUP_REPORT.md:66
+- Clasificación: KEEP
+
+### data/raw/payments/sample.csv
+
+Referencias detectadas:
+
+- **code**: scripts/generate_big_payments.py:6, tests/test_io_fs.py:185, tests/test_io_fs.py:186, tests/test_io_fs.py:187, tests/test_io_fs.py:211
+- **configs**: config/datasets/finanzas/payments_v2/dataset.yml:5, ci/test_dataset.yml:5
+- **docs**: docs/CLEANUP_REPORT.md:68, docs/CLEANUP_REPORT.md:72, docs/CLEANUP_REPORT.md:558, docs/CLEANUP_REPORT.md:588, docs/cleanup.json:1523, docs/cleanup.json:1623
+- Clasificación: KEEP
+
+### data/s3a-staging/finanzas/payments/raw/sample.jsonl
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1557, docs/CLEANUP_REPORT.md:69, docs/CLEANUP_REPORT.md:567
+- Clasificación: KEEP
+
+### data/s3a-staging/raw/casos-uso/payments-high-volume/payments-high-volume/payments_batch_001.csv
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1579, docs/CLEANUP_REPORT.md:70, docs/CLEANUP_REPORT.md:574
+- Clasificación: KEEP
+
+### data/s3a-staging/raw/casos-uso/payments-high-volume/payments-high-volume/payments_batch_002.csv
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1601, docs/CLEANUP_REPORT.md:71, docs/CLEANUP_REPORT.md:581
+- Clasificación: KEEP
+
+### data/s3a-staging/raw/payments_v3/sample.csv
+
+Referencias detectadas:
+
+- **code**: scripts/generate_big_payments.py:6, tests/test_io_fs.py:185, tests/test_io_fs.py:186, tests/test_io_fs.py:187, tests/test_io_fs.py:211
+- **configs**: config/datasets/finanzas/payments_v2/dataset.yml:5, ci/test_dataset.yml:5
+- **docs**: docs/cleanup.json:1523, docs/cleanup.json:1623, docs/CLEANUP_REPORT.md:68, docs/CLEANUP_REPORT.md:72, docs/CLEANUP_REPORT.md:558, docs/CLEANUP_REPORT.md:588
+- Clasificación: KEEP
+
+### docker/spark-pandas-udf/Dockerfile
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:131
+- **configs**: docker-compose.yml:49, docker-compose.yml:65, docker-compose.yml:81
+- **docs**: docs/cleanup.json:1657, docs/CLEANUP_REPORT.md:73, docs/CLEANUP_REPORT.md:597
+- Clasificación: KEEP
+
+### docker-compose.yml
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1666, docs/cleanup.json:1667, docs/cleanup.json:1668, docs/cleanup.json:1685, docs/cleanup.json:2889, docs/cleanup.json:3032, docs/cleanup.json:3033, docs/CLEANUP_REPORT.md:74
+- Clasificación: KEEP
+
+### docs/CLEANUP_REPORT.md
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:211, tools/audit_cleanup.py:527
+- **docs**: docs/diagrams/deps_cleanup.md:15, docs/cleanup.json:63, docs/cleanup.json:64, docs/cleanup.json:89, docs/cleanup.json:90, docs/cleanup.json:117, docs/cleanup.json:118, docs/cleanup.json:119
+- Clasificación: KEEP
+
+### docs/PROJECT_DOCUMENTATION.md
+
+Referencias detectadas:
+
+- **docs**: README.md:33, docs/cleanup.json:209, docs/cleanup.json:234, docs/cleanup.json:526, docs/cleanup.json:527, docs/cleanup.json:528, docs/cleanup.json:748, docs/cleanup.json:749
+- Clasificación: KEEP
+
+### docs/REPORT.md
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:33, tools/audit_cleanup.py:211, tools/audit_cleanup.py:527
+- **docs**: docs/diagrams/deps_cleanup.md:9, docs/diagrams/deps_cleanup.md:15, docs/cleanup.json:63, docs/cleanup.json:64, docs/cleanup.json:89, docs/cleanup.json:90, docs/cleanup.json:117, docs/cleanup.json:118
+- Notas: Conservar en /legacy/docs hasta validar que no sea referencia externa.
+- Clasificación: QUARANTINE
+
+### docs/cleanup.json
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:212, tools/audit_cleanup.py:526
+- **docs**: docs/cleanup.json:62, docs/cleanup.json:88, docs/cleanup.json:114, docs/cleanup.json:115, docs/cleanup.json:116, docs/cleanup.json:143, docs/cleanup.json:165, docs/cleanup.json:187
+- Clasificación: KEEP
+
+### docs/diagrams/dependencies.md
+
+Referencias detectadas:
+
+- **docs**: docs/REPORT.md:45, docs/cleanup.json:1830, docs/CLEANUP_REPORT.md:79, docs/CLEANUP_REPORT.md:645
+- Clasificación: KEEP
+
+### docs/diagrams/deps_cleanup.md
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:213
+- **docs**: docs/cleanup.json:113, docs/cleanup.json:142, docs/cleanup.json:1724, docs/cleanup.json:1782, docs/cleanup.json:1783, docs/cleanup.json:1853, docs/cleanup.json:1945, docs/cleanup.json:2917
+- Clasificación: KEEP
+
+### docs/diagrams/pipeline_flow.md
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1881, docs/cleanup.json:2511, docs/cleanup.json:2550, docs/CLEANUP_REPORT.md:81, docs/CLEANUP_REPORT.md:660, docs/CLEANUP_REPORT.md:838, docs/CLEANUP_REPORT.md:847, docs/REPORT.md:46
+- Clasificación: KEEP
+
+### docs/policies/DEP-001-legacy-removal.md
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:214
+- **docs**: docs/cleanup.json:1908, docs/CLEANUP_REPORT.md:82, docs/CLEANUP_REPORT.md:667
+- Clasificación: KEEP
+
+### docs/report.json
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:40
+- **docs**: docs/diagrams/deps_cleanup.md:10, docs/cleanup.json:35, docs/cleanup.json:36, docs/cleanup.json:37, docs/cleanup.json:38, docs/cleanup.json:1934, docs/cleanup.json:2222, docs/cleanup.json:2223
+- Notas: Generado por tooling previo; no usado en pipelines.
+- Clasificación: QUARANTINE
+
+### docs/run/aws.md
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:49, docs/cleanup.json:1963, docs/CLEANUP_REPORT.md:84, docs/CLEANUP_REPORT.md:684
+- Clasificación: KEEP
+
+### docs/run/azure.md
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:51, docs/cleanup.json:1986, docs/CLEANUP_REPORT.md:85, docs/CLEANUP_REPORT.md:691, docs/CLEANUP_REPORT.md:1336, docs/CLEANUP_REPORT.md:1337
+- Clasificación: KEEP
+
+### docs/run/configs.md
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:529, docs/cleanup.json:530, docs/cleanup.json:788, docs/cleanup.json:966, docs/cleanup.json:1119, docs/cleanup.json:1264, docs/cleanup.json:1383, docs/cleanup.json:2011
+- Clasificación: KEEP
+
+### docs/run/databricks.md
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:48, docs/cleanup.json:2038, docs/CLEANUP_REPORT.md:87, docs/CLEANUP_REPORT.md:705, docs/CLEANUP_REPORT.md:1338, docs/CLEANUP_REPORT.md:1339, docs/CLEANUP_REPORT.md:1340
+- Clasificación: KEEP
+
+### docs/run/gcp.md
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:50, docs/cleanup.json:2064, docs/CLEANUP_REPORT.md:88, docs/CLEANUP_REPORT.md:712
+- Clasificación: KEEP
+
+### docs/run/jobs/aws_stepfunctions.json
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:39, docs/cleanup.json:40, docs/cleanup.json:41, docs/cleanup.json:42, docs/cleanup.json:2087, docs/CLEANUP_REPORT.md:89, docs/CLEANUP_REPORT.md:160, docs/CLEANUP_REPORT.md:719
+- Clasificación: KEEP
+
+### docs/run/jobs/databricks_job.json
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:2114, docs/CLEANUP_REPORT.md:90, docs/CLEANUP_REPORT.md:726
+- Clasificación: KEEP
+
+### docs/run/jobs/dataproc_workflow.yaml
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:54
+- **docs**: docs/cleanup.json:2136, docs/CLEANUP_REPORT.md:91, docs/CLEANUP_REPORT.md:733
+- Notas: Considerar mover a legacy/infra antes de eliminar.
+- Clasificación: QUARANTINE
+
+### docs/tools/list_io.py
+
+Referencias detectadas:
+
+- **docs**: README.md:40, docs/cleanup.json:2160, docs/cleanup.json:3737, docs/CLEANUP_REPORT.md:92, docs/CLEANUP_REPORT.md:151, docs/CLEANUP_REPORT.md:742, docs/CLEANUP_REPORT.md:1166, docs/CLEANUP_REPORT.md:1259
+- Clasificación: KEEP
+
+### pipelines/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/common.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:128, docs/report.json:144, docs/cleanup.json:2213, docs/CLEANUP_REPORT.md:94, docs/CLEANUP_REPORT.md:756, docs/CLEANUP_REPORT.md:1196, docs/CLEANUP_REPORT.md:1260, docs/CLEANUP_REPORT.md:1261
+- Clasificación: KEEP
+
+### pipelines/config/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/config/loader.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:15, docs/cleanup.json:2267, docs/CLEANUP_REPORT.md:96, docs/CLEANUP_REPORT.md:770, docs/CLEANUP_REPORT.md:1197, docs/CLEANUP_REPORT.md:1198, docs/CLEANUP_REPORT.md:1199, docs/CLEANUP_REPORT.md:1265
+- Clasificación: KEEP
+
+### pipelines/database/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/database/db_manager.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:992, docs/cleanup.json:1145, docs/cleanup.json:2320, docs/CLEANUP_REPORT.md:98, docs/CLEANUP_REPORT.md:427, docs/CLEANUP_REPORT.md:464, docs/CLEANUP_REPORT.md:784, docs/CLEANUP_REPORT.md:1200
+- Clasificación: KEEP
+
+### pipelines/database/schema_mapper.py
+
+Referencias detectadas:
+
+- **configs**: config/schema_mapping.yml:2
+- **docs**: docs/cleanup.json:994, docs/cleanup.json:1147, docs/cleanup.json:1400, docs/cleanup.json:2347, docs/CLEANUP_REPORT.md:99, docs/CLEANUP_REPORT.md:427, docs/CLEANUP_REPORT.md:464, docs/CLEANUP_REPORT.md:526
+- Clasificación: KEEP
+
+### pipelines/io/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/io/reader.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:16, docs/cleanup.json:2403, docs/CLEANUP_REPORT.md:101, docs/CLEANUP_REPORT.md:806, docs/CLEANUP_REPORT.md:1219, docs/CLEANUP_REPORT.md:1273, docs/CLEANUP_REPORT.md:1274, docs/CLEANUP_REPORT.md:1275
+- Clasificación: KEEP
+
+### pipelines/io/s3a.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:16, docs/cleanup.json:2427, docs/CLEANUP_REPORT.md:102, docs/CLEANUP_REPORT.md:813, docs/CLEANUP_REPORT.md:1220, docs/CLEANUP_REPORT.md:1276
+- Clasificación: KEEP
+
+### pipelines/io/writer.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:16, docs/PROJECT_DOCUMENTATION.md:79, docs/cleanup.json:2451, docs/CLEANUP_REPORT.md:103, docs/CLEANUP_REPORT.md:820, docs/CLEANUP_REPORT.md:1277, docs/CLEANUP_REPORT.md:1278
+- Clasificación: KEEP
+
+### pipelines/sources.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:61, docs/report.json:68, docs/PROJECT_DOCUMENTATION.md:18, docs/PROJECT_DOCUMENTATION.md:56, docs/REPORT.md:155, docs/REPORT.md:156, docs/cleanup.json:1360, docs/cleanup.json:1361
+- Clasificación: KEEP
+
+### pipelines/spark_job.py
+
+Referencias detectadas:
+
+- **docs**: docs/diagrams/pipeline_flow.md:7, docs/report.json:75, docs/cleanup.json:2502, docs/CLEANUP_REPORT.md:105, docs/CLEANUP_REPORT.md:834, docs/CLEANUP_REPORT.md:1221, docs/CLEANUP_REPORT.md:1282, docs/CLEANUP_REPORT.md:1283
+- Clasificación: KEEP
+
+### pipelines/spark_job_with_db.py
+
+Referencias detectadas:
+
+- **code**: scripts/run_high_volume_case.py:85, scripts/runner.sh:106, scripts/runner_with_db.sh:61, scripts/generate_synthetic_data.py:782, scripts/run_multiformat_case.py:110, pipelines/spark_job_with_db.py:13
+- **configs**: config/datasets/finanzas/payments_v3/dataset.yml:6, config/datasets/finanzas/payments_v3/dataset_api.yml:5
+- **docs**: README.md:13, README.md:29, docs/diagrams/pipeline_flow.md:8, docs/PROJECT_DOCUMENTATION.md:17, docs/PROJECT_DOCUMENTATION.md:40, docs/cleanup.json:2529, docs/cleanup.json:2540, docs/CLEANUP_REPORT.md:106
+- Clasificación: KEEP
+
+### pipelines/transforms/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/transforms/apply.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:14, docs/PROJECT_DOCUMENTATION.md:90, docs/cleanup.json:844, docs/cleanup.json:1031, docs/cleanup.json:1320, docs/cleanup.json:2593, docs/cleanup.json:2647, docs/CLEANUP_REPORT.md:108
+- Clasificación: KEEP
+
+### pipelines/transforms/tests/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/transforms/tests/test_apply.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:90, docs/cleanup.json:2647, docs/CLEANUP_REPORT.md:110, docs/CLEANUP_REPORT.md:871, docs/CLEANUP_REPORT.md:1293, docs/CLEANUP_REPORT.md:1294, docs/CLEANUP_REPORT.md:1295
+- Clasificación: KEEP
+
+### pipelines/udf_catalog.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:2670, docs/CLEANUP_REPORT.md:111, docs/CLEANUP_REPORT.md:878, docs/CLEANUP_REPORT.md:1222, docs/CLEANUP_REPORT.md:1223, docs/CLEANUP_REPORT.md:1224, docs/CLEANUP_REPORT.md:1225, docs/CLEANUP_REPORT.md:1226
+- Clasificación: KEEP
+
+### pipelines/utils/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/CLEANUP_REPORT.md:93, docs/CLEANUP_REPORT.md:95, docs/CLEANUP_REPORT.md:97, docs/CLEANUP_REPORT.md:100, docs/CLEANUP_REPORT.md:107, docs/CLEANUP_REPORT.md:109, docs/CLEANUP_REPORT.md:112, docs/CLEANUP_REPORT.md:115
+- Clasificación: KEEP
+
+### pipelines/utils/logger.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:12, docs/cleanup.json:2724, docs/CLEANUP_REPORT.md:113, docs/CLEANUP_REPORT.md:892
+- Clasificación: KEEP
+
+### pipelines/utils/parallel.py
+
+Referencias detectadas:
+
+- **docs**: docs/PROJECT_DOCUMENTATION.md:12, docs/cleanup.json:2747, docs/CLEANUP_REPORT.md:114, docs/CLEANUP_REPORT.md:899, docs/CLEANUP_REPORT.md:1230, docs/CLEANUP_REPORT.md:1231
+- Clasificación: KEEP
+
+### pipelines/validation/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### pipelines/validation/quality.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:119, docs/PROJECT_DOCUMENTATION.md:13, docs/cleanup.json:2799, docs/CLEANUP_REPORT.md:116, docs/CLEANUP_REPORT.md:913, docs/CLEANUP_REPORT.md:1300, docs/CLEANUP_REPORT.md:1301, docs/REPORT.md:124
+- Clasificación: KEEP
+
+### pyproject.toml
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:208
+- **docs**: docs/PROJECT_DOCUMENTATION.md:91, docs/cleanup.json:2824, docs/CLEANUP_REPORT.md:117, docs/CLEANUP_REPORT.md:920, docs/REPORT.md:84
+- Clasificación: KEEP
+
+### requirements.txt
+
+Referencias detectadas:
+
+- **code**: scripts/runner.sh:29, scripts/runner.sh:30, scripts/runner_with_db.sh:31, tools/audit_cleanup.py:209
+- **configs**: ci/build-test.yml:28
+- **docs**: README.md:11, docs/PROJECT_DOCUMENTATION.md:39, docs/cleanup.json:2850, docs/CLEANUP_REPORT.md:118, docs/CLEANUP_REPORT.md:928, docs/REPORT.md:116
+- Clasificación: KEEP
+
+### scripts/db/init.sql
+
+Referencias detectadas:
+
+- **configs**: docker-compose.yml:22
+- **docs**: docs/cleanup.json:2882, docs/CLEANUP_REPORT.md:119, docs/CLEANUP_REPORT.md:937
+- Clasificación: KEEP
+
+### scripts/generate_big_payments.py
+
+Referencias detectadas:
+
+- **code**: tools/audit_cleanup.py:47
+- **docs**: docs/diagrams/deps_cleanup.md:8, docs/CLEANUP_REPORT.md:120, docs/CLEANUP_REPORT.md:562, docs/CLEANUP_REPORT.md:592, docs/CLEANUP_REPORT.md:945, docs/cleanup.json:1529, docs/cleanup.json:1629, docs/cleanup.json:2906
+- Notas: No referenciado desde CLI actuales.
+- Clasificación: QUARANTINE
+
+### scripts/generate_synthetic_data.py
+
+Referencias detectadas:
+
+- **code**: scripts/run_high_volume_case.py:49, scripts/generate_synthetic_data.py:21, scripts/generate_synthetic_data.py:22, scripts/generate_synthetic_data.py:23, scripts/generate_synthetic_data.py:670, scripts/generate_synthetic_data.py:671, scripts/generate_synthetic_data.py:672, scripts/generate_synthetic_data.py:673
+- **docs**: docs/diagrams/deps_cleanup.md:7, docs/cleanup.json:509, docs/cleanup.json:510, docs/cleanup.json:578, docs/cleanup.json:604, docs/cleanup.json:655, docs/cleanup.json:656, docs/cleanup.json:657
+- Clasificación: KEEP
+
+### scripts/run_high_volume_case.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:161, docs/cleanup.json:23, docs/cleanup.json:24, docs/cleanup.json:25, docs/cleanup.json:26, docs/cleanup.json:506, docs/cleanup.json:654, docs/cleanup.json:2535
+- Clasificación: KEEP
+
+### scripts/run_multiformat_case.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:27, docs/cleanup.json:28, docs/cleanup.json:29, docs/cleanup.json:30, docs/cleanup.json:511, docs/cleanup.json:549, docs/cleanup.json:2539, docs/cleanup.json:2998
+- Clasificación: KEEP
+
+### scripts/runner.sh
+
+Referencias detectadas:
+
+- **configs**: docker-compose.yml:85, docker-compose.yml:86
+- **docs**: README.md:15, docs/report.json:136, docs/report.json:154, docs/PROJECT_DOCUMENTATION.md:42, docs/cleanup.json:507, docs/cleanup.json:738, docs/cleanup.json:882, docs/cleanup.json:916
+- Clasificación: KEEP
+
+### scripts/runner_with_db.sh
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:132, docs/report.json:149, docs/report.json:166, docs/cleanup.json:508, docs/cleanup.json:739, docs/cleanup.json:883, docs/cleanup.json:917, docs/cleanup.json:1070
+- Clasificación: KEEP
+
+### src/datacore/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/cli.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:3109, docs/CLEANUP_REPORT.md:127, docs/CLEANUP_REPORT.md:998, docs/CLEANUP_REPORT.md:1234, docs/CLEANUP_REPORT.md:1307, docs/CLEANUP_REPORT.md:1308, docs/CLEANUP_REPORT.md:1309, docs/CLEANUP_REPORT.md:1310
+- Clasificación: KEEP
+
+### src/datacore/config/schema.py
+
+Referencias detectadas:
+
+- **docs**: docs/run/configs.md:5, docs/run/configs.md:77, docs/cleanup.json:774, docs/cleanup.json:952, docs/cleanup.json:1105, docs/cleanup.json:1250, docs/cleanup.json:3134, docs/cleanup.json:3589
+- Clasificación: KEEP
+
+### src/datacore/context.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:3161, docs/CLEANUP_REPORT.md:129, docs/CLEANUP_REPORT.md:1012, docs/CLEANUP_REPORT.md:1241, docs/CLEANUP_REPORT.md:1313, docs/CLEANUP_REPORT.md:1314, docs/CLEANUP_REPORT.md:1315
+- Clasificación: KEEP
+
+### src/datacore/io/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/io/adapters.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1362, docs/cleanup.json:3211, docs/cleanup.json:3616, docs/CLEANUP_REPORT.md:131, docs/CLEANUP_REPORT.md:146, docs/CLEANUP_REPORT.md:517, docs/CLEANUP_REPORT.md:1026, docs/CLEANUP_REPORT.md:1131
+- Clasificación: KEEP
+
+### src/datacore/io/fs.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1530, docs/cleanup.json:1531, docs/cleanup.json:1532, docs/cleanup.json:1533, docs/cleanup.json:1630, docs/cleanup.json:1631, docs/cleanup.json:1632, docs/cleanup.json:1633
+- Clasificación: KEEP
+
+### src/datacore/layers/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/layers/bronze/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/layers/bronze/main.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:17, docs/report.json:31, docs/report.json:46, docs/cleanup.json:3319, docs/cleanup.json:3373, docs/cleanup.json:3427, docs/cleanup.json:3481, docs/CLEANUP_REPORT.md:135
+- Clasificación: KEEP
+
+### src/datacore/layers/gold/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/layers/gold/main.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:17, docs/report.json:31, docs/report.json:46, docs/CLEANUP_REPORT.md:135, docs/CLEANUP_REPORT.md:137, docs/CLEANUP_REPORT.md:139, docs/CLEANUP_REPORT.md:141, docs/CLEANUP_REPORT.md:1054
+- Clasificación: KEEP
+
+### src/datacore/layers/raw/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/layers/raw/main.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:17, docs/report.json:31, docs/report.json:46, docs/cleanup.json:3319, docs/cleanup.json:3373, docs/cleanup.json:3427, docs/cleanup.json:3481, docs/CLEANUP_REPORT.md:135
+- Clasificación: KEEP
+
+### src/datacore/layers/silver/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/layers/silver/main.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:17, docs/report.json:31, docs/report.json:46, docs/cleanup.json:3319, docs/cleanup.json:3373, docs/cleanup.json:3427, docs/cleanup.json:3481, docs/CLEANUP_REPORT.md:135
+- Clasificación: KEEP
+
+### src/datacore/pipeline/__init__.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:993, docs/cleanup.json:1146, docs/cleanup.json:2186, docs/cleanup.json:2240, docs/cleanup.json:2293, docs/cleanup.json:2376, docs/cleanup.json:2566, docs/cleanup.json:2620
+- Clasificación: KEEP
+
+### src/datacore/pipeline/utils.py
+
+Referencias detectadas:
+
+- **docs**: docs/report.json:82, docs/report.json:91, docs/report.json:98, docs/report.json:105, docs/report.json:112, docs/cleanup.json:3535, docs/CLEANUP_REPORT.md:143, docs/CLEANUP_REPORT.md:1110
+- Clasificación: KEEP
+
+### tests/test_cli_smoke.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:258, docs/cleanup.json:259, docs/cleanup.json:288, docs/cleanup.json:289, docs/cleanup.json:318, docs/cleanup.json:319, docs/cleanup.json:348, docs/cleanup.json:349
+- Clasificación: KEEP
+
+### tests/test_config_schema.py
+
+Referencias detectadas:
+
+- **docs**: docs/run/configs.md:77, docs/cleanup.json:774, docs/cleanup.json:952, docs/cleanup.json:1105, docs/cleanup.json:1250, docs/cleanup.json:3589, docs/CLEANUP_REPORT.md:145, docs/CLEANUP_REPORT.md:374
+- Clasificación: KEEP
+
+### tests/test_io_adapters.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:3616, docs/CLEANUP_REPORT.md:146, docs/CLEANUP_REPORT.md:1131, docs/CLEANUP_REPORT.md:1249
+- Clasificación: KEEP
+
+### tests/test_io_fs.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:1530, docs/cleanup.json:1531, docs/cleanup.json:1532, docs/cleanup.json:1533, docs/cleanup.json:1630, docs/cleanup.json:1631, docs/cleanup.json:1632, docs/cleanup.json:1633
+- Clasificación: KEEP
+
+### tests/test_layers_config.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:3666, docs/CLEANUP_REPORT.md:148, docs/CLEANUP_REPORT.md:1145
+- Clasificación: KEEP
+
+### tests/test_security.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:3688, docs/CLEANUP_REPORT.md:149, docs/CLEANUP_REPORT.md:1152
+- Clasificación: KEEP
+
+### tools/audit_cleanup.py
+
+Referencias detectadas:
+
+- **docs**: docs/cleanup.json:107, docs/cleanup.json:108, docs/cleanup.json:137, docs/cleanup.json:229, docs/cleanup.json:1663, docs/cleanup.json:1718, docs/cleanup.json:1719, docs/cleanup.json:1775
+- Clasificación: KEEP
+
+### tools/list_io.py
+
+Referencias detectadas:
+
+- **docs**: README.md:40, docs/cleanup.json:2160, docs/cleanup.json:3737, docs/CLEANUP_REPORT.md:92, docs/CLEANUP_REPORT.md:151, docs/CLEANUP_REPORT.md:742, docs/CLEANUP_REPORT.md:1166, docs/CLEANUP_REPORT.md:1259
+- Clasificación: KEEP
+
+## Impacto estimado
+
+- Archivos candidatos a eliminar inmediatamente: 1
+- Archivos candidatos a cuarentena: 4
+- Ahorro aproximado: 0.02 MB
+
+## Riesgos y mitigaciones
+
+- Revisar manualmente los elementos marcados como QUARANTINE antes de moverlos a /legacy.
+- Confirmar dependencias transversales en CI/CD para los elementos KEEP críticos.
+- Establecer un rollback rápido restaurando archivos desde git si un pipeline falla.
+
+## Plan sugerido
+
+1. Crear PRs por lote (infra, pipelines, documentación) para aplicar REMOVE/QUARANTINE.
+2. Actualizar dependencias declaradas (según deptry) antes de eliminar código compartido.
+3. Mover notebooks huérfanos a /legacy/notebooks con un README que documente su estado.
+
+## Anexos
+
+### Hallazgos de Vulture
+
+```
+pipelines/common.py:28: unused function 'norm_type' (60% confidence)
+pipelines/config/loader.py:20: unused function 'load_dataset_config' (60% confidence)
+pipelines/config/loader.py:24: unused function 'load_env_config' (60% confidence)
+pipelines/config/loader.py:28: unused function 'load_db_config' (60% confidence)
+pipelines/database/db_manager.py:14: unused import 'sa' (90% confidence)
+pipelines/database/db_manager.py:15: unused import 'Column' (90% confidence)
+pipelines/database/db_manager.py:15: unused import 'DateTime' (90% confidence)
+pipelines/database/db_manager.py:15: unused import 'Integer' (90% confidence)
+pipelines/database/db_manager.py:15: unused import 'String' (90% confidence)
+pipelines/database/db_manager.py:15: unused import 'Table' (90% confidence)
+pipelines/database/db_manager.py:16: unused import 'SQLAlchemyError' (90% confidence)
+pipelines/database/db_manager.py:17: unused import 'Engine' (90% confidence)
+pipelines/database/db_manager.py:72: unused variable 'created_at' (60% confidence)
+pipelines/database/db_manager.py:87: unused method 'get_connection' (60% confidence)
+pipelines/database/db_manager.py:190: unused method 'table_exists' (60% confidence)
+pipelines/database/db_manager.py:264: unused variable 'connection_props' (60% confidence)
+pipelines/database/db_manager.py:437: unused method 'execute_query' (60% confidence)
+pipelines/database/db_manager.py:447: unused method 'close' (60% confidence)
+pipelines/database/db_manager.py:568: unused method 'get_latest_dataset_version' (60% confidence)
+pipelines/database/db_manager.py:587: unused method 'get_pipeline_execution_status' (60% confidence)
+pipelines/database/schema_mapper.py:312: unused method 'generate_alter_table_ddl' (60% confidence)
+pipelines/database/schema_mapper.py:363: unused method 'validate_engine_support' (60% confidence)
+pipelines/database/schema_mapper.py:377: unused method 'validate_schema' (60% confidence)
+pipelines/io/reader.py:38: unused function 'read_table_by_jdbc' (60% confidence)
+pipelines/io/s3a.py:6: unused function 'configure_s3a' (60% confidence)
+pipelines/spark_job.py:7: unused import 'norm_type' (90% confidence)
+pipelines/udf_catalog.py:16: unused import 'udf' (90% confidence)
+pipelines/udf_catalog.py:21: unused import 'pa' (90% confidence)
+pipelines/udf_catalog.py:22: unused variable 'PANDAS_AVAILABLE' (60% confidence)
+pipelines/udf_catalog.py:37: unused function 'normalize_id_py' (60% confidence)
+pipelines/udf_catalog.py:42: unused function 'sanitize_string_py' (60% confidence)
+pipelines/udf_catalog.py:48: unused function 'standardize_name_py' (60% confidence)
+pipelines/udf_catalog.py:56: unused function 'calculate_age_py' (60% confidence)
+pipelines/udf_catalog.py:79: unused function 'format_address_py' (60% confidence)
+pipelines/utils/parallel.py:4: unused function 'run_in_threads' (60% confidence)
+pipelines/utils/parallel.py:21: unused function 'run_map_in_threads' (60% confidence)
+scripts/generate_synthetic_data.py:35: unused import 'Decimal' (90% confidence)
+scripts/generate_synthetic_data.py:42: unused import 'codecs' (90% confidence)
+src/datacore/cli.py:90: unused function 'run_layer' (60% confidence)
+src/datacore/config/schema.py:12: unused variable 'model_config' (60% confidence)
+src/datacore/config/schema.py:35: unused variable 'standardization' (60% confidence)
+src/datacore/config/schema.py:39: unused variable 'references' (60% confidence)
+src/datacore/config/schema.py:59: unused variable 'id' (60% confidence)
+src/datacore/config/schema.py:60: unused variable 'description' (60% confidence)
+src/datacore/config/schema.py:85: unused variable 'storage' (60% confidence)
+src/datacore/context.py:171: unused function 'context_paths' (60% confidence)
+src/datacore/io/fs.py:76: unused function '_load_env_value' (60% confidence)
+src/datacore/pipeline/utils.py:23: unused variable 'kwargs' (100% confidence)
+src/datacore/pipeline/utils.py:241: unused function 'run_bronze_stage' (60% confidence)
+src/datacore/pipeline/utils.py:308: unused function 'run_silver_stage' (60% confidence)
+src/datacore/pipeline/utils.py:501: unused function 'apply_gold_transformations' (60% confidence)
+src/datacore/pipeline/utils.py:533: unused function 'write_to_gold_database' (60% confidence)
+src/datacore/pipeline/utils.py:580: unused function 'write_to_gold_bucket' (60% confidence)
+tests/test_io_adapters.py:8: unused function '_clear_env' (60% confidence)
+```
+
+### Hallazgos de Deptry
+
+```
+Assuming the corresponding module name of package 'typer' is 'typer'. Install the package or configure a package_module_name_map entry to override this behaviour.
+Assuming the corresponding module name of package 'pydantic' is 'pydantic'. Install the package or configure a package_module_name_map entry to override this behaviour.
+Scanning 49 files...
+
+[1mdocs/tools/list_io.py[m[36m:[m17[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mpipelines/common.py[m[36m:[m7[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/common.py[m[36m:[m8[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/common.py[m[36m:[m9[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/common.py[m[36m:[m54[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/common.py[m[36m:[m99[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/config/loader.py[m[36m:[m3[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mpipelines/database/db_manager.py[m[36m:[m9[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mpipelines/database/db_manager.py[m[36m:[m14[36m:[m8[36m:[m [1m[31mDEP003[m 'sqlalchemy' imported but it is a transitive dependency
+[1mpipelines/database/db_manager.py[m[36m:[m15[36m:[m1[36m:[m [1m[31mDEP003[m 'sqlalchemy' imported but it is a transitive dependency
+[1mpipelines/database/db_manager.py[m[36m:[m16[36m:[m1[36m:[m [1m[31mDEP003[m 'sqlalchemy' imported but it is a transitive dependency
+[1mpipelines/database/db_manager.py[m[36m:[m17[36m:[m1[36m:[m [1m[31mDEP003[m 'sqlalchemy' imported but it is a transitive dependency
+[1mpipelines/database/db_manager.py[m[36m:[m18[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/database/schema_mapper.py[m[36m:[m8[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mpipelines/io/reader.py[m[36m:[m3[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/io/reader.py[m[36m:[m4[36m:[m1[36m:[m [1m[31mDEP003[m 'tenacity' imported but it is a transitive dependency
+[1mpipelines/io/reader.py[m[36m:[m6[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/io/s3a.py[m[36m:[m3[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/io/writer.py[m[36m:[m3[36m:[m1[36m:[m [1m[31mDEP003[m 'tenacity' imported but it is a transitive dependency
+[1mpipelines/io/writer.py[m[36m:[m5[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/sources.py[m[36m:[m4[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/sources.py[m[36m:[m7[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/sources.py[m[36m:[m145[36m:[m20[36m:[m [1m[31mDEP003[m 'requests' imported but it is a transitive dependency
+[1mpipelines/spark_job.py[m[36m:[m1[36m:[m17[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mpipelines/spark_job.py[m[36m:[m3[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/spark_job.py[m[36m:[m4[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/spark_job.py[m[36m:[m7[36m:[m1[36m:[m [1m[31mDEP001[m 'common' imported but missing from the dependency definitions
+[1mpipelines/spark_job.py[m[36m:[m8[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/spark_job_with_db.py[m[36m:[m6[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/spark_job_with_db.py[m[36m:[m7[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/spark_job_with_db.py[m[36m:[m8[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/spark_job_with_db.py[m[36m:[m9[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/spark_job_with_db.py[m[36m:[m10[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mpipelines/transforms/apply.py[m[36m:[m2[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/transforms/tests/test_apply.py[m[36m:[m1[36m:[m8[36m:[m [1m[31mDEP003[m 'pytest' imported but it is a transitive dependency
+[1mpipelines/transforms/tests/test_apply.py[m[36m:[m2[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/transforms/tests/test_apply.py[m[36m:[m3[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/udf_catalog.py[m[36m:[m16[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/udf_catalog.py[m[36m:[m17[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/udf_catalog.py[m[36m:[m20[36m:[m8[36m:[m [1m[31mDEP003[m 'pandas' imported but it is a transitive dependency
+[1mpipelines/udf_catalog.py[m[36m:[m21[36m:[m8[36m:[m [1m[31mDEP003[m 'pyarrow' imported but it is a transitive dependency
+[1mpipelines/validation/quality.py[m[36m:[m2[36m:[m1[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1mpipelines/validation/quality.py[m[36m:[m4[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1mscripts/generate_synthetic_data.py[m[36m:[m59[36m:[m5[36m:[m [1m[31mDEP001[m 'faker' imported but missing from the dependency definitions
+[1mscripts/generate_synthetic_data.py[m[36m:[m600[36m:[m20[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mscripts/generate_synthetic_data.py[m[36m:[m658[36m:[m20[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1mscripts/run_high_volume_case.py[m[36m:[m134[36m:[m16[36m:[m [1m[31mDEP001[m 'psutil' imported but missing from the dependency definitions
+[1mscripts/run_multiformat_case.py[m[36m:[m189[36m:[m16[36m:[m [1m[31mDEP001[m 'psutil' imported but missing from the dependency definitions
+[1msrc/datacore/cli.py[m[36m:[m8[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1msrc/datacore/cli.py[m[36m:[m10[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/cli.py[m[36m:[m11[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/cli.py[m[36m:[m12[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/cli.py[m[36m:[m13[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/cli.py[m[36m:[m15[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/context.py[m[36m:[m8[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1msrc/datacore/context.py[m[36m:[m11[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/context.py[m[36m:[m17[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/io/fs.py[m[36m:[m21[36m:[m8[36m:[m [1m[31mDEP001[m 'fsspec' imported but missing from the dependency definitions
+[1msrc/datacore/io/fs.py[m[36m:[m24[36m:[m12[36m:[m [1m[31mDEP003[m 'pandas' imported but it is a transitive dependency
+[1msrc/datacore/io/fs.py[m[36m:[m29[36m:[m12[36m:[m [1m[31mDEP001[m 'polars' imported but missing from the dependency definitions
+[1msrc/datacore/io/fs.py[m[36m:[m36[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/layers/bronze/main.py[m[36m:[m7[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/layers/gold/main.py[m[36m:[m7[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/layers/raw/main.py[m[36m:[m5[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/layers/raw/main.py[m[36m:[m6[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1msrc/datacore/layers/silver/main.py[m[36m:[m7[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/pipeline/utils.py[m[36m:[m8[36m:[m8[36m:[m [1m[31mDEP003[m 'yaml' imported but it is a transitive dependency
+[1msrc/datacore/pipeline/utils.py[m[36m:[m11[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/pipeline/utils.py[m[36m:[m12[36m:[m5[36m:[m [1m[31mDEP003[m 'pyspark' imported but it is a transitive dependency
+[1msrc/datacore/pipeline/utils.py[m[36m:[m36[36m:[m1[36m:[m [1m[31mDEP001[m 'datacore' imported but missing from the dependency definitions
+[1m[31mFound 70 dependency issues.[m
+
+For more information, see the documentation: https://deptry.com/
+```
+
+### Links rotos
+
+- docs/run/azure.md → https://learn.microsoft.com/azure/synapse-analytics/spark/spark-job-definitions (HTTP Error 404: Not Found)
+- docs/run/azure.md → https://learn.microsoft.com/azure/synapse-analytics/spark/apache-spark-monitor-application (HTTP Error 404: Not Found)
+- docs/run/databricks.md → https://docs.databricks.com/jobs/jobs-parameterization.html (<urlopen error Tunnel connection failed: 403 Forbidden>)
+- docs/run/databricks.md → https://docs.databricks.com/security/secrets/index.html (<urlopen error Tunnel connection failed: 403 Forbidden>)
+- docs/run/databricks.md → https://docs.databricks.com/workflows/jobs/jobs-notifications.html (<urlopen error Tunnel connection failed: 403 Forbidden>)
+
+### Documentos huérfanos
+
+- Ninguno
+
+### Notebooks huérfanos
+
+- Ninguno

--- a/docs/cleanup.json
+++ b/docs/cleanup.json
@@ -1,0 +1,3781 @@
+{
+  "meta": {
+    "branch": "feature/main-codex",
+    "commit": "e270820641ad3006c6653668bf930aba18b4da54",
+    "generated_at": "2025-10-25T02:12:40.659025Z"
+  },
+  "summary": {
+    "totals": {
+      "keep": 128,
+      "remove": 1,
+      "quarantine": 4
+    },
+    "savings_mb_estimate": 0.02
+  },
+  "items": [
+    {
+      "path": ".env",
+      "type": "other",
+      "size_kb": 0.48,
+      "last_commit": "2025-09-28",
+      "references": {
+        "code": [
+          "scripts/run_high_volume_case.py:29",
+          "scripts/run_high_volume_case.py:30",
+          "scripts/run_high_volume_case.py:31",
+          "scripts/run_high_volume_case.py:39",
+          "scripts/run_multiformat_case.py:38",
+          "scripts/run_multiformat_case.py:39",
+          "scripts/run_multiformat_case.py:40",
+          "scripts/run_multiformat_case.py:44"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:174",
+          "docs/report.json:175",
+          "docs/report.json:176",
+          "docs/report.json:177",
+          "docs/run/jobs/aws_stepfunctions.json:12",
+          "docs/run/jobs/aws_stepfunctions.json:24",
+          "docs/run/jobs/aws_stepfunctions.json:36",
+          "docs/run/jobs/aws_stepfunctions.json:48"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": ".env.example",
+      "type": "other",
+      "size_kb": 0.55,
+      "last_commit": "2025-10-06",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:53",
+          "docs/CLEANUP_REPORT.md:20",
+          "docs/CLEANUP_REPORT.md:163"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": ".gitignore",
+      "type": "other",
+      "size_kb": 6.04,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "data/output/.gitkeep:2",
+          "data/processed/.gitkeep:2",
+          "data/raw/.gitkeep:2"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:75",
+          "docs/CLEANUP_REPORT.md:21",
+          "docs/CLEANUP_REPORT.md:170"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": ".mc/config.json",
+      "type": "config",
+      "size_kb": 0.69,
+      "last_commit": "2025-09-29",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:26",
+          "tools/audit_cleanup.py:28"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:11",
+          "docs/cleanup.json:101",
+          "docs/cleanup.json:131",
+          "docs/cleanup.json:150",
+          "docs/CLEANUP_REPORT.md:22",
+          "docs/CLEANUP_REPORT.md:23",
+          "docs/CLEANUP_REPORT.md:178",
+          "docs/CLEANUP_REPORT.md:186"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": ".mc/config.json.old",
+      "type": "other",
+      "size_kb": 0.69,
+      "last_commit": "2025-09-29",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:26"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:11",
+          "docs/cleanup.json:131",
+          "docs/CLEANUP_REPORT.md:23",
+          "docs/CLEANUP_REPORT.md:186"
+        ],
+        "jobs": []
+      },
+      "classification": "REMOVE",
+      "reason": "Archivo de respaldo antiguo de MinIO; reemplazado por config.json",
+      "risk": "low",
+      "proposed_action": "delete",
+      "notes": "No se usa en CI ni en scripts actuales."
+    },
+    {
+      "path": ".mc/share/downloads.json",
+      "type": "config",
+      "size_kb": 0.03,
+      "last_commit": "2025-09-29",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:156",
+          "docs/CLEANUP_REPORT.md:24",
+          "docs/CLEANUP_REPORT.md:195"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": ".mc/share/uploads.json",
+      "type": "config",
+      "size_kb": 0.03,
+      "last_commit": "2025-09-29",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/CLEANUP_REPORT.md:25",
+          "docs/CLEANUP_REPORT.md:202",
+          "docs/cleanup.json:178"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": ".pre-commit-config.yaml",
+      "type": "config",
+      "size_kb": 0.34,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:91",
+          "docs/cleanup.json:200",
+          "docs/CLEANUP_REPORT.md:26",
+          "docs/CLEANUP_REPORT.md:209"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "README.md",
+      "type": "doc",
+      "size_kb": 1.93,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:210"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:107",
+          "docs/cleanup.json:223",
+          "docs/cleanup.json:525",
+          "docs/cleanup.json:1376",
+          "docs/cleanup.json:1377",
+          "docs/cleanup.json:1378",
+          "docs/cleanup.json:1751",
+          "docs/cleanup.json:2169"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "cfg/bronze/template.yml",
+      "type": "config",
+      "size_kb": 0.52,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tests/test_cli_smoke.py:20",
+          "tests/test_cli_smoke.py:27"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:252",
+          "docs/cleanup.json:282",
+          "docs/cleanup.json:312",
+          "docs/cleanup.json:342",
+          "docs/cleanup.json:1369",
+          "docs/cleanup.json:1370",
+          "docs/cleanup.json:1371",
+          "docs/cleanup.json:1372"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "cfg/gold/template.yml",
+      "type": "config",
+      "size_kb": 0.51,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tests/test_cli_smoke.py:20",
+          "tests/test_cli_smoke.py:27"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:252",
+          "docs/cleanup.json:282",
+          "docs/cleanup.json:312",
+          "docs/cleanup.json:342",
+          "docs/cleanup.json:1369",
+          "docs/cleanup.json:1370",
+          "docs/cleanup.json:1371",
+          "docs/cleanup.json:1372"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "cfg/raw/template.yml",
+      "type": "config",
+      "size_kb": 0.51,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tests/test_cli_smoke.py:20",
+          "tests/test_cli_smoke.py:27"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:252",
+          "docs/cleanup.json:282",
+          "docs/cleanup.json:312",
+          "docs/cleanup.json:342",
+          "docs/cleanup.json:1369",
+          "docs/cleanup.json:1370",
+          "docs/cleanup.json:1371",
+          "docs/cleanup.json:1372"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "cfg/silver/template.yml",
+      "type": "config",
+      "size_kb": 0.52,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tests/test_cli_smoke.py:20",
+          "tests/test_cli_smoke.py:27"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:252",
+          "docs/cleanup.json:282",
+          "docs/cleanup.json:312",
+          "docs/cleanup.json:342",
+          "docs/cleanup.json:1369",
+          "docs/cleanup.json:1370",
+          "docs/cleanup.json:1371",
+          "docs/cleanup.json:1372"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "ci/build-test.yml",
+      "type": "config",
+      "size_kb": 0.97,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:372",
+          "docs/cleanup.json:2862",
+          "docs/CLEANUP_REPORT.md:32",
+          "docs/CLEANUP_REPORT.md:256",
+          "docs/CLEANUP_REPORT.md:933"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "ci/check_config.sh",
+      "type": "ci",
+      "size_kb": 0.25,
+      "last_commit": "2025-09-28",
+      "references": {
+        "code": [],
+        "configs": [
+          "ci/lint.yml:18"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:396",
+          "docs/cleanup.json:1004",
+          "docs/cleanup.json:1157",
+          "docs/CLEANUP_REPORT.md:33",
+          "docs/CLEANUP_REPORT.md:263",
+          "docs/CLEANUP_REPORT.md:429",
+          "docs/CLEANUP_REPORT.md:466",
+          "docs/REPORT.md:114"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "ci/docker-compose.override.yml",
+      "type": "config",
+      "size_kb": 0.1,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:425",
+          "docs/CLEANUP_REPORT.md:34",
+          "docs/CLEANUP_REPORT.md:271"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "ci/lint.yml",
+      "type": "config",
+      "size_kb": 0.34,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:403",
+          "docs/cleanup.json:447",
+          "docs/CLEANUP_REPORT.md:35",
+          "docs/CLEANUP_REPORT.md:267",
+          "docs/CLEANUP_REPORT.md:278",
+          "docs/REPORT.md:114",
+          "docs/REPORT.md:128"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "ci/test_dataset.yml",
+      "type": "config",
+      "size_kb": 0.34,
+      "last_commit": "2025-09-28",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:473",
+          "docs/cleanup.json:1001",
+          "docs/cleanup.json:1154",
+          "docs/cleanup.json:1537",
+          "docs/cleanup.json:1637",
+          "docs/CLEANUP_REPORT.md:36",
+          "docs/CLEANUP_REPORT.md:285",
+          "docs/CLEANUP_REPORT.md:428"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/database.yml",
+      "type": "config",
+      "size_kb": 1.93,
+      "last_commit": "2025-10-09",
+      "references": {
+        "code": [
+          "scripts/run_high_volume_case.py:79",
+          "scripts/runner.sh:7",
+          "scripts/runner_with_db.sh:7",
+          "scripts/generate_synthetic_data.py:580",
+          "scripts/generate_synthetic_data.py:639",
+          "scripts/run_multiformat_case.py:104"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v2/dataset.yml:44",
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset.yml:78",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:83",
+          "config/datasets/finanzas/payments_v1/dataset.yml:49",
+          "config/datasets/casos_uso/payments_high_volume.yml:69",
+          "config/datasets/casos_uso/events_multiformat.yml:71"
+        ],
+        "ci": [],
+        "docs": [
+          "README.md:13",
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:31",
+          "docs/PROJECT_DOCUMENTATION.md:40",
+          "docs/run/configs.md:22",
+          "docs/run/configs.md:57",
+          "docs/cleanup.json:500",
+          "docs/CLEANUP_REPORT.md:37"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/events_multiformat.yml",
+      "type": "config",
+      "size_kb": 3.88,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/run_multiformat_case.py:102"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:521",
+          "docs/cleanup.json:543",
+          "docs/cleanup.json:581",
+          "docs/cleanup.json:607",
+          "docs/cleanup.json:631",
+          "docs/cleanup.json:854",
+          "docs/cleanup.json:1000",
+          "docs/cleanup.json:1041"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/events_multiformat_expectations.yml",
+      "type": "config",
+      "size_kb": 7.29,
+      "last_commit": "2025-10-16",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:624"
+        ],
+        "configs": [
+          "config/datasets/casos_uso/events_multiformat.yml:42"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:572",
+          "docs/CLEANUP_REPORT.md:39",
+          "docs/CLEANUP_REPORT.md:309"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/events_multiformat_schema.json",
+      "type": "config",
+      "size_kb": 2.14,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:621"
+        ],
+        "configs": [
+          "config/datasets/casos_uso/events_multiformat.yml:46"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:598",
+          "docs/CLEANUP_REPORT.md:40",
+          "docs/CLEANUP_REPORT.md:318"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/events_multiformat_transforms.yml",
+      "type": "config",
+      "size_kb": 0.85,
+      "last_commit": "2025-10-16",
+      "references": {
+        "code": [],
+        "configs": [
+          "config/datasets/casos_uso/events_multiformat.yml:50"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:624",
+          "docs/CLEANUP_REPORT.md:41",
+          "docs/CLEANUP_REPORT.md:327"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/payments_high_volume.yml",
+      "type": "config",
+      "size_kb": 2.96,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/run_high_volume_case.py:77",
+          "scripts/generate_synthetic_data.py:599",
+          "scripts/generate_synthetic_data.py:603",
+          "scripts/generate_synthetic_data.py:782"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:520",
+          "docs/cleanup.json:648",
+          "docs/cleanup.json:689",
+          "docs/cleanup.json:715",
+          "docs/cleanup.json:784",
+          "docs/cleanup.json:962",
+          "docs/cleanup.json:999",
+          "docs/cleanup.json:1115"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/payments_high_volume_expectations.yml",
+      "type": "config",
+      "size_kb": 5.62,
+      "last_commit": "2025-10-09",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:562"
+        ],
+        "configs": [
+          "config/datasets/casos_uso/payments_high_volume.yml:45"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:680",
+          "docs/CLEANUP_REPORT.md:43",
+          "docs/CLEANUP_REPORT.md:343"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/casos_uso/payments_high_volume_schema.json",
+      "type": "config",
+      "size_kb": 2.42,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:566"
+        ],
+        "configs": [
+          "config/datasets/casos_uso/payments_high_volume.yml:49"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:706",
+          "docs/CLEANUP_REPORT.md:44",
+          "docs/CLEANUP_REPORT.md:352"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_db_only/dataset.yml",
+      "type": "config",
+      "size_kb": 2.28,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/runner.sh:5",
+          "scripts/runner_with_db.sh:5"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset.yml:90"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:24",
+          "docs/cleanup.json:473",
+          "docs/cleanup.json:514",
+          "docs/cleanup.json:515",
+          "docs/cleanup.json:516",
+          "docs/cleanup.json:519",
+          "docs/cleanup.json:732"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_db_only/expectations.yml",
+      "type": "config",
+      "size_kb": 0.46,
+      "last_commit": "2025-10-20",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:562",
+          "scripts/generate_synthetic_data.py:624",
+          "tests/test_config_schema.py:30"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:74",
+          "config/datasets/finanzas/payments_v2/dataset.yml:29",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:54",
+          "config/datasets/finanzas/payments_v3/dataset.yml:63",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:69",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:150",
+          "config/datasets/finanzas/payments_v1/dataset.yml:30",
+          "config/datasets/casos_uso/payments_high_volume.yml:45"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/run/configs.md:52",
+          "docs/cleanup.json:572",
+          "docs/cleanup.json:680",
+          "docs/cleanup.json:766",
+          "docs/cleanup.json:944",
+          "docs/cleanup.json:1097",
+          "docs/cleanup.json:1242",
+          "docs/CLEANUP_REPORT.md:39"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_db_only/schema.yml",
+      "type": "config",
+      "size_kb": 0.69,
+      "last_commit": "2025-10-20",
+      "references": {
+        "code": [],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:34",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:47",
+          "config/datasets/finanzas/payments_v3/dataset.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset.yml:56",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:63"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/CLEANUP_REPORT.md:47",
+          "docs/CLEANUP_REPORT.md:60",
+          "docs/CLEANUP_REPORT.md:379",
+          "docs/CLEANUP_REPORT.md:496",
+          "docs/cleanup.json:806",
+          "docs/cleanup.json:1282"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_db_only/transforms.yml",
+      "type": "config",
+      "size_kb": 1.16,
+      "last_commit": "2025-10-20",
+      "references": {
+        "code": [
+          "pipelines/transforms/apply.py:10"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:77",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:51",
+          "config/datasets/finanzas/payments_v3/dataset.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset.yml:60",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:66",
+          "config/datasets/finanzas/payments_v1/dataset.yml:11",
+          "config/datasets/casos_uso/events_multiformat.yml:50"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:28",
+          "docs/cleanup.json:624",
+          "docs/cleanup.json:838",
+          "docs/cleanup.json:1025",
+          "docs/cleanup.json:1314",
+          "docs/CLEANUP_REPORT.md:41",
+          "docs/CLEANUP_REPORT.md:48",
+          "docs/CLEANUP_REPORT.md:53"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_multi/dataset.yml",
+      "type": "config",
+      "size_kb": 1.65,
+      "last_commit": "2025-10-20",
+      "references": {
+        "code": [
+          "scripts/runner.sh:5",
+          "scripts/runner_with_db.sh:5"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset.yml:90"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:24",
+          "docs/cleanup.json:473",
+          "docs/cleanup.json:514",
+          "docs/cleanup.json:515",
+          "docs/cleanup.json:516",
+          "docs/cleanup.json:519",
+          "docs/cleanup.json:732"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v1/dataset.yml",
+      "type": "config",
+      "size_kb": 2.15,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/runner.sh:5",
+          "scripts/runner_with_db.sh:5"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset.yml:90"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:24",
+          "docs/cleanup.json:473",
+          "docs/cleanup.json:514",
+          "docs/cleanup.json:515",
+          "docs/cleanup.json:516",
+          "docs/cleanup.json:519",
+          "docs/cleanup.json:732"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v1/expectations.yml",
+      "type": "config",
+      "size_kb": 0.79,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:562",
+          "scripts/generate_synthetic_data.py:624",
+          "tests/test_config_schema.py:30"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:74",
+          "config/datasets/finanzas/payments_v2/dataset.yml:29",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:54",
+          "config/datasets/finanzas/payments_v3/dataset.yml:63",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:69",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:150",
+          "config/datasets/finanzas/payments_v1/dataset.yml:30",
+          "config/datasets/casos_uso/payments_high_volume.yml:45"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/run/configs.md:52",
+          "docs/cleanup.json:572",
+          "docs/cleanup.json:680",
+          "docs/cleanup.json:766",
+          "docs/cleanup.json:944",
+          "docs/cleanup.json:1097",
+          "docs/cleanup.json:1242",
+          "docs/CLEANUP_REPORT.md:39"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v1/schema.json",
+      "type": "config",
+      "size_kb": 1.79,
+      "last_commit": "2025-10-15",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:566",
+          "scripts/generate_synthetic_data.py:621",
+          "pipelines/database/db_manager.py:706",
+          "pipelines/database/__init__.py:1",
+          "pipelines/database/schema_mapper.py:428"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v2/dataset.yml:25",
+          "config/datasets/finanzas/payments_v1/dataset.yml:34",
+          "config/datasets/casos_uso/payments_high_volume.yml:49",
+          "config/datasets/casos_uso/events_multiformat.yml:46",
+          "ci/test_dataset.yml:9"
+        ],
+        "ci": [
+          "ci/check_config.sh:6"
+        ],
+        "docs": [
+          "docs/cleanup.json:598",
+          "docs/cleanup.json:706",
+          "docs/cleanup.json:984",
+          "docs/cleanup.json:1137",
+          "docs/CLEANUP_REPORT.md:40",
+          "docs/CLEANUP_REPORT.md:44",
+          "docs/CLEANUP_REPORT.md:52",
+          "docs/CLEANUP_REPORT.md:56"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v1/transforms.yml",
+      "type": "config",
+      "size_kb": 0.4,
+      "last_commit": "2025-10-13",
+      "references": {
+        "code": [
+          "pipelines/transforms/apply.py:10"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:77",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:51",
+          "config/datasets/finanzas/payments_v3/dataset.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset.yml:60",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:66",
+          "config/datasets/finanzas/payments_v1/dataset.yml:11",
+          "config/datasets/casos_uso/events_multiformat.yml:50"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:28",
+          "docs/cleanup.json:624",
+          "docs/cleanup.json:838",
+          "docs/cleanup.json:1025",
+          "docs/cleanup.json:1314",
+          "docs/CLEANUP_REPORT.md:41",
+          "docs/CLEANUP_REPORT.md:48",
+          "docs/CLEANUP_REPORT.md:53"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v2/dataset.yml",
+      "type": "config",
+      "size_kb": 1.69,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/runner.sh:5",
+          "scripts/runner_with_db.sh:5"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset.yml:90"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:24",
+          "docs/CLEANUP_REPORT.md:36",
+          "docs/CLEANUP_REPORT.md:45",
+          "docs/CLEANUP_REPORT.md:49",
+          "docs/CLEANUP_REPORT.md:50",
+          "docs/CLEANUP_REPORT.md:54",
+          "docs/CLEANUP_REPORT.md:57"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v2/expectations.yml",
+      "type": "config",
+      "size_kb": 0.79,
+      "last_commit": "2025-10-06",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:562",
+          "scripts/generate_synthetic_data.py:624",
+          "tests/test_config_schema.py:30"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:74",
+          "config/datasets/finanzas/payments_v2/dataset.yml:29",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:54",
+          "config/datasets/finanzas/payments_v3/dataset.yml:63",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:69",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:150",
+          "config/datasets/finanzas/payments_v1/dataset.yml:30",
+          "config/datasets/casos_uso/payments_high_volume.yml:45"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/run/configs.md:52",
+          "docs/cleanup.json:572",
+          "docs/cleanup.json:680",
+          "docs/cleanup.json:766",
+          "docs/cleanup.json:944",
+          "docs/cleanup.json:1097",
+          "docs/cleanup.json:1242",
+          "docs/CLEANUP_REPORT.md:39"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v2/schema.json",
+      "type": "config",
+      "size_kb": 0.47,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:566",
+          "scripts/generate_synthetic_data.py:621",
+          "pipelines/database/db_manager.py:706",
+          "pipelines/database/__init__.py:1",
+          "pipelines/database/schema_mapper.py:428"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v2/dataset.yml:25",
+          "config/datasets/finanzas/payments_v1/dataset.yml:34",
+          "config/datasets/casos_uso/payments_high_volume.yml:49",
+          "config/datasets/casos_uso/events_multiformat.yml:46",
+          "ci/test_dataset.yml:9"
+        ],
+        "ci": [
+          "ci/check_config.sh:6"
+        ],
+        "docs": [
+          "docs/cleanup.json:598",
+          "docs/cleanup.json:706",
+          "docs/cleanup.json:984",
+          "docs/cleanup.json:1137",
+          "docs/CLEANUP_REPORT.md:40",
+          "docs/CLEANUP_REPORT.md:44",
+          "docs/CLEANUP_REPORT.md:52",
+          "docs/CLEANUP_REPORT.md:56"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v3/dataset.yml",
+      "type": "config",
+      "size_kb": 2.82,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/runner.sh:5",
+          "scripts/runner_with_db.sh:5"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset.yml:90"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:24",
+          "docs/cleanup.json:473",
+          "docs/cleanup.json:514",
+          "docs/cleanup.json:515",
+          "docs/cleanup.json:516",
+          "docs/cleanup.json:519",
+          "docs/cleanup.json:732"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v3/dataset_api.yml",
+      "type": "config",
+      "size_kb": 4.19,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:4",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:5"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:517",
+          "docs/cleanup.json:518",
+          "docs/cleanup.json:781",
+          "docs/cleanup.json:782",
+          "docs/cleanup.json:817",
+          "docs/cleanup.json:818",
+          "docs/cleanup.json:851",
+          "docs/cleanup.json:852"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v3/expectations.yml",
+      "type": "config",
+      "size_kb": 0.46,
+      "last_commit": "2025-10-16",
+      "references": {
+        "code": [
+          "scripts/generate_synthetic_data.py:562",
+          "scripts/generate_synthetic_data.py:624",
+          "tests/test_config_schema.py:30"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:74",
+          "config/datasets/finanzas/payments_v2/dataset.yml:29",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:54",
+          "config/datasets/finanzas/payments_v3/dataset.yml:63",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:69",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:150",
+          "config/datasets/finanzas/payments_v1/dataset.yml:30",
+          "config/datasets/casos_uso/payments_high_volume.yml:45"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/run/configs.md:52",
+          "docs/cleanup.json:572",
+          "docs/cleanup.json:680",
+          "docs/cleanup.json:766",
+          "docs/cleanup.json:944",
+          "docs/cleanup.json:1097",
+          "docs/cleanup.json:1242",
+          "docs/CLEANUP_REPORT.md:39"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v3/schema.yml",
+      "type": "config",
+      "size_kb": 0.7,
+      "last_commit": "2025-10-16",
+      "references": {
+        "code": [],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:34",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:47",
+          "config/datasets/finanzas/payments_v3/dataset.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset.yml:56",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:63"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:806",
+          "docs/cleanup.json:1282",
+          "docs/CLEANUP_REPORT.md:47",
+          "docs/CLEANUP_REPORT.md:60",
+          "docs/CLEANUP_REPORT.md:379",
+          "docs/CLEANUP_REPORT.md:496"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/datasets/finanzas/payments_v3/transforms.yml",
+      "type": "config",
+      "size_kb": 1.36,
+      "last_commit": "2025-10-20",
+      "references": {
+        "code": [
+          "pipelines/transforms/apply.py:10"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_multi/dataset.yml:77",
+          "config/datasets/finanzas/payments_db_only/dataset.yml:51",
+          "config/datasets/finanzas/payments_v3/dataset.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset.yml:60",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:2",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:66",
+          "config/datasets/finanzas/payments_v1/dataset.yml:11",
+          "config/datasets/casos_uso/events_multiformat.yml:50"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:28",
+          "docs/cleanup.json:624",
+          "docs/cleanup.json:838",
+          "docs/cleanup.json:1025",
+          "docs/cleanup.json:1314",
+          "docs/CLEANUP_REPORT.md:41",
+          "docs/CLEANUP_REPORT.md:48",
+          "docs/CLEANUP_REPORT.md:53"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/env.yml",
+      "type": "config",
+      "size_kb": 0.65,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/runner.sh:6",
+          "scripts/runner_with_db.sh:6",
+          "pipelines/sources.py:113",
+          "pipelines/sources.py:117",
+          "src/datacore/io/adapters.py:63"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:5",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:15",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:103",
+          "cfg/raw/template.yml:7",
+          "cfg/gold/template.yml:7",
+          "cfg/silver/template.yml:7",
+          "cfg/bronze/template.yml:7"
+        ],
+        "ci": [],
+        "docs": [
+          "README.md:13",
+          "README.md:15",
+          "README.md:38",
+          "docs/PROJECT_DOCUMENTATION.md:10",
+          "docs/PROJECT_DOCUMENTATION.md:22",
+          "docs/PROJECT_DOCUMENTATION.md:40",
+          "docs/PROJECT_DOCUMENTATION.md:42",
+          "docs/run/configs.md:20"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "config/schema_mapping.yml",
+      "type": "config",
+      "size_kb": 1.89,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [
+          "pipelines/database/schema_mapper.py:48"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/CLEANUP_REPORT.md:63",
+          "docs/CLEANUP_REPORT.md:522",
+          "docs/CLEANUP_REPORT.md:795",
+          "docs/cleanup.json:1394",
+          "docs/cleanup.json:2354"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/casos-uso/multi-format/events_batch_001.json",
+      "type": "other",
+      "size_kb": 5709.05,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/CLEANUP_REPORT.md:64",
+          "docs/CLEANUP_REPORT.md:530",
+          "docs/cleanup.json:1420"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/output/.gitkeep",
+      "type": "other",
+      "size_kb": 0.14,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:81",
+          "docs/cleanup.json:82",
+          "docs/cleanup.json:83",
+          "docs/cleanup.json:1442",
+          "docs/cleanup.json:1469",
+          "docs/cleanup.json:1496",
+          "docs/CLEANUP_REPORT.md:65",
+          "docs/CLEANUP_REPORT.md:66"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/processed/.gitkeep",
+      "type": "other",
+      "size_kb": 0.16,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:81",
+          "docs/cleanup.json:82",
+          "docs/cleanup.json:83",
+          "docs/cleanup.json:1442",
+          "docs/cleanup.json:1469",
+          "docs/cleanup.json:1496",
+          "docs/CLEANUP_REPORT.md:65",
+          "docs/CLEANUP_REPORT.md:66"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/raw/.gitkeep",
+      "type": "other",
+      "size_kb": 0.15,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:81",
+          "docs/cleanup.json:82",
+          "docs/cleanup.json:83",
+          "docs/cleanup.json:1442",
+          "docs/cleanup.json:1469",
+          "docs/cleanup.json:1496",
+          "docs/CLEANUP_REPORT.md:65",
+          "docs/CLEANUP_REPORT.md:66"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/raw/payments/sample.csv",
+      "type": "other",
+      "size_kb": 0.64,
+      "last_commit": "2025-10-15",
+      "references": {
+        "code": [
+          "scripts/generate_big_payments.py:6",
+          "tests/test_io_fs.py:185",
+          "tests/test_io_fs.py:186",
+          "tests/test_io_fs.py:187",
+          "tests/test_io_fs.py:211"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v2/dataset.yml:5",
+          "ci/test_dataset.yml:5"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/CLEANUP_REPORT.md:68",
+          "docs/CLEANUP_REPORT.md:72",
+          "docs/CLEANUP_REPORT.md:558",
+          "docs/CLEANUP_REPORT.md:588",
+          "docs/cleanup.json:1523",
+          "docs/cleanup.json:1623"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/s3a-staging/finanzas/payments/raw/sample.jsonl",
+      "type": "other",
+      "size_kb": 0.31,
+      "last_commit": "2025-10-20",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1557",
+          "docs/CLEANUP_REPORT.md:69",
+          "docs/CLEANUP_REPORT.md:567"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/s3a-staging/raw/casos-uso/payments-high-volume/payments-high-volume/payments_batch_001.csv",
+      "type": "other",
+      "size_kb": 588.43,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1579",
+          "docs/CLEANUP_REPORT.md:70",
+          "docs/CLEANUP_REPORT.md:574"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/s3a-staging/raw/casos-uso/payments-high-volume/payments-high-volume/payments_batch_002.csv",
+      "type": "other",
+      "size_kb": 588.26,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1601",
+          "docs/CLEANUP_REPORT.md:71",
+          "docs/CLEANUP_REPORT.md:581"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "data/s3a-staging/raw/payments_v3/sample.csv",
+      "type": "other",
+      "size_kb": 0.34,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/generate_big_payments.py:6",
+          "tests/test_io_fs.py:185",
+          "tests/test_io_fs.py:186",
+          "tests/test_io_fs.py:187",
+          "tests/test_io_fs.py:211"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v2/dataset.yml:5",
+          "ci/test_dataset.yml:5"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1523",
+          "docs/cleanup.json:1623",
+          "docs/CLEANUP_REPORT.md:68",
+          "docs/CLEANUP_REPORT.md:72",
+          "docs/CLEANUP_REPORT.md:558",
+          "docs/CLEANUP_REPORT.md:588"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docker/spark-pandas-udf/Dockerfile",
+      "type": "docker",
+      "size_kb": 0.34,
+      "last_commit": "2025-10-13",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:131"
+        ],
+        "configs": [
+          "docker-compose.yml:49",
+          "docker-compose.yml:65",
+          "docker-compose.yml:81"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1657",
+          "docs/CLEANUP_REPORT.md:73",
+          "docs/CLEANUP_REPORT.md:597"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docker-compose.yml",
+      "type": "config",
+      "size_kb": 3.98,
+      "last_commit": "2025-10-13",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1666",
+          "docs/cleanup.json:1667",
+          "docs/cleanup.json:1668",
+          "docs/cleanup.json:1685",
+          "docs/cleanup.json:2889",
+          "docs/cleanup.json:3032",
+          "docs/cleanup.json:3033",
+          "docs/CLEANUP_REPORT.md:74"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/CLEANUP_REPORT.md",
+      "type": "doc",
+      "size_kb": 110.83,
+      "last_commit": "",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:211",
+          "tools/audit_cleanup.py:527"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:15",
+          "docs/cleanup.json:63",
+          "docs/cleanup.json:64",
+          "docs/cleanup.json:89",
+          "docs/cleanup.json:90",
+          "docs/cleanup.json:117",
+          "docs/cleanup.json:118",
+          "docs/cleanup.json:119"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/PROJECT_DOCUMENTATION.md",
+      "type": "doc",
+      "size_kb": 5.29,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "README.md:33",
+          "docs/cleanup.json:209",
+          "docs/cleanup.json:234",
+          "docs/cleanup.json:526",
+          "docs/cleanup.json:527",
+          "docs/cleanup.json:528",
+          "docs/cleanup.json:748",
+          "docs/cleanup.json:749"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/REPORT.md",
+      "type": "doc",
+      "size_kb": 12.38,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:33",
+          "tools/audit_cleanup.py:211",
+          "tools/audit_cleanup.py:527"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:9",
+          "docs/diagrams/deps_cleanup.md:15",
+          "docs/cleanup.json:63",
+          "docs/cleanup.json:64",
+          "docs/cleanup.json:89",
+          "docs/cleanup.json:90",
+          "docs/cleanup.json:117",
+          "docs/cleanup.json:118"
+        ],
+        "jobs": []
+      },
+      "classification": "QUARANTINE",
+      "reason": "Reporte legacy previo a la documentación modular.",
+      "risk": "medium",
+      "proposed_action": "move_to_legacy",
+      "notes": "Conservar en /legacy/docs hasta validar que no sea referencia externa."
+    },
+    {
+      "path": "docs/cleanup.json",
+      "type": "doc",
+      "size_kb": 135.98,
+      "last_commit": "",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:212",
+          "tools/audit_cleanup.py:526"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:62",
+          "docs/cleanup.json:88",
+          "docs/cleanup.json:114",
+          "docs/cleanup.json:115",
+          "docs/cleanup.json:116",
+          "docs/cleanup.json:143",
+          "docs/cleanup.json:165",
+          "docs/cleanup.json:187"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/diagrams/dependencies.md",
+      "type": "doc",
+      "size_kb": 1.24,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/REPORT.md:45",
+          "docs/cleanup.json:1830",
+          "docs/CLEANUP_REPORT.md:79",
+          "docs/CLEANUP_REPORT.md:645"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/diagrams/deps_cleanup.md",
+      "type": "doc",
+      "size_kb": 0.64,
+      "last_commit": "",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:213"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:113",
+          "docs/cleanup.json:142",
+          "docs/cleanup.json:1724",
+          "docs/cleanup.json:1782",
+          "docs/cleanup.json:1783",
+          "docs/cleanup.json:1853",
+          "docs/cleanup.json:1945",
+          "docs/cleanup.json:2917"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/diagrams/pipeline_flow.md",
+      "type": "doc",
+      "size_kb": 1.17,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1881",
+          "docs/cleanup.json:2511",
+          "docs/cleanup.json:2550",
+          "docs/CLEANUP_REPORT.md:81",
+          "docs/CLEANUP_REPORT.md:660",
+          "docs/CLEANUP_REPORT.md:838",
+          "docs/CLEANUP_REPORT.md:847",
+          "docs/REPORT.md:46"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/policies/DEP-001-legacy-removal.md",
+      "type": "doc",
+      "size_kb": 2.08,
+      "last_commit": "",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:214"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1908",
+          "docs/CLEANUP_REPORT.md:82",
+          "docs/CLEANUP_REPORT.md:667"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/report.json",
+      "type": "doc",
+      "size_kb": 5.92,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:40"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:10",
+          "docs/cleanup.json:35",
+          "docs/cleanup.json:36",
+          "docs/cleanup.json:37",
+          "docs/cleanup.json:38",
+          "docs/cleanup.json:1934",
+          "docs/cleanup.json:2222",
+          "docs/cleanup.json:2223"
+        ],
+        "jobs": []
+      },
+      "classification": "QUARANTINE",
+      "reason": "Export JSON antiguo duplicando reportes actuales.",
+      "risk": "medium",
+      "proposed_action": "move_to_legacy",
+      "notes": "Generado por tooling previo; no usado en pipelines."
+    },
+    {
+      "path": "docs/run/aws.md",
+      "type": "doc",
+      "size_kb": 3.11,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:49",
+          "docs/cleanup.json:1963",
+          "docs/CLEANUP_REPORT.md:84",
+          "docs/CLEANUP_REPORT.md:684"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/azure.md",
+      "type": "doc",
+      "size_kb": 3.28,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:51",
+          "docs/cleanup.json:1986",
+          "docs/CLEANUP_REPORT.md:85",
+          "docs/CLEANUP_REPORT.md:691",
+          "docs/CLEANUP_REPORT.md:1336",
+          "docs/CLEANUP_REPORT.md:1337"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/configs.md",
+      "type": "doc",
+      "size_kb": 2.69,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:529",
+          "docs/cleanup.json:530",
+          "docs/cleanup.json:788",
+          "docs/cleanup.json:966",
+          "docs/cleanup.json:1119",
+          "docs/cleanup.json:1264",
+          "docs/cleanup.json:1383",
+          "docs/cleanup.json:2011"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/databricks.md",
+      "type": "doc",
+      "size_kb": 3.15,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:48",
+          "docs/cleanup.json:2038",
+          "docs/CLEANUP_REPORT.md:87",
+          "docs/CLEANUP_REPORT.md:705",
+          "docs/CLEANUP_REPORT.md:1338",
+          "docs/CLEANUP_REPORT.md:1339",
+          "docs/CLEANUP_REPORT.md:1340"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/gcp.md",
+      "type": "doc",
+      "size_kb": 3.61,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:50",
+          "docs/cleanup.json:2064",
+          "docs/CLEANUP_REPORT.md:88",
+          "docs/CLEANUP_REPORT.md:712"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/jobs/aws_stepfunctions.json",
+      "type": "doc",
+      "size_kb": 1.28,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:39",
+          "docs/cleanup.json:40",
+          "docs/cleanup.json:41",
+          "docs/cleanup.json:42",
+          "docs/cleanup.json:2087",
+          "docs/CLEANUP_REPORT.md:89",
+          "docs/CLEANUP_REPORT.md:160",
+          "docs/CLEANUP_REPORT.md:719"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/jobs/databricks_job.json",
+      "type": "doc",
+      "size_kb": 2.03,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:2114",
+          "docs/CLEANUP_REPORT.md:90",
+          "docs/CLEANUP_REPORT.md:726"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "docs/run/jobs/dataproc_workflow.yaml",
+      "type": "config",
+      "size_kb": 1.68,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:54"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:2136",
+          "docs/CLEANUP_REPORT.md:91",
+          "docs/CLEANUP_REPORT.md:733"
+        ],
+        "jobs": []
+      },
+      "classification": "QUARANTINE",
+      "reason": "Plantilla Dataproc sin referencias en CI/CD.",
+      "risk": "medium",
+      "proposed_action": "move_to_legacy",
+      "notes": "Considerar mover a legacy/infra antes de eliminar."
+    },
+    {
+      "path": "docs/tools/list_io.py",
+      "type": "code",
+      "size_kb": 2.94,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "README.md:40",
+          "docs/cleanup.json:2160",
+          "docs/cleanup.json:3737",
+          "docs/CLEANUP_REPORT.md:92",
+          "docs/CLEANUP_REPORT.md:151",
+          "docs/CLEANUP_REPORT.md:742",
+          "docs/CLEANUP_REPORT.md:1166",
+          "docs/CLEANUP_REPORT.md:1259"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/__init__.py",
+      "type": "code",
+      "size_kb": 0.16,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/common.py",
+      "type": "code",
+      "size_kb": 4.32,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:128",
+          "docs/report.json:144",
+          "docs/cleanup.json:2213",
+          "docs/CLEANUP_REPORT.md:94",
+          "docs/CLEANUP_REPORT.md:756",
+          "docs/CLEANUP_REPORT.md:1196",
+          "docs/CLEANUP_REPORT.md:1260",
+          "docs/CLEANUP_REPORT.md:1261"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/config/__init__.py",
+      "type": "code",
+      "size_kb": 0.05,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/config/loader.py",
+      "type": "code",
+      "size_kb": 0.75,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:15",
+          "docs/cleanup.json:2267",
+          "docs/CLEANUP_REPORT.md:96",
+          "docs/CLEANUP_REPORT.md:770",
+          "docs/CLEANUP_REPORT.md:1197",
+          "docs/CLEANUP_REPORT.md:1198",
+          "docs/CLEANUP_REPORT.md:1199",
+          "docs/CLEANUP_REPORT.md:1265"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/database/__init__.py",
+      "type": "code",
+      "size_kb": 0.06,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/database/db_manager.py",
+      "type": "code",
+      "size_kb": 29.79,
+      "last_commit": "2025-10-15",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:992",
+          "docs/cleanup.json:1145",
+          "docs/cleanup.json:2320",
+          "docs/CLEANUP_REPORT.md:98",
+          "docs/CLEANUP_REPORT.md:427",
+          "docs/CLEANUP_REPORT.md:464",
+          "docs/CLEANUP_REPORT.md:784",
+          "docs/CLEANUP_REPORT.md:1200"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/database/schema_mapper.py",
+      "type": "code",
+      "size_kb": 18.59,
+      "last_commit": "2025-10-09",
+      "references": {
+        "code": [],
+        "configs": [
+          "config/schema_mapping.yml:2"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:994",
+          "docs/cleanup.json:1147",
+          "docs/cleanup.json:1400",
+          "docs/cleanup.json:2347",
+          "docs/CLEANUP_REPORT.md:99",
+          "docs/CLEANUP_REPORT.md:427",
+          "docs/CLEANUP_REPORT.md:464",
+          "docs/CLEANUP_REPORT.md:526"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/io/__init__.py",
+      "type": "code",
+      "size_kb": 0.06,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/io/reader.py",
+      "type": "code",
+      "size_kb": 1.48,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:16",
+          "docs/cleanup.json:2403",
+          "docs/CLEANUP_REPORT.md:101",
+          "docs/CLEANUP_REPORT.md:806",
+          "docs/CLEANUP_REPORT.md:1219",
+          "docs/CLEANUP_REPORT.md:1273",
+          "docs/CLEANUP_REPORT.md:1274",
+          "docs/CLEANUP_REPORT.md:1275"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/io/s3a.py",
+      "type": "code",
+      "size_kb": 0.48,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:16",
+          "docs/cleanup.json:2427",
+          "docs/CLEANUP_REPORT.md:102",
+          "docs/CLEANUP_REPORT.md:813",
+          "docs/CLEANUP_REPORT.md:1220",
+          "docs/CLEANUP_REPORT.md:1276"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/io/writer.py",
+      "type": "code",
+      "size_kb": 1.42,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:16",
+          "docs/PROJECT_DOCUMENTATION.md:79",
+          "docs/cleanup.json:2451",
+          "docs/CLEANUP_REPORT.md:103",
+          "docs/CLEANUP_REPORT.md:820",
+          "docs/CLEANUP_REPORT.md:1277",
+          "docs/CLEANUP_REPORT.md:1278"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/sources.py",
+      "type": "code",
+      "size_kb": 13.96,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:61",
+          "docs/report.json:68",
+          "docs/PROJECT_DOCUMENTATION.md:18",
+          "docs/PROJECT_DOCUMENTATION.md:56",
+          "docs/REPORT.md:155",
+          "docs/REPORT.md:156",
+          "docs/cleanup.json:1360",
+          "docs/cleanup.json:1361"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/spark_job.py",
+      "type": "code",
+      "size_kb": 11.51,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/pipeline_flow.md:7",
+          "docs/report.json:75",
+          "docs/cleanup.json:2502",
+          "docs/CLEANUP_REPORT.md:105",
+          "docs/CLEANUP_REPORT.md:834",
+          "docs/CLEANUP_REPORT.md:1221",
+          "docs/CLEANUP_REPORT.md:1282",
+          "docs/CLEANUP_REPORT.md:1283"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/spark_job_with_db.py",
+      "type": "code",
+      "size_kb": 2.11,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/run_high_volume_case.py:85",
+          "scripts/runner.sh:106",
+          "scripts/runner_with_db.sh:61",
+          "scripts/generate_synthetic_data.py:782",
+          "scripts/run_multiformat_case.py:110",
+          "pipelines/spark_job_with_db.py:13"
+        ],
+        "configs": [
+          "config/datasets/finanzas/payments_v3/dataset.yml:6",
+          "config/datasets/finanzas/payments_v3/dataset_api.yml:5"
+        ],
+        "ci": [],
+        "docs": [
+          "README.md:13",
+          "README.md:29",
+          "docs/diagrams/pipeline_flow.md:8",
+          "docs/PROJECT_DOCUMENTATION.md:17",
+          "docs/PROJECT_DOCUMENTATION.md:40",
+          "docs/cleanup.json:2529",
+          "docs/cleanup.json:2540",
+          "docs/CLEANUP_REPORT.md:106"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/transforms/__init__.py",
+      "type": "code",
+      "size_kb": 0.05,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/transforms/apply.py",
+      "type": "code",
+      "size_kb": 4.82,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:14",
+          "docs/PROJECT_DOCUMENTATION.md:90",
+          "docs/cleanup.json:844",
+          "docs/cleanup.json:1031",
+          "docs/cleanup.json:1320",
+          "docs/cleanup.json:2593",
+          "docs/cleanup.json:2647",
+          "docs/CLEANUP_REPORT.md:108"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/transforms/tests/__init__.py",
+      "type": "code",
+      "size_kb": 0.03,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/transforms/tests/test_apply.py",
+      "type": "code",
+      "size_kb": 1.23,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:90",
+          "docs/cleanup.json:2647",
+          "docs/CLEANUP_REPORT.md:110",
+          "docs/CLEANUP_REPORT.md:871",
+          "docs/CLEANUP_REPORT.md:1293",
+          "docs/CLEANUP_REPORT.md:1294",
+          "docs/CLEANUP_REPORT.md:1295"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/udf_catalog.py",
+      "type": "code",
+      "size_kb": 4.79,
+      "last_commit": "2025-10-13",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:2670",
+          "docs/CLEANUP_REPORT.md:111",
+          "docs/CLEANUP_REPORT.md:878",
+          "docs/CLEANUP_REPORT.md:1222",
+          "docs/CLEANUP_REPORT.md:1223",
+          "docs/CLEANUP_REPORT.md:1224",
+          "docs/CLEANUP_REPORT.md:1225",
+          "docs/CLEANUP_REPORT.md:1226"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/utils/__init__.py",
+      "type": "code",
+      "size_kb": 0.06,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/CLEANUP_REPORT.md:93",
+          "docs/CLEANUP_REPORT.md:95",
+          "docs/CLEANUP_REPORT.md:97",
+          "docs/CLEANUP_REPORT.md:100",
+          "docs/CLEANUP_REPORT.md:107",
+          "docs/CLEANUP_REPORT.md:109",
+          "docs/CLEANUP_REPORT.md:112",
+          "docs/CLEANUP_REPORT.md:115"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/utils/logger.py",
+      "type": "code",
+      "size_kb": 1.16,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:12",
+          "docs/cleanup.json:2724",
+          "docs/CLEANUP_REPORT.md:113",
+          "docs/CLEANUP_REPORT.md:892"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/utils/parallel.py",
+      "type": "code",
+      "size_kb": 0.95,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:12",
+          "docs/cleanup.json:2747",
+          "docs/CLEANUP_REPORT.md:114",
+          "docs/CLEANUP_REPORT.md:899",
+          "docs/CLEANUP_REPORT.md:1230",
+          "docs/CLEANUP_REPORT.md:1231"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/validation/__init__.py",
+      "type": "code",
+      "size_kb": 0.08,
+      "last_commit": "2025-10-21",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pipelines/validation/quality.py",
+      "type": "code",
+      "size_kb": 4.31,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:119",
+          "docs/PROJECT_DOCUMENTATION.md:13",
+          "docs/cleanup.json:2799",
+          "docs/CLEANUP_REPORT.md:116",
+          "docs/CLEANUP_REPORT.md:913",
+          "docs/CLEANUP_REPORT.md:1300",
+          "docs/CLEANUP_REPORT.md:1301",
+          "docs/REPORT.md:124"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "pyproject.toml",
+      "type": "config",
+      "size_kb": 0.81,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:208"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/PROJECT_DOCUMENTATION.md:91",
+          "docs/cleanup.json:2824",
+          "docs/CLEANUP_REPORT.md:117",
+          "docs/CLEANUP_REPORT.md:920",
+          "docs/REPORT.md:84"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "requirements.txt",
+      "type": "other",
+      "size_kb": 0.68,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/runner.sh:29",
+          "scripts/runner.sh:30",
+          "scripts/runner_with_db.sh:31",
+          "tools/audit_cleanup.py:209"
+        ],
+        "configs": [
+          "ci/build-test.yml:28"
+        ],
+        "ci": [],
+        "docs": [
+          "README.md:11",
+          "docs/PROJECT_DOCUMENTATION.md:39",
+          "docs/cleanup.json:2850",
+          "docs/CLEANUP_REPORT.md:118",
+          "docs/CLEANUP_REPORT.md:928",
+          "docs/REPORT.md:116"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Governance or generated artifact",
+      "risk": "low",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "scripts/db/init.sql",
+      "type": "other",
+      "size_kb": 1.67,
+      "last_commit": "2025-10-08",
+      "references": {
+        "code": [],
+        "configs": [
+          "docker-compose.yml:22"
+        ],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:2882",
+          "docs/CLEANUP_REPORT.md:119",
+          "docs/CLEANUP_REPORT.md:937"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "scripts/generate_big_payments.py",
+      "type": "code",
+      "size_kb": 1.27,
+      "last_commit": "2025-09-29",
+      "references": {
+        "code": [
+          "tools/audit_cleanup.py:47"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:8",
+          "docs/CLEANUP_REPORT.md:120",
+          "docs/CLEANUP_REPORT.md:562",
+          "docs/CLEANUP_REPORT.md:592",
+          "docs/CLEANUP_REPORT.md:945",
+          "docs/cleanup.json:1529",
+          "docs/cleanup.json:1629",
+          "docs/cleanup.json:2906"
+        ],
+        "jobs": []
+      },
+      "classification": "QUARANTINE",
+      "reason": "Script de generación legacy reemplazado por generate_synthetic_data.py.",
+      "risk": "medium",
+      "proposed_action": "move_to_legacy",
+      "notes": "No referenciado desde CLI actuales."
+    },
+    {
+      "path": "scripts/generate_synthetic_data.py",
+      "type": "code",
+      "size_kb": 34.54,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [
+          "scripts/run_high_volume_case.py:49",
+          "scripts/generate_synthetic_data.py:21",
+          "scripts/generate_synthetic_data.py:22",
+          "scripts/generate_synthetic_data.py:23",
+          "scripts/generate_synthetic_data.py:670",
+          "scripts/generate_synthetic_data.py:671",
+          "scripts/generate_synthetic_data.py:672",
+          "scripts/generate_synthetic_data.py:673"
+        ],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/diagrams/deps_cleanup.md:7",
+          "docs/cleanup.json:509",
+          "docs/cleanup.json:510",
+          "docs/cleanup.json:578",
+          "docs/cleanup.json:604",
+          "docs/cleanup.json:655",
+          "docs/cleanup.json:656",
+          "docs/cleanup.json:657"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "scripts/run_high_volume_case.py",
+      "type": "code",
+      "size_kb": 8.63,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:161",
+          "docs/cleanup.json:23",
+          "docs/cleanup.json:24",
+          "docs/cleanup.json:25",
+          "docs/cleanup.json:26",
+          "docs/cleanup.json:506",
+          "docs/cleanup.json:654",
+          "docs/cleanup.json:2535"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "scripts/run_multiformat_case.py",
+      "type": "code",
+      "size_kb": 15.11,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:27",
+          "docs/cleanup.json:28",
+          "docs/cleanup.json:29",
+          "docs/cleanup.json:30",
+          "docs/cleanup.json:511",
+          "docs/cleanup.json:549",
+          "docs/cleanup.json:2539",
+          "docs/cleanup.json:2998"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "scripts/runner.sh",
+      "type": "other",
+      "size_kb": 4.07,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [
+          "docker-compose.yml:85",
+          "docker-compose.yml:86"
+        ],
+        "ci": [],
+        "docs": [
+          "README.md:15",
+          "docs/report.json:136",
+          "docs/report.json:154",
+          "docs/PROJECT_DOCUMENTATION.md:42",
+          "docs/cleanup.json:507",
+          "docs/cleanup.json:738",
+          "docs/cleanup.json:882",
+          "docs/cleanup.json:916"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "scripts/runner_with_db.sh",
+      "type": "other",
+      "size_kb": 3.03,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:132",
+          "docs/report.json:149",
+          "docs/report.json:166",
+          "docs/cleanup.json:508",
+          "docs/cleanup.json:739",
+          "docs/cleanup.json:883",
+          "docs/cleanup.json:917",
+          "docs/cleanup.json:1070"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/__init__.py",
+      "type": "code",
+      "size_kb": 0.32,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/cli.py",
+      "type": "code",
+      "size_kb": 4.91,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:3109",
+          "docs/CLEANUP_REPORT.md:127",
+          "docs/CLEANUP_REPORT.md:998",
+          "docs/CLEANUP_REPORT.md:1234",
+          "docs/CLEANUP_REPORT.md:1307",
+          "docs/CLEANUP_REPORT.md:1308",
+          "docs/CLEANUP_REPORT.md:1309",
+          "docs/CLEANUP_REPORT.md:1310"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/config/schema.py",
+      "type": "code",
+      "size_kb": 8.37,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/run/configs.md:5",
+          "docs/run/configs.md:77",
+          "docs/cleanup.json:774",
+          "docs/cleanup.json:952",
+          "docs/cleanup.json:1105",
+          "docs/cleanup.json:1250",
+          "docs/cleanup.json:3134",
+          "docs/cleanup.json:3589"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/context.py",
+      "type": "code",
+      "size_kb": 6.29,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:3161",
+          "docs/CLEANUP_REPORT.md:129",
+          "docs/CLEANUP_REPORT.md:1012",
+          "docs/CLEANUP_REPORT.md:1241",
+          "docs/CLEANUP_REPORT.md:1313",
+          "docs/CLEANUP_REPORT.md:1314",
+          "docs/CLEANUP_REPORT.md:1315"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/io/__init__.py",
+      "type": "code",
+      "size_kb": 0.31,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/io/adapters.py",
+      "type": "code",
+      "size_kb": 3.37,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1362",
+          "docs/cleanup.json:3211",
+          "docs/cleanup.json:3616",
+          "docs/CLEANUP_REPORT.md:131",
+          "docs/CLEANUP_REPORT.md:146",
+          "docs/CLEANUP_REPORT.md:517",
+          "docs/CLEANUP_REPORT.md:1026",
+          "docs/CLEANUP_REPORT.md:1131"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/io/fs.py",
+      "type": "code",
+      "size_kb": 19.87,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1530",
+          "docs/cleanup.json:1531",
+          "docs/cleanup.json:1532",
+          "docs/cleanup.json:1533",
+          "docs/cleanup.json:1630",
+          "docs/cleanup.json:1631",
+          "docs/cleanup.json:1632",
+          "docs/cleanup.json:1633"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/__init__.py",
+      "type": "code",
+      "size_kb": 0.0,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/bronze/__init__.py",
+      "type": "code",
+      "size_kb": 0.0,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/bronze/main.py",
+      "type": "code",
+      "size_kb": 6.72,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:17",
+          "docs/report.json:31",
+          "docs/report.json:46",
+          "docs/cleanup.json:3319",
+          "docs/cleanup.json:3373",
+          "docs/cleanup.json:3427",
+          "docs/cleanup.json:3481",
+          "docs/CLEANUP_REPORT.md:135"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/gold/__init__.py",
+      "type": "code",
+      "size_kb": 0.0,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/gold/main.py",
+      "type": "code",
+      "size_kb": 6.58,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:17",
+          "docs/report.json:31",
+          "docs/report.json:46",
+          "docs/CLEANUP_REPORT.md:135",
+          "docs/CLEANUP_REPORT.md:137",
+          "docs/CLEANUP_REPORT.md:139",
+          "docs/CLEANUP_REPORT.md:141",
+          "docs/CLEANUP_REPORT.md:1054"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/raw/__init__.py",
+      "type": "code",
+      "size_kb": 0.0,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/raw/main.py",
+      "type": "code",
+      "size_kb": 0.62,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:17",
+          "docs/report.json:31",
+          "docs/report.json:46",
+          "docs/cleanup.json:3319",
+          "docs/cleanup.json:3373",
+          "docs/cleanup.json:3427",
+          "docs/cleanup.json:3481",
+          "docs/CLEANUP_REPORT.md:135"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/silver/__init__.py",
+      "type": "code",
+      "size_kb": 0.0,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/layers/silver/main.py",
+      "type": "code",
+      "size_kb": 6.17,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:17",
+          "docs/report.json:31",
+          "docs/report.json:46",
+          "docs/cleanup.json:3319",
+          "docs/cleanup.json:3373",
+          "docs/cleanup.json:3427",
+          "docs/cleanup.json:3481",
+          "docs/CLEANUP_REPORT.md:135"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/pipeline/__init__.py",
+      "type": "code",
+      "size_kb": 0.0,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:993",
+          "docs/cleanup.json:1146",
+          "docs/cleanup.json:2186",
+          "docs/cleanup.json:2240",
+          "docs/cleanup.json:2293",
+          "docs/cleanup.json:2376",
+          "docs/cleanup.json:2566",
+          "docs/cleanup.json:2620"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "src/datacore/pipeline/utils.py",
+      "type": "code",
+      "size_kb": 24.75,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/report.json:82",
+          "docs/report.json:91",
+          "docs/report.json:98",
+          "docs/report.json:105",
+          "docs/report.json:112",
+          "docs/cleanup.json:3535",
+          "docs/CLEANUP_REPORT.md:143",
+          "docs/CLEANUP_REPORT.md:1110"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tests/test_cli_smoke.py",
+      "type": "code",
+      "size_kb": 2.76,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:258",
+          "docs/cleanup.json:259",
+          "docs/cleanup.json:288",
+          "docs/cleanup.json:289",
+          "docs/cleanup.json:318",
+          "docs/cleanup.json:319",
+          "docs/cleanup.json:348",
+          "docs/cleanup.json:349"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tests/test_config_schema.py",
+      "type": "code",
+      "size_kb": 2.22,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/run/configs.md:77",
+          "docs/cleanup.json:774",
+          "docs/cleanup.json:952",
+          "docs/cleanup.json:1105",
+          "docs/cleanup.json:1250",
+          "docs/cleanup.json:3589",
+          "docs/CLEANUP_REPORT.md:145",
+          "docs/CLEANUP_REPORT.md:374"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tests/test_io_adapters.py",
+      "type": "code",
+      "size_kb": 1.88,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:3616",
+          "docs/CLEANUP_REPORT.md:146",
+          "docs/CLEANUP_REPORT.md:1131",
+          "docs/CLEANUP_REPORT.md:1249"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tests/test_io_fs.py",
+      "type": "code",
+      "size_kb": 7.97,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:1530",
+          "docs/cleanup.json:1531",
+          "docs/cleanup.json:1532",
+          "docs/cleanup.json:1533",
+          "docs/cleanup.json:1630",
+          "docs/cleanup.json:1631",
+          "docs/cleanup.json:1632",
+          "docs/cleanup.json:1633"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tests/test_layers_config.py",
+      "type": "code",
+      "size_kb": 2.24,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:3666",
+          "docs/CLEANUP_REPORT.md:148",
+          "docs/CLEANUP_REPORT.md:1145"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tests/test_security.py",
+      "type": "code",
+      "size_kb": 0.95,
+      "last_commit": "2025-10-24",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:3688",
+          "docs/CLEANUP_REPORT.md:149",
+          "docs/CLEANUP_REPORT.md:1152"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tools/audit_cleanup.py",
+      "type": "code",
+      "size_kb": 20.54,
+      "last_commit": "",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "docs/cleanup.json:107",
+          "docs/cleanup.json:108",
+          "docs/cleanup.json:137",
+          "docs/cleanup.json:229",
+          "docs/cleanup.json:1663",
+          "docs/cleanup.json:1718",
+          "docs/cleanup.json:1719",
+          "docs/cleanup.json:1775"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    },
+    {
+      "path": "tools/list_io.py",
+      "type": "code",
+      "size_kb": 3.18,
+      "last_commit": "",
+      "references": {
+        "code": [],
+        "configs": [],
+        "ci": [],
+        "docs": [
+          "README.md:40",
+          "docs/cleanup.json:2160",
+          "docs/cleanup.json:3737",
+          "docs/CLEANUP_REPORT.md:92",
+          "docs/CLEANUP_REPORT.md:151",
+          "docs/CLEANUP_REPORT.md:742",
+          "docs/CLEANUP_REPORT.md:1166",
+          "docs/CLEANUP_REPORT.md:1259"
+        ],
+        "jobs": []
+      },
+      "classification": "KEEP",
+      "reason": "Referenced or recently modified.",
+      "risk": "medium",
+      "proposed_action": "keep",
+      "notes": ""
+    }
+  ]
+}

--- a/docs/diagrams/deps_cleanup.md
+++ b/docs/diagrams/deps_cleanup.md
@@ -1,0 +1,18 @@
+# Impacto de limpieza
+
+```mermaid
+graph TD
+    A[Plataforma actual] -->|KEEP| B[src/datacore]
+    A -->|KEEP| C[pipelines/]
+    A -->|KEEP| D[scripts/generate_synthetic_data.py]
+    A -->|QUARANTINE| E[scripts/generate_big_payments.py]
+    A -->|QUARANTINE| F[docs/REPORT.md]
+    A -->|QUARANTINE| G[docs/report.json]
+    A -->|REMOVE| H[.mc/config.json.old]
+    C -->|dependencia| I[cfg/]
+    C -->|dependencia| J[config/]
+    E -->|I/O legacy| K[URIs externos detectados]
+    F -->|Duplicado| L[CLEANUP_REPORT.md]
+```
+
+El diagrama resalta scripts y documentos legacy identificados, y su relación con los artefactos activos propuestos para conservar.

--- a/docs/policies/DEP-001-legacy-removal.md
+++ b/docs/policies/DEP-001-legacy-removal.md
@@ -1,0 +1,34 @@
+# DEP-001: Legacy Asset Retirement Policy
+
+## Objetivo
+Garantizar que los artefactos obsoletos del repositorio se aíslen y retiren de forma controlada, preservando trazabilidad y reduciendo el riesgo operativo.
+
+## Alcance
+Esta política aplica a cualquier archivo marcado como **QUARANTINE** o **REMOVE NOW** en los reportes de auditoría, incluyendo código, configuraciones, infraestructura, notebooks, documentación y activos de datos de ejemplo.
+
+## Principios
+- **Seguridad primero**: los activos productivos o regulados se mantienen como KEEP hasta contar con aprobación explícita del área de plataformas.
+- **Trazabilidad completa**: cualquier movimiento a `/legacy/` o `/attic/` debe acompañarse de un README local con fecha, owner y motivo.
+- **Reversibilidad**: toda acción de eliminación definitiva requiere verificar que exista un commit de respaldo y que los pipelines críticos pasen.
+
+## Flujo de cuarentena
+1. Crear un subdirectorio bajo `/legacy/<dominio>/YYYY-MM-DD-<slug>`.
+2. Mover los archivos marcados como QUARANTINE, agregando un README con:
+   - Identificador del hallazgo en `cleanup.json`.
+   - Owner responsable y canal de contacto.
+   - Fecha objetivo de retiro definitivo.
+3. Actualizar documentación para señalar la nueva ubicación.
+4. Mantener el asset en cuarentena durante **30 días**. Durante este periodo, monitorear alertas en CI/CD o soporte.
+
+## Eliminación definitiva
+- Se ejecuta una vez transcurridos 30 días sin incidentes reportados.
+- Requiere aprobación del **Tech Lead** y del **Data Governance Officer**.
+- Antes de borrar, realizar `git tag legacy-cleanup-<fecha>` apuntando al último commit donde existía el archivo.
+- Registrar la acción en el changelog de plataforma con enlace al PR de remoción.
+
+## Excepciones
+- Artefactos normativos (políticas, ADRs, diagramas regulatorios) no pueden moverse a `/legacy/` sin aprobación del área legal.
+- Datos de ejemplo con restricciones de uso deben anonimizarse antes de la cuarentena.
+
+## Revisión
+La política se revisa cada 6 meses o ante eventos significativos (incidentes operativos, auditorías externas).

--- a/tools/audit_cleanup.py
+++ b/tools/audit_cleanup.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""Comprehensive repository cleanup audit generator."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+from urllib.error import URLError, HTTPError
+from urllib.request import Request, urlopen
+
+REFERENCE_LIMIT = 8
+STALE_DAYS_REMOVE = 365
+STALE_DAYS_QUARANTINE = 180
+
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+MANUAL_RULES = {
+    ".mc/config.json.old": {
+        "classification": "REMOVE",
+        "reason": "Archivo de respaldo antiguo de MinIO; reemplazado por config.json",
+        "risk": "low",
+        "proposed_action": "delete",
+        "notes": "No se usa en CI ni en scripts actuales.",
+    },
+    "docs/REPORT.md": {
+        "classification": "QUARANTINE",
+        "reason": "Reporte legacy previo a la documentación modular.",
+        "risk": "medium",
+        "proposed_action": "move_to_legacy",
+        "notes": "Conservar en /legacy/docs hasta validar que no sea referencia externa.",
+    },
+    "docs/report.json": {
+        "classification": "QUARANTINE",
+        "reason": "Export JSON antiguo duplicando reportes actuales.",
+        "risk": "medium",
+        "proposed_action": "move_to_legacy",
+        "notes": "Generado por tooling previo; no usado en pipelines.",
+    },
+    "scripts/generate_big_payments.py": {
+        "classification": "QUARANTINE",
+        "reason": "Script de generación legacy reemplazado por generate_synthetic_data.py.",
+        "risk": "medium",
+        "proposed_action": "move_to_legacy",
+        "notes": "No referenciado desde CLI actuales.",
+    },
+    "docs/run/jobs/dataproc_workflow.yaml": {
+        "classification": "QUARANTINE",
+        "reason": "Plantilla Dataproc sin referencias en CI/CD.",
+        "risk": "medium",
+        "proposed_action": "move_to_legacy",
+        "notes": "Considerar mover a legacy/infra antes de eliminar.",
+    },
+}
+
+
+@dataclass
+class ReferenceBucket:
+    code: List[str] = field(default_factory=list)
+    configs: List[str] = field(default_factory=list)
+    ci: List[str] = field(default_factory=list)
+    docs: List[str] = field(default_factory=list)
+    jobs: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, List[str]]:
+        return {
+            "code": self.code,
+            "configs": self.configs,
+            "ci": self.ci,
+            "docs": self.docs,
+            "jobs": self.jobs,
+        }
+
+    @property
+    def count(self) -> int:
+        return sum(len(bucket) for bucket in self.to_dict().values())
+
+
+@dataclass
+class CleanupItem:
+    path: Path
+    type: str
+    size_kb: float
+    last_commit: Optional[str]
+    references: ReferenceBucket
+    classification: str
+    reason: str
+    risk: str
+    proposed_action: str
+    notes: str = ""
+
+    def to_json(self) -> Dict[str, object]:
+        return {
+            "path": str(self.path).replace(os.sep, "/"),
+            "type": self.type,
+            "size_kb": round(self.size_kb, 2),
+            "last_commit": self.last_commit or "",
+            "references": self.references.to_dict(),
+            "classification": self.classification,
+            "reason": self.reason,
+            "risk": self.risk,
+            "proposed_action": self.proposed_action,
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class AuditArtifacts:
+    broken_links: List[Dict[str, str]] = field(default_factory=list)
+    orphan_docs: List[str] = field(default_factory=list)
+    orphan_notebooks: List[str] = field(default_factory=list)
+    vulture_output: str = ""
+    deptry_output: str = ""
+
+
+def detect_type(repo_root: Path, path: Path) -> str:
+    rel = path.relative_to(repo_root)
+    if rel.suffix == ".ipynb":
+        return "notebook"
+    if rel.suffix in {".py", ".pyi"}:
+        return "code"
+    if rel.suffix in {".yml", ".yaml", ".ini", ".toml", ".cfg"}:
+        return "config"
+    if rel.name.startswith("Dockerfile") or rel.suffix in {".dockerfile"}:
+        return "docker"
+    if rel.parts[0] in {"infra", "terraform", "helm"}:
+        return "infra"
+    if rel.parts[0] in {".github", "ci"} or rel.suffix in {".yml", ".yaml"} and ".github" in rel.parts:
+        return "ci"
+    if rel.suffix in {".md", ".rst"} or rel.parts[0] == "docs":
+        return "doc"
+    if rel.suffix in {".json", ".ndjson"} and rel.parts[0] != "data":
+        return "config"
+    return "other"
+
+
+def run_cmd(cmd: List[str], cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+
+
+def get_git_last_commit(repo_root: Path, path: Path) -> Optional[str]:
+    result = run_cmd(["git", "log", "-1", "--format=%cs", str(path.relative_to(repo_root))], cwd=repo_root)
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.strip()
+
+
+def search_references(repo_root: Path, path: Path) -> ReferenceBucket:
+    bucket = ReferenceBucket()
+    target = path.name
+    if not target:
+        return bucket
+    rg_path = shutil.which("rg")
+    if rg_path is None:
+        return bucket
+    cmd = [rg_path, "--no-heading", "--line-number", "--color", "never", "--fixed-strings", target, str(repo_root)]
+    result = run_cmd(cmd, cwd=repo_root)
+    if result.returncode not in {0, 1}:
+        return bucket
+    rel_self = str(path.relative_to(repo_root))
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            match_path, match_line, *_ = line.split(":", 2)
+        except ValueError:
+            continue
+        if match_path == rel_self:
+            continue
+        match_path_obj = Path(match_path)
+        try:
+            match_rel = match_path_obj.relative_to(repo_root)
+        except ValueError:
+            match_rel = match_path_obj
+        match_type = detect_type(repo_root, repo_root / match_rel)
+        entry = f"{match_rel}:{match_line}"
+        bucket_list = getattr(bucket, {
+            "code": "code",
+            "config": "configs",
+            "docker": "configs",
+            "infra": "jobs",
+            "ci": "ci",
+            "doc": "docs",
+        }.get(match_type, "code"))
+        if len(bucket_list) < REFERENCE_LIMIT:
+            bucket_list.append(entry)
+    return bucket
+
+
+def classify_item(item: CleanupItem, today: dt.date) -> CleanupItem:
+    references_count = item.references.count
+    last_commit_date = None
+    if item.last_commit:
+        try:
+            last_commit_date = dt.datetime.strptime(item.last_commit, "%Y-%m-%d").date()
+        except ValueError:
+            last_commit_date = None
+    age_days = (today - last_commit_date).days if last_commit_date else None
+
+    special_keep = {
+        "pyproject.toml",
+        "requirements.txt",
+        "README.md",
+        "docs/CLEANUP_REPORT.md",
+        "docs/cleanup.json",
+        "docs/diagrams/deps_cleanup.md",
+        "docs/policies/DEP-001-legacy-removal.md",
+    }
+    rel = str(item.path)
+    if rel in special_keep or rel.startswith("docs/policies/"):
+        item.classification = "KEEP"
+        item.reason = "Governance or generated artifact"
+        item.risk = "low"
+        item.proposed_action = "keep"
+        return item
+
+    if item.type == "doc" and "policy" in rel:
+        item.classification = "KEEP"
+        item.reason = "Policy documentation"
+        item.risk = "low"
+        item.proposed_action = "keep"
+        return item
+
+    if references_count == 0 and age_days and age_days > STALE_DAYS_REMOVE:
+        item.classification = "REMOVE"
+        item.reason = "No references detected and stale (>12 months)."
+        item.risk = "low"
+        item.proposed_action = "delete"
+    elif references_count == 0 and age_days and age_days > STALE_DAYS_QUARANTINE:
+        item.classification = "QUARANTINE"
+        item.reason = "No references detected and stale (>6 months)."
+        item.risk = "medium"
+        item.proposed_action = "move_to_legacy"
+    else:
+        item.classification = "KEEP"
+        item.reason = item.reason or "Referenced or recently modified."
+        if references_count == 0:
+            item.reason = "Recently modified; needs manual confirmation."
+        item.risk = item.risk or "medium"
+        item.proposed_action = "keep"
+    return item
+
+
+def collect_files(repo_root: Path) -> List[Path]:
+    ignore_dirs = {".git", "__pycache__", "build", "dist", ".mypy_cache", ".pytest_cache"}
+    paths: List[Path] = []
+    for path in repo_root.rglob("*"):
+        if any(part in ignore_dirs for part in path.parts):
+            continue
+        if path.is_dir():
+            continue
+        if path.name.endswith("~"):
+            continue
+        paths.append(path)
+    return sorted(paths)
+
+
+def detect_broken_links(repo_root: Path) -> List[Dict[str, str]]:
+    broken: List[Dict[str, str]] = []
+    for md in repo_root.rglob("*.md"):
+        if ".git" in md.parts:
+            continue
+        text = md.read_text(encoding="utf-8", errors="ignore")
+        for match in MARKDOWN_LINK_RE.finditer(text):
+            target = match.group(2)
+            if target.startswith("mailto:"):
+                continue
+            if target.startswith("http://") or target.startswith("https://"):
+                try:
+                    req = Request(target, method="HEAD")
+                    with urlopen(req, timeout=5):  # nosec - head request
+                        pass
+                except (HTTPError, URLError, TimeoutError) as exc:
+                    broken.append({
+                        "source": str(md.relative_to(repo_root)),
+                        "link": target,
+                        "error": str(exc),
+                    })
+            elif target.startswith("#"):
+                continue
+            else:
+                candidate = (md.parent / target).resolve()
+                try:
+                    candidate.relative_to(repo_root)
+                except ValueError:
+                    # points outside repo
+                    continue
+                if not candidate.exists():
+                    broken.append({
+                        "source": str(md.relative_to(repo_root)),
+                        "link": target,
+                        "error": "missing file",
+                    })
+    return broken
+
+
+def detect_orphans(repo_root: Path, suffix: str) -> List[str]:
+    results: List[str] = []
+    rg_path = shutil.which("rg")
+    for path in repo_root.rglob(f"*{suffix}"):
+        if path.is_dir():
+            continue
+        rel = str(path.relative_to(repo_root))
+        if rg_path is None:
+            results.append(rel)
+            continue
+        cmd = [rg_path, "--no-heading", "--count", rel.split("/")[-1], str(repo_root)]
+        result = run_cmd(cmd, cwd=repo_root)
+        if result.returncode not in {0, 1}:
+            continue
+        count = 0
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            try:
+                _, occurrences = line.rsplit(":", 1)
+                count += int(occurrences)
+            except ValueError:
+                continue
+        if count <= 1:
+            results.append(rel)
+    return sorted(results)
+
+
+def run_optional_tool(cmd: List[str], cwd: Path) -> str:
+    result = run_cmd(cmd, cwd=cwd)
+    output = result.stdout
+    if result.stderr:
+        output = (output + "\n" + result.stderr).strip()
+    if result.returncode not in {0, 1}:
+        return output
+    return output
+
+
+def create_markdown(report_path: Path, repo_root: Path, items: List[CleanupItem], artifacts: AuditArtifacts, summary: Dict[str, object]) -> None:
+    lines: List[str] = []
+    lines.append("# Cleanup Audit Report")
+    lines.append("")
+    lines.append(f"_Generated on {dt.datetime.utcnow().isoformat()}Z_")
+    lines.append("")
+    lines.append("## Resumen ejecutivo")
+    lines.append("")
+    totals = summary["totals"]
+    lines.append("| Clasificación | Conteo |")
+    lines.append("| --- | ---: |")
+    for key in ("remove", "quarantine", "keep"):
+        lines.append(f"| {key.upper()} | {totals.get(key, 0)} |")
+    lines.append("")
+    lines.append(f"**Ahorro estimado**: {summary['savings_mb_estimate']:.2f} MB si se aplica REMOVE + QUARANTINE.")
+    lines.append("")
+
+    lines.append("## Tabla maestra")
+    lines.append("")
+    lines.append("| Path | Tipo | Tamaño (KB) | Último commit | # refs | Clasificación | Motivo | Riesgo | Acción |")
+    lines.append("| --- | --- | ---: | --- | ---: | --- | --- | --- | --- |")
+    for item in items:
+        rel = str(item.path)
+        lines.append(
+            "| {path} | {type} | {size:.2f} | {commit} | {refs} | {cls} | {reason} | {risk} | {action} |".format(
+                path=rel,
+                type=item.type,
+                size=item.size_kb,
+                commit=item.last_commit or "-",
+                refs=item.references.count,
+                cls=item.classification,
+                reason=item.reason.replace("|", "/"),
+                risk=item.risk,
+                action=item.proposed_action,
+            )
+        )
+    lines.append("")
+
+    lines.append("## Evidencia por elemento")
+    lines.append("")
+    for item in items:
+        rel = str(item.path)
+        lines.append(f"### {rel}")
+        lines.append("")
+        if item.references.count:
+            lines.append("Referencias detectadas:")
+            lines.append("")
+            for key, entries in item.references.to_dict().items():
+                if not entries:
+                    continue
+                lines.append(f"- **{key}**: {', '.join(entries)}")
+        else:
+            lines.append("- No se detectaron referencias (búsqueda por nombre de archivo).")
+        if item.notes:
+            lines.append(f"- Notas: {item.notes}")
+        lines.append("- Clasificación: {0}".format(item.classification))
+        lines.append("")
+
+    lines.append("## Impacto estimado")
+    lines.append("")
+    lines.append(f"- Archivos candidatos a eliminar inmediatamente: {totals.get('remove', 0)}")
+    lines.append(f"- Archivos candidatos a cuarentena: {totals.get('quarantine', 0)}")
+    lines.append(f"- Ahorro aproximado: {summary['savings_mb_estimate']:.2f} MB")
+    lines.append("")
+    lines.append("## Riesgos y mitigaciones")
+    lines.append("")
+    lines.append("- Revisar manualmente los elementos marcados como QUARANTINE antes de moverlos a /legacy.")
+    lines.append("- Confirmar dependencias transversales en CI/CD para los elementos KEEP críticos.")
+    lines.append("- Establecer un rollback rápido restaurando archivos desde git si un pipeline falla.")
+    lines.append("")
+
+    lines.append("## Plan sugerido")
+    lines.append("")
+    lines.append("1. Crear PRs por lote (infra, pipelines, documentación) para aplicar REMOVE/QUARANTINE.")
+    lines.append("2. Actualizar dependencias declaradas (según deptry) antes de eliminar código compartido.")
+    lines.append("3. Mover notebooks huérfanos a /legacy/notebooks con un README que documente su estado.")
+    lines.append("")
+
+    lines.append("## Anexos")
+    lines.append("")
+    lines.append("### Hallazgos de Vulture")
+    lines.append("")
+    lines.append("```")
+    lines.append(artifacts.vulture_output.strip() or "No disponible")
+    lines.append("```")
+    lines.append("")
+    lines.append("### Hallazgos de Deptry")
+    lines.append("")
+    lines.append("```")
+    lines.append(artifacts.deptry_output.strip() or "No disponible")
+    lines.append("```")
+    lines.append("")
+    lines.append("### Links rotos")
+    lines.append("")
+    if artifacts.broken_links:
+        for entry in artifacts.broken_links:
+            lines.append(f"- {entry['source']} → {entry['link']} ({entry['error']})")
+    else:
+        lines.append("- No se detectaron links rotos.")
+    lines.append("")
+    lines.append("### Documentos huérfanos")
+    lines.append("")
+    if artifacts.orphan_docs:
+        for doc in artifacts.orphan_docs:
+            lines.append(f"- {doc}")
+    else:
+        lines.append("- Ninguno")
+    lines.append("")
+    lines.append("### Notebooks huérfanos")
+    lines.append("")
+    if artifacts.orphan_notebooks:
+        for nb in artifacts.orphan_notebooks:
+            lines.append(f"- {nb}")
+    else:
+        lines.append("- Ninguno")
+
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def build_items(repo_root: Path) -> List[CleanupItem]:
+    today = dt.date.today()
+    items: List[CleanupItem] = []
+    for path in collect_files(repo_root):
+        rel = path.relative_to(repo_root)
+        file_type = detect_type(repo_root, path)
+        try:
+            size_kb = path.stat().st_size / 1024
+        except OSError:
+            size_kb = 0.0
+        last_commit = get_git_last_commit(repo_root, path)
+        references = search_references(repo_root, path)
+        item = CleanupItem(
+            path=rel,
+            type=file_type,
+            size_kb=size_kb,
+            last_commit=last_commit,
+            references=references,
+            classification="KEEP",
+            reason="",
+            risk="medium",
+            proposed_action="keep",
+            notes="",
+        )
+        if file_type == "doc" and "README" in rel.name:
+            item.reason = "Punto de entrada documental"
+            item.risk = "low"
+        classify_item(item, today)
+        items.append(item)
+    return items
+
+
+def apply_manual_overrides(items: List[CleanupItem]) -> None:
+    for item in items:
+        rel = str(item.path)
+        if rel in MANUAL_RULES:
+            rule = MANUAL_RULES[rel]
+            item.classification = rule["classification"]
+            item.reason = rule["reason"]
+            item.risk = rule["risk"]
+            item.proposed_action = rule["proposed_action"]
+            item.notes = rule.get("notes", "")
+
+
+def compute_summary(items: List[CleanupItem]) -> Dict[str, object]:
+    totals = defaultdict(int)
+    savings_kb = 0.0
+    for item in items:
+        totals[item.classification.lower()] += 1
+        if item.classification in {"REMOVE", "QUARANTINE"}:
+            savings_kb += item.size_kb
+    return {
+        "totals": totals,
+        "savings_mb_estimate": round(savings_kb / 1024, 2),
+    }
+
+
+def ensure_relative_paths(items: List[CleanupItem], repo_root: Path) -> None:
+    for item in items:
+        if isinstance(item.path, Path):
+            item.path = item.path  # already relative
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-json", default="docs/cleanup.json")
+    parser.add_argument("--output-md", default="docs/CLEANUP_REPORT.md")
+    parser.add_argument("--skip-markdown", action="store_true", help="Only produce JSON output.")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    items = build_items(repo_root)
+    ensure_relative_paths(items, repo_root)
+    apply_manual_overrides(items)
+    summary = compute_summary(items)
+
+    head_sha = run_cmd(["git", "rev-parse", "HEAD"], cwd=repo_root).stdout.strip()
+    meta = {
+        "branch": "feature/main-codex",
+        "commit": head_sha,
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+    }
+
+    data = {
+        "meta": meta,
+        "summary": {
+            "totals": dict(summary["totals"]),
+            "savings_mb_estimate": summary["savings_mb_estimate"],
+        },
+        "items": [item.to_json() for item in items],
+    }
+
+    output_json_path = (repo_root / args.output_json).resolve()
+    output_json_path.parent.mkdir(parents=True, exist_ok=True)
+    output_json_path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    artifacts = AuditArtifacts()
+    artifacts.broken_links = detect_broken_links(repo_root)
+    artifacts.orphan_docs = detect_orphans(repo_root, ".md")
+    artifacts.orphan_notebooks = detect_orphans(repo_root, ".ipynb")
+
+    vulture_path = shutil.which("vulture")
+    if vulture_path:
+        artifacts.vulture_output = run_optional_tool([vulture_path, "src", "pipelines", "scripts", "tests"], repo_root)
+    else:
+        artifacts.vulture_output = "vulture no disponible"
+
+    deptry_path = shutil.which("deptry")
+    if deptry_path:
+        artifacts.deptry_output = run_optional_tool([deptry_path, "."], repo_root)
+    else:
+        artifacts.deptry_output = "deptry no disponible"
+
+    if not args.skip_markdown:
+        report_path = (repo_root / args.output_md).resolve()
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        create_markdown(report_path, repo_root, items, artifacts, summary)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/list_io.py
+++ b/tools/list_io.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Scan repository sources for read/write operations and legacy runners."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+SCAN_ROOTS = [Path("src"), Path("pipelines"), Path("scripts")]
+IO_PATTERNS = {
+    "spark_read": re.compile(r"spark\.read\.(\w+)", re.IGNORECASE),
+    "spark_write": re.compile(r"\.write\.(\w+)", re.IGNORECASE),
+    "pandas_read": re.compile(r"read_(csv|json|parquet|table)\(", re.IGNORECASE),
+    "pandas_write": re.compile(r"to_(csv|json|parquet|table)\(", re.IGNORECASE),
+    "filesystem_uri": re.compile(r"(s3://|abfss://|gs://|dbfs:/|file://|wasbs://)", re.IGNORECASE),
+    "jdbc_uri": re.compile(r"jdbc:[a-z0-9]+://", re.IGNORECASE),
+}
+LEGACY_RUNNER_PATTERNS = {
+    "spark_submit": re.compile(r"spark-submit"),
+    "databricks_cli": re.compile(r"databricks\s+jobs"),
+    "airflow_dag": re.compile(r"AirflowDagOperator|airflow\.operators", re.IGNORECASE),
+}
+
+
+def iter_source_files() -> Iterable[Path]:
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            yield path
+
+
+def scan_file(path: Path) -> Dict[str, List[Dict[str, str]]]:
+    findings: Dict[str, List[Dict[str, str]]] = {key: [] for key in IO_PATTERNS}
+    findings.update({key: [] for key in LEGACY_RUNNER_PATTERNS})
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return findings
+    for lineno, line in enumerate(lines, start=1):
+        for key, pattern in IO_PATTERNS.items():
+            if pattern.search(line):
+                findings[key].append({"line": lineno, "content": line.strip()})
+        for key, pattern in LEGACY_RUNNER_PATTERNS.items():
+            if pattern.search(line):
+                findings[key].append({"line": lineno, "content": line.strip()})
+    return {key: value for key, value in findings.items() if value}
+
+
+def build_report() -> Dict[str, Dict[str, List[Dict[str, str]]]]:
+    report: Dict[str, Dict[str, List[Dict[str, str]]]] = {}
+    for path in iter_source_files():
+        matches = scan_file(path)
+        if matches:
+            report[str(path)] = matches
+    return report
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print the report in JSON format.")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    report = build_report()
+    if args.json:
+        json.dump(report, fp=sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+    else:
+        if not report:
+            print("No read/write operations detected in the scanned roots.")
+            return 0
+        for file_path, matches in sorted(report.items()):
+            print(file_path)
+            for kind, entries in matches.items():
+                print(f"  [{kind}]")
+                for entry in entries:
+                    print(f"    L{entry['line']}: {entry['content']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tools/audit_cleanup.py` to inventory repository assets, classify cleanup candidates, and generate `docs/cleanup.json` plus the human-readable `docs/CLEANUP_REPORT.md`
- capture dependency insights with a Mermaid impact diagram and a DEP-001 legacy retirement policy for quarantine/delete workflows
- provide a reusable `tools/list_io.py` helper to scan Spark/Pandas IO usage and surface legacy runners

## Testing
- python tools/audit_cleanup.py
- python tools/list_io.py --json


------
https://chatgpt.com/codex/tasks/task_e_68fc305535548320b9d17b5f27972926