### PR TITLE
Release v0.2.0 rollout multi-cloud configs

### DIFF
--- a/.github/rulesets/feature-main-codex.json
+++ b/.github/rulesets/feature-main-codex.json
@@ -1,0 +1,24 @@
+{
+  "name": "feature/main-codex protections",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["feature/main-codex"]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict": true,
+        "required_checks": [
+          "Build & Test / build-and-test",
+          "Build & Test / smoke",
+          "Build & Test / smoke-prod",
+          "Lint & Validate / cleanup-enforcement"
+        ]
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [0.2.0] - 2025-02-18
+
+### Highlights
+- Raw layer runner enabled by default with production-ready storage fallbacks across AWS, Azure, and GCP.
+- End-to-end smoke workflows now cover multi-cloud production configurations with forced dry-run validation in CI.
+- Enforced no-Docker policy baked into CI alongside cross-layer, TLS, and legacy cleanup guards.
+
+### Configuration
+- Added identity-based production YAMLs for raw, bronze, silver, and gold layers per cloud provider.
+- Introduced managed identity environment manifests to avoid embedding static keys.
+- Documented orchestration templates for Databricks, AWS Glue/EMR, Azure Synapse/ADF, and GCP Dataproc using v0.2.0 wheel artifacts.
+
+### Tooling & CI
+- Added `smoke-prod` GitHub Actions job that forces dry-run execution of every `*.prod.yml` configuration.
+- Published reusable submission script and workflow templates for cloud orchestrators.
+- Declared required branch protection checks and CODEOWNERS for production configs.
+
+### Documentation
+- Added identity credential guidance to the README.
+- Refreshed runbooks to reference v0.2.0 artifacts and prod YAML locations.
+
+[0.2.0]: https://example.com/releases/v0.2.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Production configuration requires cloud and security review
+cfg/*/*.prod.yml @data-platform/cloud-admins @security/ops

--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ Plataforma modular de ingesta y transformación basada en configuración. Expone
 
 El repositorio ya no contiene archivos de build Docker ni manifests docker compose. CI falla si reaparecen artefactos bajo `docker/`, `.docker/` o manifests de build/compose. Las ejecuciones deben empaquetarse como wheel (`python -m build`) y desplegarse en la plataforma de elección.
 
+## Credenciales por identidad
+
+- **AWS**: los YAML `cfg/*/aws.prod.yml` asumen que los jobs corren con un rol IAM asociado a la instancia/servicio. El archivo `config/env.aws.prod.yml` habilita TLS (`use_ssl: true`) y firma SigV4 sin exponer llaves.
+- **Azure**: las variantes `cfg/*/azure.prod.yml` se autentican mediante Managed Identity; `config/env.azure.prod.yml` sólo declara `auth: managed_identity` y opciones TLS.
+- **GCP**: las configuraciones `cfg/*/gcp.prod.yml` dependen de cuentas de servicio sin llaves gracias a Workload Identity (`config/env.gcp.prod.yml`).
+
 ## Ejecución por capa con CLI
 
 - Las configuraciones `cfg/<layer>/example.yml` apuntan al dataset de humo `samples/toy_customers.csv`. Raw ya ejecuta la ingesta real (puede cambiarse a Spark ajustando `compute.kind`), mientras que Bronze/Silver/Gold mantienen `dry_run` por defecto.
 - `prodi run-layer <layer>` valida esquema, reglas de calidad y escritura de cada capa de forma aislada.
 - El pipeline declarativo `cfg/pipelines/example.yml` encadena los mismos YAML y puede ejecutarse con `prodi run-pipeline -p cfg/pipelines/example.yml`.
 - Para orquestación externa, ver `docs/run/` (Databricks, AWS Glue/EMR, Dataproc, Azure Synapse/ADF). Los manifiestos en `docs/run/jobs/` muestran cómo invocar el wheel con argumentos `prodi run-layer`.
+- Forzar `PRODI_FORCE_DRY_RUN=1` permite validar configuraciones productivas (`cfg/*/*.prod.yml`) sin ejecutar escrituras reales; este mismo override se usa en CI (`smoke-prod`).
 
 ## Documentación clave
 

--- a/cfg/bronze/aws.prod.yml
+++ b/cfg/bronze/aws.prod.yml
@@ -1,0 +1,25 @@
+layer: bronze
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.aws.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: parquet
+    path: s3://datalake-mvp-raw-prod/toy_customers/landing/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: s3://datalake-mvp-bronze-prod/tables/toy_customers/
+    options:
+      checkpointLocation: s3://datalake-mvp-bronze-prod/checkpoints/toy_customers/
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/bronze/azure.prod.yml
+++ b/cfg/bronze/azure.prod.yml
@@ -1,0 +1,25 @@
+layer: bronze
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.azure.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: parquet
+    path: abfss://landing@datalakeprod.dfs.core.windows.net/raw/toy_customers/landing/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: abfss://curated@datalakeprod.dfs.core.windows.net/bronze/toy_customers/
+    options:
+      checkpointLocation: abfss://curated@datalakeprod.dfs.core.windows.net/bronze/checkpoints/toy_customers/
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/bronze/gcp.prod.yml
+++ b/cfg/bronze/gcp.prod.yml
@@ -1,0 +1,25 @@
+layer: bronze
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.gcp.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: parquet
+    path: gs://datalake-mvp-raw-prod/toy_customers/landing/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: gs://datalake-mvp-bronze-prod/tables/toy_customers/
+    options:
+      checkpointLocation: gs://datalake-mvp-bronze-prod/checkpoints/toy_customers/
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/gold/aws.prod.yml
+++ b/cfg/gold/aws.prod.yml
@@ -1,0 +1,25 @@
+layer: gold
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.aws.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: delta
+    path: s3://datalake-mvp-silver-prod/tables/toy_customers/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: s3://datalake-mvp-gold-prod/marts/toy_customers/
+    options:
+      mergeSchema: true
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/gold/azure.prod.yml
+++ b/cfg/gold/azure.prod.yml
@@ -1,0 +1,25 @@
+layer: gold
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.azure.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: delta
+    path: abfss://curated@datalakeprod.dfs.core.windows.net/silver/toy_customers/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: abfss://curated@datalakeprod.dfs.core.windows.net/gold/toy_customers/
+    options:
+      mergeSchema: true
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/gold/gcp.prod.yml
+++ b/cfg/gold/gcp.prod.yml
@@ -1,0 +1,25 @@
+layer: gold
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.gcp.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: delta
+    path: gs://datalake-mvp-silver-prod/tables/toy_customers/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: gs://datalake-mvp-gold-prod/marts/toy_customers/
+    options:
+      mergeSchema: true
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/raw/aws.prod.yml
+++ b/cfg/raw/aws.prod.yml
@@ -1,0 +1,26 @@
+layer: raw
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.aws.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    dataset_config: config/datasets/examples/toy_customers.yml
+    environment_config: config/env.aws.prod.yml
+    preferred_protocol: s3
+  sink:
+    kind: spark
+    format: parquet
+    mode: overwrite
+    path: s3://datalake-mvp-raw-prod/toy_customers/landing/
+storage:
+  s3:
+    default_uri: s3://datalake-mvp-raw-prod/
+    storage_options:
+      client_kwargs:
+        use_ssl: true

--- a/cfg/raw/azure.prod.yml
+++ b/cfg/raw/azure.prod.yml
@@ -1,0 +1,26 @@
+layer: raw
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.azure.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    dataset_config: config/datasets/examples/toy_customers.yml
+    environment_config: config/env.azure.prod.yml
+    preferred_protocol: abfss
+  sink:
+    kind: spark
+    format: parquet
+    mode: overwrite
+    path: abfss://landing@datalakeprod.dfs.core.windows.net/raw/toy_customers/landing/
+storage:
+  abfss:
+    default_uri: abfss://landing@datalakeprod.dfs.core.windows.net/raw/toy_customers/
+    storage_options:
+      use_ssl: true
+      azure_cloud: AzurePublicCloud

--- a/cfg/raw/gcp.prod.yml
+++ b/cfg/raw/gcp.prod.yml
@@ -1,0 +1,26 @@
+layer: raw
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.gcp.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    dataset_config: config/datasets/examples/toy_customers.yml
+    environment_config: config/env.gcp.prod.yml
+    preferred_protocol: gs
+  sink:
+    kind: spark
+    format: parquet
+    mode: overwrite
+    path: gs://datalake-mvp-raw-prod/toy_customers/landing/
+storage:
+  gs:
+    default_uri: gs://datalake-mvp-raw-prod/toy_customers/
+    storage_options:
+      use_tls: true
+      project: data-platform-prod

--- a/cfg/silver/aws.prod.yml
+++ b/cfg/silver/aws.prod.yml
@@ -1,0 +1,25 @@
+layer: silver
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.aws.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: delta
+    path: s3://datalake-mvp-bronze-prod/tables/toy_customers/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: s3://datalake-mvp-silver-prod/tables/toy_customers/
+    options:
+      checkpointLocation: s3://datalake-mvp-silver-prod/checkpoints/toy_customers/
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/silver/azure.prod.yml
+++ b/cfg/silver/azure.prod.yml
@@ -1,0 +1,25 @@
+layer: silver
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.azure.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: delta
+    path: abfss://curated@datalakeprod.dfs.core.windows.net/bronze/toy_customers/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: abfss://curated@datalakeprod.dfs.core.windows.net/silver/toy_customers/
+    options:
+      checkpointLocation: abfss://curated@datalakeprod.dfs.core.windows.net/silver/checkpoints/toy_customers/
+transform:
+  functions: []
+dq:
+  checks: []

--- a/cfg/silver/gcp.prod.yml
+++ b/cfg/silver/gcp.prod.yml
@@ -1,0 +1,25 @@
+layer: silver
+environment: production
+dry_run: false
+paths:
+  dataset: config/datasets/examples/toy_customers.yml
+  environment: config/env.gcp.prod.yml
+compute:
+  engine: spark
+  options:
+    spark.sql.session.timeZone: UTC
+io:
+  source:
+    format: delta
+    path: gs://datalake-mvp-bronze-prod/tables/toy_customers/
+  sink:
+    kind: spark
+    format: delta
+    mode: overwrite
+    path: gs://datalake-mvp-silver-prod/tables/toy_customers/
+    options:
+      checkpointLocation: gs://datalake-mvp-silver-prod/checkpoints/toy_customers/
+transform:
+  functions: []
+dq:
+  checks: []

--- a/ci/build-test.yml
+++ b/ci/build-test.yml
@@ -74,3 +74,33 @@ jobs:
         with:
           name: smoke-logs
           path: smoke.log
+
+  smoke-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Validate production configs (forced dry-run)
+        env:
+          PYTHONPATH: src
+        run: |
+          set -o pipefail
+          bash scripts/smoke_prod_configs.sh 2>&1 | tee smoke-prod.log
+
+      - name: Upload production smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-prod-logs
+          path: smoke-prod.log

--- a/config/env.aws.prod.yml
+++ b/config/env.aws.prod.yml
@@ -1,0 +1,9 @@
+timezone: UTC
+storage:
+  s3:
+    auth: iam_role
+    storage_options:
+      client_kwargs:
+        use_ssl: true
+      config_kwargs:
+        signature_version: s3v4

--- a/config/env.azure.prod.yml
+++ b/config/env.azure.prod.yml
@@ -1,0 +1,8 @@
+timezone: UTC
+storage:
+  abfss:
+    auth: managed_identity
+    storage_options:
+      use_ssl: true
+      azure_tenant: production
+      azure_cloud: AzurePublicCloud

--- a/config/env.gcp.prod.yml
+++ b/config/env.gcp.prod.yml
@@ -1,0 +1,7 @@
+timezone: UTC
+storage:
+  gs:
+    auth: workload_identity
+    storage_options:
+      project: data-platform-prod
+      use_tls: true

--- a/docs/STABILIZATION_REPORT.md
+++ b/docs/STABILIZATION_REPORT.md
@@ -48,7 +48,7 @@
 
 ## Riesgos y mitigaciones
 
-- **Dependencia de wheel name**: los ejemplos asumen `mvp_config_driven-0.1.0`. Mitigación: documentar que se debe ajustar al
+- **Dependencia de wheel name**: los ejemplos asumen `mvp_config_driven-0.2.0`. Mitigación: documentar que se debe ajustar al
   número de versión publicado.
 - **Ambientes sin `ripgrep`**: CI instala la dependencia explícitamente; en entornos locales puede replicarse ejecutando
   `sudo apt-get install ripgrep` o usando el script `tests/test_security_invariants.py` como guardia.

--- a/docs/run/aws.md
+++ b/docs/run/aws.md
@@ -9,101 +9,68 @@ gold) en AWS Glue utilizando jobs basados en wheel y comandos `prodi run-layer`.
    ```bash
    poetry build -f wheel
    ```
-2. Carga el artefacto a un bucket S3 accesible desde Glue junto con las
-   configuraciones declarativas:
+2. Carga el artefacto y las configuraciones productivas en un bucket S3 accesible
+   desde Glue:
    ```bash
-   aws s3 cp dist/mvp_config_driven-0.1.0-py3-none-any.whl s3://datalake-artifacts/prodi/
+   aws s3 cp dist/mvp_config_driven-0.2.0-py3-none-any.whl s3://datalake-artifacts/prodi/
    aws s3 sync cfg s3://datalake-artifacts/cfg/
    ```
 
-## 2. Configurar el Job de Glue
+## 2. Configurar los Jobs de Glue y Step Functions
 
-Crea un Job de tipo Python shell 3.9 o Spark (según la capa) y define como script
-principal el entrypoint del wheel usando `--additional-python-modules`.
+El archivo [`docs/run/jobs/aws_glue_v020.json`](jobs/aws_glue_v020.json) define un
+Workflow de Step Functions que dispara cuatro jobs de Glue (uno por capa) con las
+configuraciones `cfg/<layer>/aws.prod.yml`. Sube el JSON mediante la consola o la
+CLI de Step Functions y crea los jobs Glue referenciados (`prodi-layer-raw`,
+`prodi-layer-bronze`, etc.).
+
+Para ejecutar manualmente cada capa o integrarla en pipelines existentes puedes
+utilizar el script `scripts/aws_glue_submit.sh`:
 
 ```bash
-aws glue create-job \
-  --name prodi-layer-raw \
-  --role AWSGlueServiceRoleDefault \
-  --command '{
-    "Name": "glueetl",
-    "PythonVersion": "3",
-    "ScriptLocation": "s3://datalake-artifacts/scripts/prodi_glue_entry.py"
-  }' \
-  --default-arguments '{
-    "--additional-python-modules": "s3://datalake-artifacts/prodi/mvp_config_driven-0.1.0-py3-none-any.whl",
-    "--extra-py-files": "s3://datalake-artifacts/cfg.zip",
-    "--layer": "raw",
-    "--config": "s3://datalake-artifacts/cfg/raw/example.yml"
-  }'
+bash scripts/aws_glue_submit.sh raw
+bash scripts/aws_glue_submit.sh bronze
+bash scripts/aws_glue_submit.sh silver
+bash scripts/aws_glue_submit.sh gold
 ```
 
-El script `prodi_glue_entry.py` expone la invocación al entrypoint:
+Los jobs y el script delegan en un entrypoint Python mínimo (`prodi_glue_entry.py`)
+que invoca `prodi.cli.main(["run-layer", ...])` reutilizando el wheel publicado.
 
-```python
-import prodi.cli
-
-if __name__ == "__main__":
-    prodi.cli.main(["run-layer"])
-```
-
-### Encadenar capas
-
-Define un job por capa y utiliza Workflows de Glue o Step Functions para
-ejecutarlos secuencialmente. El archivo [`docs/run/jobs/aws_stepfunctions.json`](jobs/aws_stepfunctions.json)
-ya referencia las rutas `cfg/<layer>/example.yml` y puede importarse sin
-modificaciones.
-
-```json
-{
-  "Comment": "Cadena prodi",
-  "StartAt": "raw",
-  "States": {
-    "raw": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::glue:startJobRun.sync",
-      "Parameters": {"JobName": "prodi-layer-raw"},
-      "Next": "bronze"
-    },
-    "bronze": {"Type": "Task", "Resource": "arn:aws:states:::glue:startJobRun.sync", "Parameters": {"JobName": "prodi-layer-bronze"}, "Next": "silver"},
-    "silver": {"Type": "Task", "Resource": "arn:aws:states:::glue:startJobRun.sync", "Parameters": {"JobName": "prodi-layer-silver"}, "Next": "gold"},
-    "gold": {"Type": "Task", "Resource": "arn:aws:states:::glue:startJobRun.sync", "Parameters": {"JobName": "prodi-layer-gold"}, "End": true}
-  }
-}
-```
-
-Para ejecuciones sobre EMR o EMR Serverless, lanza un `spark-submit` por capa
-con el mismo wheel:
+Para ejecuciones sobre EMR o EMR Serverless lanza un `spark-submit` por capa con
+el mismo wheel y YAML de producción:
 
 ```bash
 spark-submit \
   --deploy-mode cluster \
-  --py-files s3://datalake-artifacts/prodi/mvp_config_driven-0.1.0-py3-none-any.whl \
+  --py-files s3://datalake-artifacts/prodi/mvp_config_driven-0.2.0-py3-none-any.whl \
   s3://datalake-artifacts/scripts/prodi_emr_entry.py \
   --layer bronze \
-  --config s3://datalake-artifacts/cfg/bronze/example.yml
+  --config s3://datalake-artifacts/cfg/bronze/aws.prod.yml
 ```
-
-El script `prodi_emr_entry.py` debe delegar en `prodi.cli.main(["run-layer", ...])`,
-idéntico al usado en Glue y Dataproc.
 
 ## 3. Validación `dry-run`
 
-Ejecuta pruebas en modo validación agregando el argumento `--dry-run`:
+Antes de tocar datos reales ejecuta una validación `dry-run` forzada con la misma
+configuración productiva. Tanto los jobs de Glue como Step Functions aceptan
+variables de entorno a través de `--arguments`:
 
 ```bash
-aws glue start-job-run --job-name prodi-layer-raw --arguments '{"--dry-run":"true"}'
+aws glue start-job-run --job-name prodi-layer-raw \
+  --arguments '{"--env.PRODI_FORCE_DRY_RUN":"true"}'
 ```
 
-En entornos de QA puedes forzar el flag desde la definición del job en
-`--default-arguments` y sobreescribirlo en producción.
+El flag `PRODI_FORCE_DRY_RUN=1` replica el job `smoke-prod` de CI y obliga a que
+`prodi` no ejecute acciones sobre los buckets aun cuando el YAML defina
+`dry_run: false`.
 
-## 4. Parámetros dinámicos
+## 4. Parámetros dinámicos y credenciales
 
-* Define parámetros globales en el Workflow y pásalos a cada job como
-  `--env=prod` o `--date=2024-03-31`.
-* Usa AWS Secrets Manager para credenciales y recupéralos en tiempo de ejecución
-  con `boto3` antes de invocar `prodi run-layer`.
+* Define parámetros globales en Step Functions y pásalos a cada job como
+  `--env=prod` o fechas de partición.
+* Usa AWS Secrets Manager o Parameter Store para secretos operativos; las rutas
+  `cfg/*/aws.prod.yml` se apoyan únicamente en IAM (sin llaves embebidas) como se
+  describe en la sección de credenciales por identidad del README.
 
 ## 5. Observabilidad
 

--- a/docs/run/gcp.md
+++ b/docs/run/gcp.md
@@ -9,56 +9,22 @@ Dataproc utilizando jobs de tipo PySpark que consumen el wheel de `prodi`.
    ```bash
    poetry build -f wheel
    ```
-2. Publica el wheel y configuraciones en un bucket regional:
+2. Publica el wheel y las configuraciones productivas en un bucket regional:
    ```bash
-   gsutil cp dist/mvp_config_driven-0.1.0-py3-none-any.whl gs://datalake-artifacts/libs/
+   gsutil cp dist/mvp_config_driven-0.2.0-py3-none-any.whl gs://datalake-artifacts/libs/
    gsutil cp -r cfg gs://datalake-artifacts/cfg
    ```
 
-## 2. Definir un workflow template
+## 2. Definir el workflow template
 
-Crea un [Dataproc Workflow Template](https://cloud.google.com/dataproc/docs/concepts/workflows/overview)
-con un paso por capa. Cada paso invoca `prodi run-layer` mediante
-`gcloud dataproc jobs submit pyspark` usando el wheel como archivo extra.
+El archivo [`docs/run/jobs/dataproc_v020.yaml`](jobs/dataproc_v020.yaml) declara
+cuatro pasos encadenados (`raw` → `bronze` → `silver` → `gold`) que ejecutan
+`gcloud dataproc jobs submit pyspark` con los YAML `cfg/<layer>/gcp.prod.yml`.
+Importa el template, ajusta la región/zona y actualiza los URIs si tu bucket
+cambia.
 
-```yaml
-jobs:
-  - step-id: raw
-    pyspark-job:
-      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
-      python-file-uris:
-        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
-      args: ["--layer", "raw", "--config", "gs://datalake-artifacts/cfg/raw/example.yml"]
-  - step-id: bronze
-    prerequisite-step-ids: [raw]
-    pyspark-job:
-      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
-      python-file-uris:
-        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
-      args: ["--layer", "bronze", "--config", "gs://datalake-artifacts/cfg/bronze/example.yml"]
-  - step-id: silver
-    prerequisite-step-ids: [bronze]
-    pyspark-job:
-      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
-      python-file-uris:
-        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
-      args: ["--layer", "silver", "--config", "gs://datalake-artifacts/cfg/silver/example.yml"]
-  - step-id: gold
-    prerequisite-step-ids: [silver]
-    pyspark-job:
-      main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
-      python-file-uris:
-        - gs://datalake-artifacts/libs/prodi-1.4.0-py3-none-any.whl
-      args: ["--layer", "gold", "--config", "gs://datalake-artifacts/cfg/gold/example.yml"]
-cluster-selector:
-  zone: us-central1-a
-  cluster-labels:
-    env: prod
-
-## 3. Script de entrada
-
-El archivo `prodi_dataproc_entry.py` debe residir en el mismo bucket y delegar en
-el CLI de `prodi`:
+Cada paso invoca un entrypoint ligero (`prodi_dataproc_entry.py`) que reenvía los
+argumentos a `prodi.cli.main`. Coloca este script en el bucket junto al wheel:
 
 ```python
 import sys
@@ -68,37 +34,35 @@ if __name__ == "__main__":
     main(["run-layer", *sys.argv[1:]])
 ```
 
-## 4. Validación `dry-run`
+## 3. Validación `dry-run`
 
-Antes de ejecutar el workflow completo, lanza un job aislado con el flag
-`--dry-run` para validar la configuración de la capa:
+Antes de calendarizar el workflow, ejecuta un job aislado habilitando el override
+por identidad administrada:
 
 ```bash
 gcloud dataproc jobs submit pyspark gs://datalake-artifacts/scripts/prodi_dataproc_entry.py \
   --cluster=dp-ops-validation \
   --region=us-central1 \
-  --jars=gs://datalake-artifacts/libs/mvp_config_driven-0.1.0-py3-none-any.whl \
+  --jars=gs://datalake-artifacts/libs/mvp_config_driven-0.2.0-py3-none-any.whl \
   -- \
   --layer raw \
-  --config gs://datalake-artifacts/cfg/raw/example.yml \
-  --dry-run
+  --config gs://datalake-artifacts/cfg/raw/gcp.prod.yml \
+  --env.PRODI_FORCE_DRY_RUN=true
 ```
 
-Puedes repetir el comando para cada capa, o bien crear una versión alternativa
-del template que fije `args: [..., "--dry-run"]` para entornos de QA.
+El parámetro `--env.PRODI_FORCE_DRY_RUN=true` aplica el mismo mecanismo que la
+job `smoke-prod` en CI y evita side-effects aun cuando `dry_run: false` está
+configurado en los YAML productivos.
 
-Cuando necesites ejecutar la cadena completa desde un orquestador externo,
-crea una tarea por capa reutilizando el mismo wheel. Encadena `run-layer` para
-raw → bronze → silver → gold y mantén `--dry-run` hasta validar la integración.
-
-## 5. Buenas prácticas operativas
+## 4. Buenas prácticas operativas
 
 * Activa [diagnostic logs](https://cloud.google.com/dataproc/docs/guides/logging) y
-  envía los logs de `stdout` a Cloud Logging con filtros por `task-id`.
-* Usa variables de plantilla (`{{execution_date}}`) al parametrizar rutas de
-  entrada/salida en los YAML.
-* Desactiva el cluster tras la ejecución utilizando Workflow Templates sin
+  envía los logs de `stdout` a Cloud Logging con filtros por `step-id`.
+* Parametriza fechas y rutas mediante variables del template y mantén las
+  identidades de servicio con alcance mínimo; los YAML se apoyan en cuentas de
+  servicio administradas sin llaves embebidas.
+* Desactiva el clúster tras la ejecución utilizando Workflow Templates sin
   clúster preexistente o [Dataproc Serverless](https://cloud.google.com/dataproc-serverless/docs).
 
-Consulta plantillas adicionales en [`docs/run/jobs/`](jobs/) para integrarlas con
-Cloud Composer u orquestadores externos.
+Consulta plantillas adicionales en [`docs/run/jobs/`](jobs/) para integraciones
+con Cloud Composer u orquestadores externos.

--- a/docs/run/jobs/aws_glue_v020.json
+++ b/docs/run/jobs/aws_glue_v020.json
@@ -1,0 +1,54 @@
+{
+  "Comment": "Orquestación v0.2.0 prodi",
+  "StartAt": "raw",
+  "States": {
+    "raw": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-raw",
+        "Arguments": {
+          "--layer": "raw",
+          "--config": "s3://datalake-artifacts/cfg/raw/aws.prod.yml"
+        }
+      },
+      "Next": "bronze"
+    },
+    "bronze": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-bronze",
+        "Arguments": {
+          "--layer": "bronze",
+          "--config": "s3://datalake-artifacts/cfg/bronze/aws.prod.yml"
+        }
+      },
+      "Next": "silver"
+    },
+    "silver": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-silver",
+        "Arguments": {
+          "--layer": "silver",
+          "--config": "s3://datalake-artifacts/cfg/silver/aws.prod.yml"
+        }
+      },
+      "Next": "gold"
+    },
+    "gold": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "prodi-layer-gold",
+        "Arguments": {
+          "--layer": "gold",
+          "--config": "s3://datalake-artifacts/cfg/gold/aws.prod.yml"
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/docs/run/jobs/azure_adf_pipeline.json
+++ b/docs/run/jobs/azure_adf_pipeline.json
@@ -23,7 +23,7 @@
                 "type": "PipelineReference"
               },
               "parameters": {
-                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/raw/example.yml",
+                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/raw/azure.prod.yml",
                 "dryRun": "@{pipeline().parameters.dryRun}"
               }
             }
@@ -43,7 +43,7 @@
                 "type": "PipelineReference"
               },
               "parameters": {
-                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/bronze/example.yml",
+                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/bronze/azure.prod.yml",
                 "dryRun": "@{pipeline().parameters.dryRun}"
               }
             }
@@ -63,7 +63,7 @@
                 "type": "PipelineReference"
               },
               "parameters": {
-                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/silver/example.yml",
+                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/silver/azure.prod.yml",
                 "dryRun": "@{pipeline().parameters.dryRun}"
               }
             }
@@ -83,7 +83,7 @@
                 "type": "PipelineReference"
               },
               "parameters": {
-                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/gold/example.yml",
+                "configUri": "abfss://artifacts@datalake.dfs.core.windows.net/cfg/gold/azure.prod.yml",
                 "dryRun": "@{pipeline().parameters.dryRun}"
               }
             }

--- a/docs/run/jobs/databricks_v020.json
+++ b/docs/run/jobs/databricks_v020.json
@@ -1,0 +1,88 @@
+{
+  "name": "prodi-mvp-v020",
+  "job_clusters": [
+    {
+      "job_cluster_key": "shared_cluster",
+      "new_cluster": {
+        "spark_version": "13.3.x-scala2.12",
+        "node_type_id": "Standard_D3_v2",
+        "num_workers": 2,
+        "aws_attributes": {
+          "availability": "SPOT_WITH_FALLBACK"
+        }
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "task_key": "raw",
+      "job_cluster_key": "shared_cluster",
+      "depends_on": [],
+      "libraries": [
+        { "whl": "dbfs:/libs/mvp-config-driven.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "raw",
+          "--config", "dbfs:/cfg/raw/aws.prod.yml"
+        ]
+      }
+    },
+    {
+      "task_key": "bronze",
+      "depends_on": [
+        { "task_key": "raw" }
+      ],
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/mvp-config-driven.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "bronze",
+          "--config", "dbfs:/cfg/bronze/aws.prod.yml"
+        ]
+      }
+    },
+    {
+      "task_key": "silver",
+      "depends_on": [
+        { "task_key": "bronze" }
+      ],
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/mvp-config-driven.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "silver",
+          "--config", "dbfs:/cfg/silver/aws.prod.yml"
+        ]
+      }
+    },
+    {
+      "task_key": "gold",
+      "depends_on": [
+        { "task_key": "silver" }
+      ],
+      "job_cluster_key": "shared_cluster",
+      "libraries": [
+        { "whl": "dbfs:/libs/mvp-config-driven.whl" }
+      ],
+      "wheel_task": {
+        "package_name": "prodi",
+        "entry_point": "run-layer",
+        "parameters": [
+          "--layer", "gold",
+          "--config", "dbfs:/cfg/gold/aws.prod.yml"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/run/jobs/dataproc_v020.yaml
+++ b/docs/run/jobs/dataproc_v020.yaml
@@ -4,32 +4,45 @@ jobs:
       main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
       python-file-uris:
         - gs://datalake-artifacts/libs/mvp_config_driven-0.2.0-py3-none-any.whl
-      args: ["--layer", "raw", "--config", "gs://datalake-artifacts/cfg/raw/gcp.prod.yml"]
+      args:
+        - --layer
+        - raw
+        - --config
+        - gs://datalake-artifacts/cfg/raw/gcp.prod.yml
   - step-id: bronze
     prerequisite-step-ids: [raw]
     pyspark-job:
       main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
       python-file-uris:
         - gs://datalake-artifacts/libs/mvp_config_driven-0.2.0-py3-none-any.whl
-      args: ["--layer", "bronze", "--config", "gs://datalake-artifacts/cfg/bronze/gcp.prod.yml"]
+      args:
+        - --layer
+        - bronze
+        - --config
+        - gs://datalake-artifacts/cfg/bronze/gcp.prod.yml
   - step-id: silver
     prerequisite-step-ids: [bronze]
     pyspark-job:
       main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
       python-file-uris:
         - gs://datalake-artifacts/libs/mvp_config_driven-0.2.0-py3-none-any.whl
-      args: ["--layer", "silver", "--config", "gs://datalake-artifacts/cfg/silver/gcp.prod.yml"]
+      args:
+        - --layer
+        - silver
+        - --config
+        - gs://datalake-artifacts/cfg/silver/gcp.prod.yml
   - step-id: gold
     prerequisite-step-ids: [silver]
     pyspark-job:
       main-python-file-uri: gs://datalake-artifacts/scripts/prodi_dataproc_entry.py
       python-file-uris:
         - gs://datalake-artifacts/libs/mvp_config_driven-0.2.0-py3-none-any.whl
-      args: ["--layer", "gold", "--config", "gs://datalake-artifacts/cfg/gold/gcp.prod.yml"]
+      args:
+        - --layer
+        - gold
+        - --config
+        - gs://datalake-artifacts/cfg/gold/gcp.prod.yml
 cluster-selector:
   zone: us-central1-a
   cluster-labels:
     env: prod
-parameters:
-  dryRun:
-    default: "false"

--- a/docs/run/jobs/emr_steps.json
+++ b/docs/run/jobs/emr_steps.json
@@ -9,10 +9,10 @@
         "Args": [
           "spark-submit",
           "--deploy-mode", "cluster",
-          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.1.0-py3-none-any.whl",
+          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.2.0-py3-none-any.whl",
           "s3://datalake-artifacts/scripts/prodi_emr_entry.py",
           "--layer", "raw",
-          "--config", "s3://datalake-artifacts/cfg/raw/example.yml"
+          "--config", "s3://datalake-artifacts/cfg/raw/aws.prod.yml"
         ]
       }
     },
@@ -24,10 +24,10 @@
         "Args": [
           "spark-submit",
           "--deploy-mode", "cluster",
-          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.1.0-py3-none-any.whl",
+          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.2.0-py3-none-any.whl",
           "s3://datalake-artifacts/scripts/prodi_emr_entry.py",
           "--layer", "bronze",
-          "--config", "s3://datalake-artifacts/cfg/bronze/example.yml"
+          "--config", "s3://datalake-artifacts/cfg/bronze/aws.prod.yml"
         ]
       }
     },
@@ -39,10 +39,10 @@
         "Args": [
           "spark-submit",
           "--deploy-mode", "cluster",
-          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.1.0-py3-none-any.whl",
+          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.2.0-py3-none-any.whl",
           "s3://datalake-artifacts/scripts/prodi_emr_entry.py",
           "--layer", "silver",
-          "--config", "s3://datalake-artifacts/cfg/silver/example.yml"
+          "--config", "s3://datalake-artifacts/cfg/silver/aws.prod.yml"
         ]
       }
     },
@@ -54,10 +54,10 @@
         "Args": [
           "spark-submit",
           "--deploy-mode", "cluster",
-          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.1.0-py3-none-any.whl",
+          "--py-files", "s3://datalake-artifacts/prodi/mvp_config_driven-0.2.0-py3-none-any.whl",
           "s3://datalake-artifacts/scripts/prodi_emr_entry.py",
           "--layer", "gold",
-          "--config", "s3://datalake-artifacts/cfg/gold/example.yml"
+          "--config", "s3://datalake-artifacts/cfg/gold/aws.prod.yml"
         ]
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mvp-config-driven"
-version = "0.1.0"
+version = "0.2.0"
 description = "Config-driven Spark pipeline orchestration"
 requires-python = ">=3.10"
 dependencies = [

--- a/scripts/aws_glue_submit.sh
+++ b/scripts/aws_glue_submit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <layer>" >&2
+  exit 1
+fi
+
+layer="$1"
+case "$layer" in
+  raw|bronze|silver|gold) ;;
+  *)
+    echo "Unsupported layer: $layer" >&2
+    exit 1
+    ;;
+esac
+
+cfg_base="${AWS_PRODI_CFG_BASE:-s3://datalake-artifacts/cfg}"
+job_prefix="${AWS_PRODI_JOB_PREFIX:-prodi-layer}"
+config_uri="${cfg_base}/${layer}/aws.prod.yml"
+job_name="${job_prefix}-${layer}"
+
+arguments=$(python - <<PY
+import json
+import os
+payload = {"--layer": "${layer}", "--config": "${config_uri}"}
+if os.getenv("FORCE_DRY_RUN", "0").lower() not in {"0", "false", ""}:
+    payload["--env.PRODI_FORCE_DRY_RUN"] = "true"
+print(json.dumps(payload))
+PY
+)
+
+echo "[aws-glue] starting job ${job_name} with config ${config_uri}" >&2
+aws glue start-job-run --job-name "${job_name}" --arguments "${arguments}"

--- a/scripts/smoke_prod_configs.sh
+++ b/scripts/smoke_prod_configs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PRODI_FORCE_DRY_RUN="${PRODI_FORCE_DRY_RUN:-1}"
+
+mapfile -t CONFIGS < <(find "${ROOT_DIR}/cfg" -maxdepth 2 -name '*.prod.yml' -print | sort)
+
+if [[ ${#CONFIGS[@]} -eq 0 ]]; then
+  echo "[smoke-prod] No production configurations found" >&2
+  exit 1
+fi
+
+for cfg in "${CONFIGS[@]}"; do
+  layer="$(basename "$(dirname "${cfg}")")"
+  echo "[smoke-prod] Validating ${layer} -> ${cfg}" >&2
+  prodi run-layer "${layer}" -c "${cfg}"
+done

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -91,3 +91,19 @@ def test_run_pipeline_uses_yaml_declaration(monkeypatch, tmp_path) -> None:
 
     assert result.exit_code == 0
     assert executed == ["raw", "bronze"]
+
+
+def test_force_dry_run_env_overrides(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    config_path = tmp_path / "raw.yml"
+    config_path.write_text(
+        yaml.safe_dump({"layer": "raw", "dry_run": False}), encoding="utf-8"
+    )
+
+    monkeypatch.setenv("PRODI_FORCE_DRY_RUN", "1")
+
+    result = runner.invoke(app, ["run-layer", "raw", "-c", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "PRODI_FORCE_DRY_RUN=1 - forcing dry_run execution" in result.stdout
+    assert "[raw] Dry run requested" in result.stdout


### PR DESCRIPTION
## Summary
- bump the package to v0.2.0 and add the corresponding changelog entry
- introduce production YAMLs per cloud with identity-based env manifests, forced dry-run override, and a new smoke-prod CI job
- refresh runbooks, orchestration templates, CODEOWNERS, and branch protections for the release

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc558d57cc8320a89ee7860ed7caa7