### PR TITLE
Add Azure adapters and Delta merge integration

### DIFF
--- a/src/mvp_config_driven/adapters/__init__.py
+++ b/src/mvp_config_driven/adapters/__init__.py
@@ -35,6 +35,13 @@ def _ensure_defaults() -> None:
     else:
         register_adapter_factory("aws", _build_aws)
 
+    try:  # Optional dependency guard - Azure adapters require azure SDKs
+        from .azure import build_default_adapters as _build_azure
+    except ImportError:  # pragma: no cover - azure optional in some deployments
+        pass
+    else:
+        register_adapter_factory("azure", _build_azure)
+
     _INITIALIZED = True
 
 

--- a/src/mvp_config_driven/adapters/azure/__init__.py
+++ b/src/mvp_config_driven/adapters/azure/__init__.py
@@ -1,0 +1,113 @@
+"""Azure-backed orchestration adapters relying on managed services."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from ..local import LocalStreamingAdapter, LocalTablesAdapter, LocalStorageAdapter
+from ...ports import SecretsPort, StoragePort
+from .job_databricks import DatabricksJobBackend
+from .secret_keyvault import KeyVaultSecretsAdapter
+from .storage_adls import AdlsStorageAdapter
+
+
+def _build_storage_adapter(config: Mapping[str, Any]) -> StoragePort:
+    if isinstance(config, Mapping):
+        account_name = config.get("account_name")
+        credential = config.get("credential") or config.get("account_key")
+        sas_token = config.get("sas_token")
+        auth = config.get("auth") or config.get("authentication")
+        endpoint_suffix = config.get("endpoint_suffix") or "dfs.core.windows.net"
+        managed_identity_cfg = config.get("managed_identity") if isinstance(config.get("managed_identity"), Mapping) else {}
+        managed_identity_client_id = (
+            managed_identity_cfg.get("client_id")
+            if isinstance(managed_identity_cfg, Mapping)
+            else None
+        )
+        try:
+            return AdlsStorageAdapter(
+                account_name=account_name,
+                credential=credential,
+                sas_token=sas_token,
+                auth=str(auth) if auth else None,
+                managed_identity_client_id=managed_identity_client_id,
+                endpoint_suffix=str(endpoint_suffix),
+            )
+        except ImportError:
+            return LocalStorageAdapter()
+    return LocalStorageAdapter()
+
+
+def _build_secrets_adapter(config: Mapping[str, Any]) -> SecretsPort:
+    if isinstance(config, Mapping):
+        vault_url = config.get("vault_url") or config.get("url")
+        credential = config.get("credential")
+        auth = config.get("auth") or config.get("authentication")
+        managed_identity_cfg = config.get("managed_identity") if isinstance(config.get("managed_identity"), Mapping) else {}
+        managed_identity_client_id = (
+            managed_identity_cfg.get("client_id")
+            if isinstance(managed_identity_cfg, Mapping)
+            else None
+        )
+        try:
+            return KeyVaultSecretsAdapter(
+                vault_url=str(vault_url) if vault_url else None,
+                credential=credential,
+                auth=str(auth) if auth else None,
+                managed_identity_client_id=managed_identity_client_id,
+            )
+        except ImportError:
+            return KeyVaultSecretsAdapter(vault_url=None)
+    return KeyVaultSecretsAdapter(vault_url=None)
+
+
+def _build_job_backend(config: Mapping[str, Any]) -> DatabricksJobBackend:
+    if not isinstance(config, Mapping):
+        return DatabricksJobBackend()
+    cli_path = config.get("cli_path")
+    profile = config.get("profile")
+    host = config.get("host")
+    token = config.get("token")
+    default_job_id = config.get("job_id") or config.get("default_job_id")
+    default_pipeline_id = (
+        config.get("pipeline_id") or config.get("default_pipeline_id")
+    )
+    workspace_cfg = config.get("workspace") if isinstance(config.get("workspace"), Mapping) else {}
+    if isinstance(workspace_cfg, Mapping):
+        host = host or workspace_cfg.get("host")
+        profile = profile or workspace_cfg.get("profile")
+        token = token or workspace_cfg.get("token")
+    return DatabricksJobBackend(
+        cli_path=str(cli_path) if cli_path else "databricks",
+        profile=str(profile) if profile else None,
+        host=str(host) if host else None,
+        token=str(token) if token else None,
+        default_job_id=str(default_job_id) if default_job_id else None,
+        default_pipeline_id=str(default_pipeline_id) if default_pipeline_id else None,
+    )
+
+
+def build_default_adapters(config: Mapping[str, object] | None = None) -> Dict[str, object]:
+    """Instantiate Azure-backed adapters honoring the provided ``config``."""
+
+    config = config or {}
+    storage_cfg = config.get("storage") if isinstance(config.get("storage"), Mapping) else {}
+    secrets_cfg = config.get("secrets") if isinstance(config.get("secrets"), Mapping) else {}
+    job_cfg = config.get("job_backend") if isinstance(config.get("job_backend"), Mapping) else {}
+
+    storage = _build_storage_adapter(storage_cfg)
+    secrets = _build_secrets_adapter(secrets_cfg)
+    job_backend = _build_job_backend(job_cfg)
+
+    tables = LocalTablesAdapter(storage=storage)
+
+    return {
+        "storage": storage,
+        "tables": tables,
+        "secrets": secrets,
+        "job_backend": job_backend,
+        "streaming": LocalStreamingAdapter(),
+    }
+
+
+__all__ = ["build_default_adapters"]

--- a/src/mvp_config_driven/adapters/azure/job_databricks.py
+++ b/src/mvp_config_driven/adapters/azure/job_databricks.py
@@ -1,0 +1,123 @@
+"""Databricks job backend integrating with the Databricks CLI."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+from ...ports import JobBackendPort
+
+
+def _as_str_sequence(values: Optional[Sequence[Any]]) -> list[str]:
+    if not values:
+        return []
+    return [str(value) for value in values]
+
+
+def _merge_payload(base: MutableMapping[str, Any], extra: Optional[Mapping[str, Any]]) -> None:
+    if not extra:
+        return
+    for key, value in extra.items():
+        base[key] = value
+
+
+class DatabricksJobBackend(JobBackendPort):
+    """Job backend that prepares Databricks CLI invocations."""
+
+    def __init__(
+        self,
+        *,
+        cli_path: str = "databricks",
+        profile: str | None = None,
+        host: str | None = None,
+        token: str | None = None,
+        default_job_id: str | None = None,
+        default_pipeline_id: str | None = None,
+    ) -> None:
+        self._cli_path = cli_path
+        self._profile = profile
+        self._host = host
+        self._token = token
+        self._default_job_id = default_job_id
+        self._default_pipeline_id = default_pipeline_id
+
+    def ensure_engine(self, context: object) -> Any:  # pragma: no cover - remote execution
+        return None
+
+    def stop_engine(self, context: object) -> None:  # pragma: no cover - remote execution
+        return None
+
+    def _base_command(self) -> list[str]:
+        command = [self._cli_path]
+        if self._profile:
+            command.extend(["--profile", self._profile])
+        if self._host:
+            command.extend(["--host", self._host])
+        if self._token:
+            command.extend(["--token", self._token])
+        return command
+
+    def build_run_now_command(
+        self,
+        *,
+        job_id: str | None = None,
+        job_name: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        notebook_params: Mapping[str, Any] | None = None,
+        python_params: Sequence[Any] | None = None,
+        jar_params: Sequence[Any] | None = None,
+        spark_submit_params: Sequence[Any] | None = None,
+        extra_payload: Mapping[str, Any] | None = None,
+    ) -> list[str]:
+        """Return the CLI command to trigger ``databricks jobs run-now``."""
+
+        payload: MutableMapping[str, Any] = {}
+        resolved_job_id = job_id or self._default_job_id
+        if resolved_job_id:
+            payload["job_id"] = resolved_job_id
+        if job_name:
+            payload["job_name"] = job_name
+        _merge_payload(payload, parameters)
+        if notebook_params:
+            payload["notebook_params"] = dict(notebook_params)
+        if python_params:
+            payload["python_params"] = _as_str_sequence(python_params)
+        if jar_params:
+            payload["jar_params"] = _as_str_sequence(jar_params)
+        if spark_submit_params:
+            payload["spark_submit_params"] = _as_str_sequence(spark_submit_params)
+        _merge_payload(payload, extra_payload)
+
+        if not payload:
+            raise ValueError("At least a job_id, job_name or payload must be provided")
+
+        command = self._base_command()
+        command.extend(["jobs", "run-now"])
+        command.extend(["--json", json.dumps(payload, sort_keys=True)])
+        return command
+
+    def build_pipeline_start_command(
+        self,
+        *,
+        pipeline_id: str | None = None,
+        pipeline_name: str | None = None,
+        full_refresh: bool | None = None,
+    ) -> list[str]:
+        """Return the CLI command to trigger ``databricks pipelines start``."""
+
+        resolved_pipeline_id = pipeline_id or self._default_pipeline_id
+        if not resolved_pipeline_id and not pipeline_name:
+            raise ValueError("Pipeline id or name is required")
+
+        command = self._base_command()
+        command.extend(["pipelines", "start"])
+        if resolved_pipeline_id:
+            command.extend(["--pipeline-id", resolved_pipeline_id])
+        if pipeline_name:
+            command.extend(["--pipeline-name", pipeline_name])
+        if full_refresh:
+            command.append("--full-refresh")
+        return command
+
+
+__all__ = ["DatabricksJobBackend"]

--- a/src/mvp_config_driven/adapters/azure/secret_keyvault.py
+++ b/src/mvp_config_driven/adapters/azure/secret_keyvault.py
@@ -1,0 +1,102 @@
+"""Azure Key Vault backed secrets adapter."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency in CI
+    from azure.core.exceptions import ResourceNotFoundError  # type: ignore
+except Exception:  # pragma: no cover - azure sdk optional
+    class ResourceNotFoundError(Exception):  # type: ignore[override]
+        pass
+
+try:  # pragma: no cover - optional dependency in CI
+    from azure.identity import ManagedIdentityCredential  # type: ignore
+except Exception:  # pragma: no cover - azure identity optional
+    ManagedIdentityCredential = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency in CI
+    from azure.keyvault.secrets import SecretClient  # type: ignore
+except Exception:  # pragma: no cover - azure keyvault optional
+    SecretClient = None  # type: ignore
+
+from ...ports import SecretsPort
+
+
+class _NullSecretClient:
+    """Fallback client used when no Key Vault configuration is provided."""
+
+    def get_secret(self, key: str) -> object:  # pragma: no cover - trivial fallback
+        raise ResourceNotFoundError()
+
+
+class KeyVaultSecretsAdapter(SecretsPort):
+    """Secrets adapter that retrieves secrets from Azure Key Vault."""
+
+    def __init__(
+        self,
+        *,
+        vault_url: str | None,
+        credential: object | None = None,
+        auth: str | None = None,
+        managed_identity_client_id: str | None = None,
+        secret_client: object | None = None,
+    ) -> None:
+        self._vault_url = vault_url
+        if secret_client is not None:
+            self._secret_client = secret_client
+        elif not vault_url:
+            self._secret_client = _NullSecretClient()
+        else:
+            self._secret_client = self._build_client(
+                vault_url=vault_url,
+                credential=credential,
+                auth=auth,
+                managed_identity_client_id=managed_identity_client_id,
+            )
+
+    def _build_client(
+        self,
+        *,
+        vault_url: str | None,
+        credential: object | None,
+        auth: str | None,
+        managed_identity_client_id: str | None,
+    ) -> object:
+        if not vault_url:
+            raise ValueError("vault_url is required when secret_client is not provided")
+        if SecretClient is None:
+            raise ImportError("azure-keyvault-secrets is required for Key Vault support")
+        credential_obj = self._resolve_credential(
+            credential=credential,
+            auth=auth,
+            managed_identity_client_id=managed_identity_client_id,
+        )
+        if credential_obj is None:
+            return SecretClient(vault_url=vault_url)
+        return SecretClient(vault_url=vault_url, credential=credential_obj)
+
+    @staticmethod
+    def _resolve_credential(
+        *,
+        credential: object | None,
+        auth: str | None,
+        managed_identity_client_id: str | None,
+    ) -> object | None:
+        if auth and auth.strip().lower() in {"msi", "managed_identity"}:
+            if ManagedIdentityCredential is None:
+                raise ImportError("azure-identity is required for managed identity auth")
+            return ManagedIdentityCredential(client_id=managed_identity_client_id)
+        return credential
+
+    def get_secret(self, key: str) -> Optional[str]:
+        if not key:
+            return None
+        try:
+            secret = self._secret_client.get_secret(key)
+        except ResourceNotFoundError:
+            return None
+        return getattr(secret, "value", None)
+
+
+__all__ = ["KeyVaultSecretsAdapter"]

--- a/src/mvp_config_driven/adapters/azure/storage_adls.py
+++ b/src/mvp_config_driven/adapters/azure/storage_adls.py
@@ -1,0 +1,159 @@
+"""Azure Data Lake Storage adapter built on top of ``azure-storage-file-datalake``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+try:  # pragma: no cover - optional dependency in CI
+    from azure.core.exceptions import ResourceNotFoundError  # type: ignore
+except Exception:  # pragma: no cover - azure SDK optional
+    class ResourceNotFoundError(Exception):  # type: ignore[override]
+        """Fallback error used when Azure SDK is unavailable."""
+
+        pass
+
+try:  # pragma: no cover - optional dependency in CI
+    from azure.identity import ManagedIdentityCredential  # type: ignore
+except Exception:  # pragma: no cover - azure identity optional
+    ManagedIdentityCredential = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency in CI
+    from azure.storage.filedatalake import DataLakeServiceClient  # type: ignore
+except Exception:  # pragma: no cover - azure storage optional
+    DataLakeServiceClient = None  # type: ignore
+
+from ...ports import StoragePort
+
+
+@dataclass
+class _FileClientWrapper:
+    """Lightweight wrapper used by tests to emulate file client interactions."""
+
+    file_client: object
+
+    def read_text(self) -> str:
+        downloader = getattr(self.file_client, "download_file")()
+        payload = downloader.readall()
+        if isinstance(payload, bytes):
+            return payload.decode("utf-8")
+        return str(payload)
+
+    def write_text(self, content: str) -> None:
+        self.file_client.upload_data(content.encode("utf-8"), overwrite=True)
+
+    def exists(self) -> bool:
+        try:
+            self.file_client.get_file_properties()
+        except ResourceNotFoundError:
+            return False
+        return True
+
+
+class AdlsStorageAdapter(StoragePort):
+    """Storage adapter that reads configuration files from ADLS Gen2."""
+
+    def __init__(
+        self,
+        *,
+        account_name: str | None = None,
+        credential: object | None = None,
+        sas_token: str | None = None,
+        auth: str | None = None,
+        managed_identity_client_id: str | None = None,
+        endpoint_suffix: str = "dfs.core.windows.net",
+        service_client: object | None = None,
+    ) -> None:
+        self._service_client = service_client or self._build_service_client(
+            account_name=account_name,
+            credential=credential,
+            sas_token=sas_token,
+            auth=auth,
+            managed_identity_client_id=managed_identity_client_id,
+            endpoint_suffix=endpoint_suffix,
+        )
+
+    def _build_service_client(
+        self,
+        *,
+        account_name: str | None,
+        credential: object | None,
+        sas_token: str | None,
+        auth: str | None,
+        managed_identity_client_id: str | None,
+        endpoint_suffix: str,
+    ) -> object:
+        if self._is_provided(self, "_service_client"):
+            return getattr(self, "_service_client")
+        if account_name is None:
+            raise ValueError("account_name is required when service_client is not provided")
+        if DataLakeServiceClient is None:
+            raise ImportError(
+                "azure-storage-file-datalake is required to build an ADLS adapter"
+            )
+        credential_obj = self._resolve_credential(
+            credential=credential,
+            sas_token=sas_token,
+            auth=auth,
+            managed_identity_client_id=managed_identity_client_id,
+        )
+        account_url = f"https://{account_name}.{endpoint_suffix}".rstrip("/")
+        if credential_obj is None:
+            return DataLakeServiceClient(account_url=account_url)
+        return DataLakeServiceClient(account_url=account_url, credential=credential_obj)
+
+    @staticmethod
+    def _resolve_credential(
+        *,
+        credential: object | None,
+        sas_token: str | None,
+        auth: str | None,
+        managed_identity_client_id: str | None,
+    ) -> object | None:
+        if auth:
+            normalized = auth.strip().lower()
+            if normalized in {"msi", "managed_identity"}:
+                if ManagedIdentityCredential is None:
+                    raise ImportError("azure-identity is required for managed identity auth")
+                return ManagedIdentityCredential(client_id=managed_identity_client_id)
+            if normalized == "sas" and sas_token:
+                return sas_token
+        if sas_token and not credential:
+            return sas_token
+        return credential
+
+    @staticmethod
+    def _is_provided(obj: object, attr: str) -> bool:
+        return hasattr(obj, attr) and getattr(obj, attr) is not None
+
+    def _resolve_file_client(self, uri: str) -> _FileClientWrapper:
+        filesystem, path = self._split_uri(uri)
+        client = self._service_client.get_file_system_client(filesystem)
+        file_client = client.get_file_client(path)
+        return _FileClientWrapper(file_client)
+
+    def read_text(self, uri: str) -> str:
+        wrapper = self._resolve_file_client(uri)
+        return wrapper.read_text()
+
+    def exists(self, uri: str) -> bool:
+        wrapper = self._resolve_file_client(uri)
+        return wrapper.exists()
+
+    def write_text(self, uri: str, content: str) -> None:
+        wrapper = self._resolve_file_client(uri)
+        wrapper.write_text(content)
+
+    @staticmethod
+    def _split_uri(uri: str) -> Tuple[str, str]:
+        if not uri.startswith("abfss://"):
+            raise ValueError(f"Unsupported URI: {uri}")
+        path = uri[8:]
+        filesystem, _, remainder = path.partition("@")
+        if not remainder:
+            raise ValueError(f"Invalid ABFSS URI: {uri}")
+        _, _, relative_path = remainder.partition("/")
+        return filesystem, relative_path
+
+
+__all__ = ["AdlsStorageAdapter"]

--- a/tests/test_adapters_azure.py
+++ b/tests/test_adapters_azure.py
@@ -1,0 +1,331 @@
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+if "pydantic" not in sys.modules:
+    fake_pydantic = types.ModuleType("pydantic")
+
+    class _BaseModel:
+        model_config = {}
+
+        @classmethod
+        def model_validate(cls, value):
+            return value
+
+        def model_dump(self, **_: object) -> dict:
+            return {}
+
+    def _field(*, default=None, default_factory=None, **__: object):
+        if default_factory is not None:
+            return default_factory()
+        return default
+
+    def _config_dict(**kwargs: object) -> dict:
+        return dict(kwargs)
+
+    fake_pydantic.BaseModel = _BaseModel
+    fake_pydantic.Field = _field
+    fake_pydantic.ConfigDict = _config_dict
+    sys.modules["pydantic"] = fake_pydantic
+
+if "fsspec" not in sys.modules:
+    fake_fsspec = types.ModuleType("fsspec")
+
+    def _filesystem(protocol: str, **_: object) -> object:  # pragma: no cover - stub
+        return object()
+
+    def _open(*args: object, **kwargs: object):  # pragma: no cover - stub
+        raise FileNotFoundError()
+
+    fake_fsspec.filesystem = _filesystem
+    fake_fsspec.open = _open
+
+    core_module = types.ModuleType("fsspec.core")
+
+    def _url_to_fs(uri: str, **_: object):  # pragma: no cover - stub
+        class _DummyFS:
+            def exists(self, path: str) -> bool:
+                return False
+
+        return _DummyFS(), uri
+
+    core_module.url_to_fs = _url_to_fs
+    fake_fsspec.core = core_module
+    sys.modules["fsspec"] = fake_fsspec
+    sys.modules["fsspec.core"] = core_module
+
+from mvp_config_driven.adapters.azure import secret_keyvault as secrets_module
+from mvp_config_driven.adapters.azure import storage_adls as storage_module
+from mvp_config_driven.adapters.azure.job_databricks import DatabricksJobBackend
+
+KeyVaultSecretsAdapter = secrets_module.KeyVaultSecretsAdapter
+KeyVaultResourceNotFoundError = secrets_module.ResourceNotFoundError
+AdlsStorageAdapter = storage_module.AdlsStorageAdapter
+AdlsResourceNotFoundError = storage_module.ResourceNotFoundError
+
+
+class FakeDownloader:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def readall(self) -> bytes:
+        return self._data
+
+
+class FakeFileClient:
+    def __init__(self, path: str, store: dict[str, bytes]) -> None:
+        self._path = path
+        self._store = store
+
+    def download_file(self) -> FakeDownloader:
+        if self._path not in self._store:
+            raise AdlsResourceNotFoundError()
+        return FakeDownloader(self._store[self._path])
+
+    def upload_data(self, data: bytes, *, overwrite: bool = False) -> None:
+        self._store[self._path] = data
+
+    def get_file_properties(self) -> None:
+        if self._path not in self._store:
+            raise AdlsResourceNotFoundError()
+
+
+class FakeFileSystemClient:
+    def __init__(self, filesystem: str, store: dict[tuple[str, str], bytes]) -> None:
+        self._filesystem = filesystem
+        self._store = store
+
+    def get_file_client(self, path: str) -> FakeFileClient:
+        key = (self._filesystem, path)
+        return FakeFileClient(path, FakeStoreProxy(self._store, key))
+
+
+class FakeServiceClient:
+    def __init__(self, store: dict[tuple[str, str], bytes]) -> None:
+        self._store = store
+
+    def get_file_system_client(self, filesystem: str) -> FakeFileSystemClient:
+        return FakeFileSystemClient(filesystem, self._store)
+
+
+class FakeStoreProxy(dict):
+    def __init__(self, backing: dict[tuple[str, str], bytes], key: tuple[str, str]) -> None:
+        super().__init__()
+        self._backing = backing
+        self._key = key
+
+    def __getitem__(self, _: str) -> bytes:
+        return self._backing[self._key]
+
+    def __setitem__(self, _: str, value: bytes) -> None:
+        self._backing[self._key] = value
+
+    def get(self, _: str, default: bytes | None = None) -> bytes | None:
+        return self._backing.get(self._key, default)
+
+    def __contains__(self, _: object) -> bool:
+        return self._key in self._backing
+
+
+def test_adls_storage_adapter_roundtrip() -> None:
+    store: dict[tuple[str, str], bytes] = {}
+    service = FakeServiceClient(store)
+    adapter = AdlsStorageAdapter(service_client=service)
+
+    uri = "abfss://configs@contoso.dfs.core.windows.net/env.yml"
+    adapter.write_text(uri, "timezone: UTC")
+
+    assert adapter.exists(uri)
+    assert adapter.read_text(uri) == "timezone: UTC"
+    assert not adapter.exists(
+        "abfss://configs@contoso.dfs.core.windows.net/missing.yml"
+    )
+
+
+def test_adls_storage_adapter_managed_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeCredential:
+        def __init__(self, *, client_id: str | None = None) -> None:
+            captured["client_id"] = client_id
+
+    class FakeClient:
+        def __init__(self, *, account_url: str, credential: object | None = None) -> None:
+            captured["account_url"] = account_url
+            captured["credential"] = credential
+
+        def get_file_system_client(self, filesystem: str) -> None:  # pragma: no cover
+            raise AssertionError("No filesystem interactions expected")
+
+    monkeypatch.setattr("mvp_config_driven.adapters.azure.storage_adls.ManagedIdentityCredential", FakeCredential)
+    monkeypatch.setattr("mvp_config_driven.adapters.azure.storage_adls.DataLakeServiceClient", FakeClient)
+
+    AdlsStorageAdapter(
+        account_name="contoso",
+        auth="managed_identity",
+        managed_identity_client_id="client-123",
+    )
+
+    assert captured["account_url"] == "https://contoso.dfs.core.windows.net"
+    assert isinstance(captured["credential"], FakeCredential)
+    assert captured["client_id"] == "client-123"
+
+
+def test_adls_storage_adapter_sas_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeClient:
+        def __init__(self, *, account_url: str, credential: object | None = None) -> None:
+            captured["account_url"] = account_url
+            captured["credential"] = credential
+
+        def get_file_system_client(self, filesystem: str) -> None:  # pragma: no cover
+            raise AssertionError("Unexpected filesystem access")
+
+    monkeypatch.setattr("mvp_config_driven.adapters.azure.storage_adls.DataLakeServiceClient", FakeClient)
+
+    AdlsStorageAdapter(account_name="contoso", auth="sas", sas_token="?sig=abc")
+
+    assert captured["account_url"] == "https://contoso.dfs.core.windows.net"
+    assert captured["credential"] == "?sig=abc"
+
+
+def test_keyvault_secrets_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSecret:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    class FakeClient:
+        def __init__(self, vault_url: str, credential: object | None = None) -> None:
+            self._vault_url = vault_url
+            self._credential = credential
+            self._values = {"token": FakeSecret("value")}
+
+        def get_secret(self, key: str) -> FakeSecret:
+            if key not in self._values:
+                raise KeyVaultResourceNotFoundError()
+            return self._values[key]
+
+    monkeypatch.setattr(
+        "mvp_config_driven.adapters.azure.secret_keyvault.SecretClient",
+        FakeClient,
+    )
+
+    adapter = KeyVaultSecretsAdapter(vault_url="https://vault.local", credential=None)
+
+    assert adapter.get_secret("token") == "value"
+    assert adapter.get_secret("missing") is None
+
+
+def test_keyvault_secrets_adapter_managed_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeCredential:
+        def __init__(self, *, client_id: str | None = None) -> None:
+            captured["client_id"] = client_id
+
+    class FakeClient:
+        def __init__(self, vault_url: str, credential: object | None = None) -> None:
+            captured["vault_url"] = vault_url
+            captured["credential"] = credential
+
+        def get_secret(self, key: str) -> None:  # pragma: no cover
+            raise KeyVaultResourceNotFoundError()
+
+    monkeypatch.setattr(
+        "mvp_config_driven.adapters.azure.secret_keyvault.ManagedIdentityCredential",
+        FakeCredential,
+    )
+    monkeypatch.setattr(
+        "mvp_config_driven.adapters.azure.secret_keyvault.SecretClient",
+        FakeClient,
+    )
+
+    KeyVaultSecretsAdapter(
+        vault_url="https://vault.local",
+        auth="managed_identity",
+        managed_identity_client_id="abc",
+    )
+
+    assert captured["vault_url"] == "https://vault.local"
+    assert isinstance(captured["credential"], FakeCredential)
+    assert captured["client_id"] == "abc"
+
+
+def test_databricks_job_backend_builds_commands() -> None:
+    backend = DatabricksJobBackend(
+        host="https://adb.local",
+        token="token",
+        default_job_id="123",
+        default_pipeline_id="pipeline-1",
+    )
+
+    command = backend.build_run_now_command(
+        notebook_params={"layer": "raw"},
+        python_params=["--layer", "raw"],
+    )
+
+    assert command[:5] == ["databricks", "--host", "https://adb.local", "--token", "token"]
+    assert command[5:7] == ["jobs", "run-now"]
+    payload = json.loads(command[-1])
+    assert payload["job_id"] == "123"
+    assert payload["notebook_params"] == {"layer": "raw"}
+    assert payload["python_params"] == ["--layer", "raw"]
+
+    pipeline_cmd = backend.build_pipeline_start_command(full_refresh=True)
+    assert pipeline_cmd[:5] == ["databricks", "--host", "https://adb.local", "--token", "token"]
+    assert pipeline_cmd[5:] == ["pipelines", "start", "--pipeline-id", "pipeline-1", "--full-refresh"]
+
+
+def test_build_adapters_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    import mvp_config_driven.adapters as adapters_module
+
+    monkeypatch.setattr(adapters_module, "_FACTORIES", {})
+    monkeypatch.setattr(adapters_module, "_INITIALIZED", False)
+
+    class FakeStorageClient:
+        def __init__(self, *, account_url: str, credential: object | None = None) -> None:
+            self.account_url = account_url
+            self.credential = credential
+
+        def get_file_system_client(self, filesystem: str) -> FakeFileSystemClient:
+            return FakeFileSystemClient(filesystem, {})
+
+    class FakeSecretClient:
+        def __init__(self, vault_url: str, credential: object | None = None) -> None:
+            self.vault_url = vault_url
+            self.credential = credential
+
+        def get_secret(self, key: str) -> None:
+            raise KeyVaultResourceNotFoundError()
+
+    monkeypatch.setattr(
+        "mvp_config_driven.adapters.azure.storage_adls.DataLakeServiceClient",
+        FakeStorageClient,
+    )
+    monkeypatch.setattr(
+        "mvp_config_driven.adapters.azure.secret_keyvault.SecretClient",
+        FakeSecretClient,
+    )
+
+    adapters = adapters_module.build_adapters(
+        platform="azure",
+        config={
+            "storage": {"account_name": "contoso", "auth": "sas", "sas_token": "?sig=abc"},
+            "secrets": {"vault_url": "https://vault.local"},
+            "job_backend": {
+                "cli_path": "dbx",
+                "host": "https://adb.local",
+                "token": "secret",
+                "job_id": "42",
+            },
+        },
+    )
+
+    assert isinstance(adapters["storage"], AdlsStorageAdapter)
+    assert isinstance(adapters["secrets"], KeyVaultSecretsAdapter)
+    assert isinstance(adapters["job_backend"], DatabricksJobBackend)
+    assert adapters["job_backend"].build_pipeline_start_command(pipeline_id="p")[0] == "dbx"

--- a/tests/test_delta_merge.py
+++ b/tests/test_delta_merge.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from types import SimpleNamespace
+
+import pytest
+
+if "pydantic" not in sys.modules:
+    fake_pydantic = types.ModuleType("pydantic")
+
+    class _BaseModel:
+        model_config = {}
+
+        @classmethod
+        def model_validate(cls, value):
+            return value
+
+        def model_dump(self, **_: object) -> dict:
+            return {}
+
+    def _field(*, default=None, default_factory=None, **__: object):
+        if default_factory is not None:
+            return default_factory()
+        return default
+
+    def _config_dict(**kwargs: object) -> dict:
+        return dict(kwargs)
+
+    fake_pydantic.BaseModel = _BaseModel
+    fake_pydantic.Field = _field
+    fake_pydantic.ConfigDict = _config_dict
+    sys.modules["pydantic"] = fake_pydantic
+
+if "fsspec" not in sys.modules:
+    fake_fsspec = types.ModuleType("fsspec")
+
+    def _filesystem(protocol: str, **_: object) -> object:  # pragma: no cover - stub
+        return object()
+
+    def _open(*args: object, **kwargs: object):  # pragma: no cover - stub
+        raise FileNotFoundError()
+
+    fake_fsspec.filesystem = _filesystem
+    fake_fsspec.open = _open
+
+    core_module = types.ModuleType("fsspec.core")
+
+    def _url_to_fs(uri: str, **_: object):  # pragma: no cover - stub
+        class _DummyFS:
+            def exists(self, path: str) -> bool:
+                return False
+
+        return _DummyFS(), uri
+
+    core_module.url_to_fs = _url_to_fs
+    fake_fsspec.core = core_module
+    sys.modules["fsspec"] = fake_fsspec
+    sys.modules["fsspec.core"] = core_module
+
+from datacore.layers.raw import main as raw_main
+
+
+class FakeMergeBuilder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+
+    def whenMatchedUpdateAll(self, condition: str | None = None):
+        self.calls.append(("whenMatchedUpdateAll", (condition,)))
+        return self
+
+    def whenMatchedUpdate(self, *, set: dict[str, str], condition: str | None = None):
+        self.calls.append(("whenMatchedUpdate", (set, condition)))
+        return self
+
+    def whenNotMatchedInsertAll(self, condition: str | None = None):
+        self.calls.append(("whenNotMatchedInsertAll", (condition,)))
+        return self
+
+    def whenNotMatchedInsert(self, *, values: dict[str, str], condition: str | None = None):
+        self.calls.append(("whenNotMatchedInsert", (values, condition)))
+        return self
+
+    def whenNotMatchedBySourceDelete(self, condition: str | None = None):
+        self.calls.append(("whenNotMatchedBySourceDelete", (condition,)))
+        return self
+
+    def whenMatchedDelete(self, condition: str | None = None):
+        self.calls.append(("whenMatchedDelete", (condition,)))
+        return self
+
+    def execute(self) -> None:
+        self.calls.append(("execute", ()))
+
+
+class FakeDeltaTable:
+    existing_paths: set[str] = set()
+    last_instance: "FakeDeltaTable" | None = None
+
+    def __init__(self) -> None:
+        self.builder = FakeMergeBuilder()
+        self.alias_value: str | None = None
+        self.merge_condition: str | None = None
+        self.source_alias: str | None = None
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.existing_paths.clear()
+        cls.last_instance = None
+
+    @classmethod
+    def isDeltaTable(cls, _spark: object, path: str) -> bool:
+        return path in cls.existing_paths
+
+    @classmethod
+    def forPath(cls, _spark: object, path: str) -> "FakeDeltaTable":
+        cls.existing_paths.add(path)
+        instance = cls()
+        instance.path = path
+        cls.last_instance = instance
+        return instance
+
+    @classmethod
+    def forName(cls, _spark: object, name: str) -> "FakeDeltaTable":
+        instance = cls()
+        instance.table = name
+        cls.last_instance = instance
+        return instance
+
+    def alias(self, alias: str) -> "FakeDeltaTable":
+        self.alias_value = alias
+        return self
+
+    def merge(self, df_alias: SimpleNamespace, condition: str) -> FakeMergeBuilder:
+        self.source_alias = df_alias.alias
+        self.merge_condition = condition
+        return self.builder
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+
+    def format(self, fmt: str) -> "FakeWriter":
+        self.calls.append(("format", (fmt,)))
+        return self
+
+    def options(self, **opts: str) -> "FakeWriter":
+        self.calls.append(("options", (opts,)))
+        return self
+
+    def mode(self, mode: str) -> "FakeWriter":
+        self.calls.append(("mode", (mode,)))
+        return self
+
+    def save(self, path: str) -> None:
+        self.calls.append(("save", (path,)))
+
+    def saveAsTable(self, table: str) -> None:
+        self.calls.append(("saveAsTable", (table,)))
+
+
+class FakeDataFrame:
+    def __init__(self, writer: FakeWriter | None = None) -> None:
+        self._writer = writer or FakeWriter()
+
+    @property
+    def write(self) -> FakeWriter:
+        return self._writer
+
+    def alias(self, alias: str) -> SimpleNamespace:
+        return SimpleNamespace(alias=alias)
+
+
+class FakeAdapter:
+    def __init__(self, uri: str, writer_options: dict[str, str] | None = None) -> None:
+        self.uri = uri
+        self._writer_options = writer_options or {}
+        self.storage_options: dict[str, str] = {}
+
+    def merge_writer_options(self, overrides: dict[str, str]) -> dict[str, str]:
+        return dict(self._writer_options | overrides)
+
+
+@pytest.fixture(autouse=True)
+def patch_delta(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeDeltaTable.reset()
+    monkeypatch.setattr(raw_main, "DeltaTable", FakeDeltaTable)
+
+
+def test_perform_delta_merge_generates_condition() -> None:
+    df = FakeDataFrame()
+    adapter = FakeAdapter("abfss://container@acct.dfs.core.windows.net/path")
+    FakeDeltaTable.existing_paths.add(adapter.uri)
+
+    raw_main._perform_delta_merge(
+        SimpleNamespace(),
+        df,
+        {"key_columns": ["id"]},
+        mode="append",
+        writer_options={},
+        adapter=adapter,
+    )
+
+    instance = FakeDeltaTable.last_instance
+    assert instance is not None
+    assert instance.alias_value == "target"
+    assert instance.source_alias == "source"
+    assert instance.merge_condition == "target.id = source.id"
+    assert ("whenMatchedUpdateAll", (None,)) in instance.builder.calls
+    assert ("whenNotMatchedInsertAll", (None,)) in instance.builder.calls
+    assert instance.builder.calls[-1][0] == "execute"
+
+
+def test_perform_delta_merge_creates_table_when_missing() -> None:
+    writer = FakeWriter()
+    df = FakeDataFrame(writer)
+    adapter = FakeAdapter("abfss://container@acct.dfs.core.windows.net/path")
+
+    raw_main._perform_delta_merge(
+        SimpleNamespace(),
+        df,
+        {"key_columns": ["id"]},
+        mode="overwrite",
+        writer_options={"checkpointLocation": "abfss://chk"},
+        adapter=adapter,
+    )
+
+    instance = FakeDeltaTable.last_instance
+    assert instance is not None
+    assert ("format", ("delta",)) in writer.calls
+    assert ("mode", ("overwrite",)) in writer.calls
+    assert ("save", ("abfss://container@acct.dfs.core.windows.net/path",)) in writer.calls
+    # Initial creation skips merge execution
+    assert instance.builder.calls == []
+
+
+def test_perform_delta_merge_requires_condition_or_keys() -> None:
+    df = FakeDataFrame()
+    adapter = FakeAdapter("abfss://container@acct.dfs.core.windows.net/path")
+
+    with pytest.raises(ValueError):
+        raw_main._perform_delta_merge(
+            SimpleNamespace(),
+            df,
+            {},
+            mode="append",
+            writer_options={},
+            adapter=adapter,
+        )


### PR DESCRIPTION
## Summary
- add Azure storage, secrets, and job adapters with optional MSI/SAS credential handling and Databricks CLI helpers
- register the Azure adapter factory and update the raw layer to handle Delta Lake merge workflows
- cover the new Azure adapters and Delta merge logic with isolated tests using fakes

## Testing
- pytest tests/test_adapters_azure.py tests/test_delta_merge.py

------
https://chatgpt.com/codex/tasks/task_e_690214e890688320bc03ab7959f51293