### PR TITLE
Add GCP adapters and tests

### DIFF
--- a/src/mvp_config_driven/adapters/__init__.py
+++ b/src/mvp_config_driven/adapters/__init__.py
@@ -42,6 +42,13 @@ def _ensure_defaults() -> None:
     else:
         register_adapter_factory("azure", _build_azure)
 
+    try:  # Optional dependency guard - GCP adapters require google SDKs
+        from .gcp import build_default_adapters as _build_gcp
+    except ImportError:  # pragma: no cover - google cloud optional in some deployments
+        pass
+    else:
+        register_adapter_factory("gcp", _build_gcp)
+
     _INITIALIZED = True
 
 

--- a/src/mvp_config_driven/adapters/gcp/__init__.py
+++ b/src/mvp_config_driven/adapters/gcp/__init__.py
@@ -1,0 +1,137 @@
+"""GCP-backed orchestration adapters leveraging Google Cloud services."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Mapping
+
+from ..local import (
+    LocalSecretsAdapter,
+    LocalStorageAdapter,
+    LocalStreamingAdapter,
+    LocalTablesAdapter,
+)
+from ...ports import SecretsPort, StoragePort
+from .job_dataproc import DataprocJobBackend
+from .secret_manager import SecretManagerAdapter
+from .storage_gcs import GCSStorageAdapter
+
+
+def _parse_credentials(value: object) -> object | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text
+    return value
+
+
+def _build_secrets_adapter(config: Mapping[str, Any]) -> SecretsPort:
+    project_id = config.get("project_id") or config.get("project")
+    version = config.get("version") or config.get("secret_version") or "latest"
+    credentials = _parse_credentials(config.get("credentials"))
+    try:
+        return SecretManagerAdapter(
+            project_id=str(project_id) if project_id else None,
+            secret_version=str(version),
+            credentials=credentials,
+        )
+    except ImportError:
+        return LocalSecretsAdapter()
+
+
+def _build_storage_adapter(config: Mapping[str, Any], secrets: SecretsPort) -> StoragePort:
+    project = config.get("project")
+    auth = config.get("auth") or config.get("authentication")
+    credentials = _parse_credentials(config.get("credentials"))
+    credentials_secret = config.get("credentials_secret") or config.get("credentialsSecret")
+    options = config.get("gcsfs_options") or config.get("storage_options") or {}
+    if not isinstance(options, Mapping):
+        options = {}
+    try:
+        return GCSStorageAdapter(
+            project=str(project) if project else None,
+            auth=str(auth) if auth else None,
+            credentials=credentials,
+            credentials_secret=str(credentials_secret) if credentials_secret else None,
+            secret_provider=secrets,
+            gcsfs_options=options,
+        )
+    except ImportError:
+        return LocalStorageAdapter()
+
+
+def _parse_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    return default
+
+
+def _build_job_backend(config: Mapping[str, Any], secrets: SecretsPort) -> DataprocJobBackend:
+    cli_path = config.get("cli_path") or "gcloud"
+    component = config.get("component") or "dataproc"
+    project = config.get("project")
+    region = config.get("region")
+    service_account = config.get("service_account") or config.get("serviceAccount")
+    subnet = config.get("subnet") or config.get("subnetwork")
+    batch_id = config.get("batch_id") or config.get("default_batch_id")
+    auth = config.get("auth") or config.get("authentication")
+    workload_identity_default = True if not auth else auth.strip().lower() in {
+        "workload_identity",
+        "workload-identity",
+        "wi",
+    }
+    workload_identity = _parse_bool(config.get("workload_identity"), workload_identity_default)
+    credentials_secret = config.get("credentials_secret") or config.get("runner_credentials_secret")
+    return DataprocJobBackend(
+        cli_path=str(cli_path),
+        component=str(component),
+        default_project=str(project) if project else None,
+        default_region=str(region) if region else None,
+        default_service_account=str(service_account) if service_account else None,
+        default_subnet=str(subnet) if subnet else None,
+        default_batch_id=str(batch_id) if batch_id else None,
+        workload_identity=workload_identity,
+        secret_provider=secrets,
+        credentials_secret=str(credentials_secret) if credentials_secret else None,
+    )
+
+
+def build_default_adapters(config: Mapping[str, object] | None = None) -> Dict[str, object]:
+    """Instantiate GCP-backed adapters honoring the provided ``config``."""
+
+    config = config or {}
+    secrets_cfg = config.get("secrets") if isinstance(config.get("secrets"), Mapping) else {}
+    secrets = _build_secrets_adapter(secrets_cfg)
+
+    storage_cfg = config.get("storage") if isinstance(config.get("storage"), Mapping) else {}
+    storage = _build_storage_adapter(storage_cfg, secrets)
+
+    job_cfg = config.get("job_backend") if isinstance(config.get("job_backend"), Mapping) else {}
+    job_backend = _build_job_backend(job_cfg, secrets)
+
+    tables = LocalTablesAdapter(storage=storage)
+
+    return {
+        "storage": storage,
+        "tables": tables,
+        "secrets": secrets,
+        "job_backend": job_backend,
+        "streaming": LocalStreamingAdapter(),
+    }
+
+
+__all__ = ["build_default_adapters"]

--- a/src/mvp_config_driven/adapters/gcp/job_dataproc.py
+++ b/src/mvp_config_driven/adapters/gcp/job_dataproc.py
@@ -1,0 +1,160 @@
+"""Dataproc job backend that wraps ``gcloud dataproc batches submit`` invocations."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ...ports import JobBackendPort, SecretsPort
+
+
+class DataprocJobBackend(JobBackendPort):
+    """Job backend that prepares ``gcloud dataproc`` batch commands."""
+
+    def __init__(
+        self,
+        *,
+        cli_path: str = "gcloud",
+        component: str = "dataproc",
+        default_project: str | None = None,
+        default_region: str | None = None,
+        default_service_account: str | None = None,
+        default_subnet: str | None = None,
+        default_batch_id: str | None = None,
+        workload_identity: bool = True,
+        secret_provider: SecretsPort | None = None,
+        credentials_secret: str | None = None,
+    ) -> None:
+        self._cli_path = cli_path
+        self._component = component
+        self._default_project = default_project
+        self._default_region = default_region
+        self._default_service_account = default_service_account
+        self._default_subnet = default_subnet
+        self._default_batch_id = default_batch_id
+        self._workload_identity = workload_identity
+        self._secret_provider = secret_provider
+        self._credentials_secret = credentials_secret
+        self._cached_credentials_path: Path | None = None
+
+    def ensure_engine(self, context: object) -> Any:  # pragma: no cover - remote execution
+        return None
+
+    def stop_engine(self, context: object) -> None:  # pragma: no cover - remote execution
+        return None
+
+    def build_batches_submit_command(
+        self,
+        *,
+        batch_id: str | None = None,
+        main_python_file_uri: str,
+        project: str | None = None,
+        region: str | None = None,
+        service_account: str | None = None,
+        subnet: str | None = None,
+        container_image: str | None = None,
+        jars: Sequence[str] | None = None,
+        python_files: Sequence[str] | None = None,
+        files: Sequence[str] | None = None,
+        properties: Mapping[str, Any] | None = None,
+        labels: Mapping[str, Any] | None = None,
+        args: Sequence[Any] | None = None,
+        extra_flags: Sequence[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> tuple[list[str], dict[str, str]]:
+        """Return the command and environment variables for a Dataproc batch run."""
+
+        resolved_batch = batch_id or self._default_batch_id
+        if not resolved_batch:
+            raise ValueError("batch_id is required to submit a Dataproc batch")
+
+        resolved_project = project or self._default_project
+        resolved_region = region or self._default_region
+        resolved_service_account = service_account or self._default_service_account
+        resolved_subnet = subnet or self._default_subnet
+
+        command: list[str] = [
+            self._cli_path,
+            self._component,
+            "batches",
+            "submit",
+            "pyspark",
+            main_python_file_uri,
+        ]
+        command.extend(["--batch", resolved_batch])
+        if resolved_region:
+            command.extend(["--region", resolved_region])
+        if resolved_project:
+            command.extend(["--project", resolved_project])
+        if resolved_service_account:
+            command.extend(["--service-account", resolved_service_account])
+        if resolved_subnet:
+            command.extend(["--subnet", resolved_subnet])
+        if container_image:
+            command.extend(["--container-image", container_image])
+
+        for jar in jars or []:
+            command.extend(["--jar", str(jar)])
+        for py_file in python_files or []:
+            command.extend(["--py-file", str(py_file)])
+        for file_uri in files or []:
+            command.extend(["--file", str(file_uri)])
+
+        if properties:
+            serialized = self._serialize_mapping(properties)
+            if serialized:
+                command.extend(["--properties", serialized])
+        if labels:
+            serialized = self._serialize_mapping(labels)
+            if serialized:
+                command.extend(["--labels", serialized])
+
+        if extra_flags:
+            command.extend([str(flag) for flag in extra_flags])
+
+        payload_args = [str(argument) for argument in args or []]
+        if payload_args:
+            command.append("--")
+            command.extend(payload_args)
+
+        resolved_env: dict[str, str] = dict(env or {})
+        credentials_path = self._resolve_credentials_path()
+        if credentials_path:
+            resolved_env.setdefault("GOOGLE_APPLICATION_CREDENTIALS", credentials_path)
+
+        return command, resolved_env
+
+    @staticmethod
+    def _serialize_mapping(values: Mapping[str, Any]) -> str:
+        pairs = [f"{key}={values[key]}" for key in sorted(values)]
+        return ",".join(pairs)
+
+    def _resolve_credentials_path(self) -> str | None:
+        if self._workload_identity:
+            return None
+        if not self._credentials_secret or self._secret_provider is None:
+            return None
+        if self._cached_credentials_path and self._cached_credentials_path.exists():
+            return str(self._cached_credentials_path)
+
+        payload = self._secret_provider.get_secret(self._credentials_secret)
+        if not payload:
+            return None
+
+        try:
+            json.loads(payload)
+        except (TypeError, json.JSONDecodeError):
+            return None
+
+        fd, raw_path = tempfile.mkstemp(prefix="dataproc-credentials-", suffix=".json")
+        os.close(fd)
+        path = Path(raw_path)
+        path.write_text(str(payload), encoding="utf-8")
+        self._cached_credentials_path = path
+        return str(path)
+
+
+__all__ = ["DataprocJobBackend"]

--- a/src/mvp_config_driven/adapters/gcp/secret_manager.py
+++ b/src/mvp_config_driven/adapters/gcp/secret_manager.py
@@ -1,0 +1,85 @@
+"""Secrets adapter backed by Google Secret Manager."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from ...ports import SecretsPort
+
+try:  # pragma: no cover - optional dependency in CI environments
+    from google.api_core.exceptions import NotFound  # type: ignore
+except Exception:  # pragma: no cover - google api core optional
+    class NotFound(Exception):  # type: ignore[override]
+        """Fallback NotFound error when google API core is unavailable."""
+
+        pass
+
+try:  # pragma: no cover - optional dependency in CI environments
+    from google.cloud import secretmanager  # type: ignore
+except Exception:  # pragma: no cover - secret manager optional
+    secretmanager = None  # type: ignore
+
+
+class SecretManagerAdapter(SecretsPort):
+    """Resolve secrets from Google Secret Manager."""
+
+    def __init__(
+        self,
+        *,
+        project_id: str | None = None,
+        secret_version: str = "latest",
+        client: object | None = None,
+        credentials: object | None = None,
+        cache_enabled: bool = True,
+    ) -> None:
+        if client is not None:
+            self._client = client
+        else:
+            if secretmanager is None:
+                raise ImportError("google-cloud-secret-manager is required for Secret Manager support")
+            client_kwargs: dict[str, object] = {}
+            if credentials is not None:
+                client_kwargs["credentials"] = credentials
+            self._client = secretmanager.SecretManagerServiceClient(**client_kwargs)
+        self._project_id = project_id
+        self._secret_version = secret_version or "latest"
+        self._cache_enabled = cache_enabled
+        self._cache: Dict[str, Optional[str]] = {}
+
+    def get_secret(self, key: str) -> Optional[str]:
+        if not key:
+            return None
+        if self._cache_enabled and key in self._cache:
+            return self._cache[key]
+
+        resource_name = self._resolve_resource_name(key)
+        if not resource_name:
+            value: Optional[str] = None
+        else:
+            try:
+                response = self._client.access_secret_version(name=resource_name)
+            except NotFound:
+                value = None
+            else:
+                payload = getattr(response, "payload", None)
+                data = getattr(payload, "data", None) if payload is not None else None
+                if isinstance(data, (bytes, bytearray)):
+                    value = data.decode("utf-8")
+                elif data is None:
+                    value = None
+                else:
+                    value = str(data)
+
+        if self._cache_enabled:
+            self._cache[key] = value
+        return value
+
+    def _resolve_resource_name(self, key: str) -> str | None:
+        if key.startswith("projects/"):
+            return key
+        if not self._project_id:
+            return None
+        return f"projects/{self._project_id}/secrets/{key}/versions/{self._secret_version}"
+
+
+__all__ = ["SecretManagerAdapter"]

--- a/src/mvp_config_driven/adapters/gcp/storage_gcs.py
+++ b/src/mvp_config_driven/adapters/gcp/storage_gcs.py
@@ -1,0 +1,145 @@
+"""Google Cloud Storage adapter built on top of :mod:`gcsfs`."""
+
+from __future__ import annotations
+
+import json
+from typing import Mapping
+
+from ...ports import SecretsPort, StoragePort
+
+try:  # pragma: no cover - optional dependency in CI environments
+    import gcsfs  # type: ignore
+except Exception:  # pragma: no cover - gcsfs optional
+    gcsfs = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency in CI environments
+    from google.cloud import storage  # type: ignore
+except Exception:  # pragma: no cover - google cloud optional
+    storage = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency in CI environments
+    from google.oauth2 import service_account  # type: ignore
+except Exception:  # pragma: no cover - service account helpers optional
+    service_account = None  # type: ignore
+
+
+class GCSStorageAdapter(StoragePort):
+    """Storage adapter that relies on Google Cloud credentials resolution."""
+
+    def __init__(
+        self,
+        *,
+        project: str | None = None,
+        auth: str | None = None,
+        credentials: object | None = None,
+        credentials_secret: str | None = None,
+        secret_provider: SecretsPort | None = None,
+        client: object | None = None,
+        filesystem: object | None = None,
+        gcsfs_options: Mapping[str, object] | None = None,
+    ) -> None:
+        self._auth = (auth or "").strip().lower() or None
+        self._secret_provider = secret_provider
+        self._credentials_secret = credentials_secret
+
+        resolved_credentials = self._resolve_credentials(credentials)
+        if resolved_credentials is None and self._should_fetch_credentials():
+            secret_payload = self._fetch_credentials_payload()
+            resolved_credentials = self._resolve_credentials(secret_payload)
+
+        self._credentials = resolved_credentials
+
+        if client is not None:
+            self._client = client
+        else:
+            if storage is None:
+                raise ImportError("google-cloud-storage is required for GCS support")
+            client_kwargs: dict[str, object] = {}
+            if project:
+                client_kwargs["project"] = project
+            if resolved_credentials is not None:
+                client_kwargs["credentials"] = resolved_credentials
+            self._client = storage.Client(**client_kwargs)
+
+        options = dict(gcsfs_options or {})
+        if project and "project" not in options:
+            options["project"] = project
+        if resolved_credentials is not None and "token" not in options:
+            options["token"] = resolved_credentials
+
+        if filesystem is not None:
+            self._filesystem = filesystem
+        else:
+            if gcsfs is None:
+                raise ImportError("gcsfs is required for GCS support")
+            self._filesystem = gcsfs.GCSFileSystem(**options)
+
+    def read_text(self, uri: str) -> str:
+        with self._filesystem.open(uri, "rb") as handle:  # type: ignore[call-arg]
+            data = handle.read()
+        if isinstance(data, str):
+            return data
+        return data.decode("utf-8")
+
+    def exists(self, uri: str) -> bool:
+        bucket_name, blob_name = self._split(uri)
+        bucket = self._client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        try:
+            return bool(blob.exists(self._client))
+        except TypeError:  # pragma: no cover - some stubs ignore the argument
+            return bool(blob.exists())
+
+    def write_text(self, uri: str, content: str) -> None:
+        bucket_name, blob_name = self._split(uri)
+        bucket = self._client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        blob.upload_from_string(content.encode("utf-8"))
+
+    def _should_fetch_credentials(self) -> bool:
+        if not self._credentials_secret or self._secret_provider is None:
+            return False
+        if self._auth and self._auth not in {"service_account", "service-account"}:
+            return False
+        return True
+
+    def _fetch_credentials_payload(self) -> object | None:
+        if not self._credentials_secret or self._secret_provider is None:
+            return None
+        return self._secret_provider.get_secret(self._credentials_secret)
+
+    @staticmethod
+    def _normalize_credentials_payload(payload: object | None) -> object | None:
+        if payload is None:
+            return None
+        if isinstance(payload, str):
+            text = payload.strip()
+            if not text:
+                return None
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                return text
+            return parsed
+        if isinstance(payload, Mapping):
+            return dict(payload)
+        return payload
+
+    def _resolve_credentials(self, payload: object | None) -> object | None:
+        normalized = self._normalize_credentials_payload(payload)
+        if normalized is None:
+            return None
+        if isinstance(normalized, Mapping) and service_account is not None:
+            return service_account.Credentials.from_service_account_info(dict(normalized))
+        return normalized
+
+    @staticmethod
+    def _split(uri: str) -> tuple[str, str]:
+        if not uri.startswith("gs://"):
+            raise ValueError(f"Unsupported URI: {uri}")
+        path = uri[5:]
+        bucket, _, blob = path.partition("/")
+        return bucket, blob
+
+
+__all__ = ["GCSStorageAdapter"]

--- a/tests/test_adapters_gcp.py
+++ b/tests/test_adapters_gcp.py
@@ -1,0 +1,367 @@
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+if "pydantic" not in sys.modules:
+    fake_pydantic = types.ModuleType("pydantic")
+
+    class _BaseModel:
+        model_config = {}
+
+        @classmethod
+        def model_validate(cls, value: object) -> object:
+            return value
+
+        def model_dump(self, **_: object) -> dict[str, Any]:
+            return {}
+
+    def _field(*, default: object = None, default_factory=None, **__: object) -> object:
+        if default_factory is not None:
+            return default_factory()
+        return default
+
+    def _config_dict(**kwargs: object) -> dict[str, object]:
+        return dict(kwargs)
+
+    fake_pydantic.BaseModel = _BaseModel
+    fake_pydantic.Field = _field
+    fake_pydantic.ConfigDict = _config_dict
+    sys.modules["pydantic"] = fake_pydantic
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs for optional google cloud dependencies used by the adapters
+# ---------------------------------------------------------------------------
+
+if "gcsfs" not in sys.modules:
+    fake_gcsfs = types.ModuleType("gcsfs")
+    fake_gcsfs._STORE: dict[tuple[str, str], bytes] = {}
+
+    class _FakeGCSHandle:
+        def __init__(self, store: dict[tuple[str, str], bytes], uri: str, mode: str) -> None:
+            self._store = store
+            self._uri = uri
+            self._mode = mode
+
+        def __enter__(self) -> "_FakeGCSHandle":
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - context manager protocol
+            return None
+
+        def read(self) -> bytes | str:
+            bucket, blob = self._split(self._uri)
+            data = self._store.get((bucket, blob), b"")
+            if "b" in self._mode:
+                return data
+            return data.decode("utf-8")
+
+        def write(self, data: bytes | str) -> None:  # pragma: no cover - unused helper
+            bucket, blob = self._split(self._uri)
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            self._store[(bucket, blob)] = data
+
+        @staticmethod
+        def _split(uri: str) -> tuple[str, str]:
+            if not uri.startswith("gs://"):
+                raise ValueError(uri)
+            path = uri[5:]
+            bucket, _, blob = path.partition("/")
+            return bucket, blob
+
+    class FakeGCSFileSystem:
+        def __init__(self, **options: object) -> None:
+            self.options = options
+
+        def open(self, uri: str, mode: str = "rb") -> _FakeGCSHandle:
+            return _FakeGCSHandle(fake_gcsfs._STORE, uri, mode)
+
+    fake_gcsfs.GCSFileSystem = FakeGCSFileSystem
+    sys.modules["gcsfs"] = fake_gcsfs
+
+if "google" not in sys.modules:
+    sys.modules["google"] = types.ModuleType("google")
+
+if "google.cloud" not in sys.modules:
+    sys.modules["google.cloud"] = types.ModuleType("google.cloud")
+
+if "google.api_core" not in sys.modules:
+    api_core = types.ModuleType("google.api_core")
+    exceptions_module = types.ModuleType("google.api_core.exceptions")
+
+    class NotFound(Exception):
+        pass
+
+    exceptions_module.NotFound = NotFound
+    api_core.exceptions = exceptions_module
+    sys.modules["google.api_core"] = api_core
+    sys.modules["google.api_core.exceptions"] = exceptions_module
+else:
+    exceptions_module = sys.modules.setdefault(
+        "google.api_core.exceptions", types.ModuleType("google.api_core.exceptions")
+    )
+    if not hasattr(exceptions_module, "NotFound"):
+        exceptions_module.NotFound = type("NotFound", (Exception,), {})
+
+if "google.cloud.storage" not in sys.modules:
+    storage_module = types.ModuleType("google.cloud.storage")
+    storage_module._STORE: dict[tuple[str, str], bytes] = {}
+
+    class FakeBlob:
+        def __init__(self, bucket: "FakeBucket", name: str) -> None:
+            self._bucket = bucket
+            self._name = name
+
+        def upload_from_string(self, data: bytes) -> None:
+            storage_module._STORE[(self._bucket.name, self._name)] = data
+
+        def download_as_bytes(self) -> bytes:
+            return storage_module._STORE[(self._bucket.name, self._name)]
+
+        def exists(self, client: object | None = None) -> bool:  # pragma: no cover - simple proxy
+            return (self._bucket.name, self._name) in storage_module._STORE
+
+    class FakeBucket:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def blob(self, name: str) -> FakeBlob:
+            return FakeBlob(self, name)
+
+    class FakeClient:
+        def __init__(self, project: str | None = None, credentials: object | None = None) -> None:
+            self.project = project
+            self.credentials = credentials
+
+        def bucket(self, name: str) -> FakeBucket:
+            return FakeBucket(name)
+
+    storage_module.Client = FakeClient
+    storage_module.Blob = FakeBlob
+    sys.modules["google.cloud.storage"] = storage_module
+else:
+    storage_module = sys.modules["google.cloud.storage"]
+
+if "google.cloud.secretmanager" not in sys.modules:
+    secretmanager_module = types.ModuleType("google.cloud.secretmanager")
+    secretmanager_module._STORE: dict[str, bytes] = {}
+
+    class FakePayload:
+        def __init__(self, data: bytes) -> None:
+            self.data = data
+
+    class FakeSecretResponse:
+        def __init__(self, data: bytes) -> None:
+            self.payload = FakePayload(data)
+
+    class FakeSecretManagerServiceClient:
+        def __init__(self, credentials: object | None = None) -> None:
+            self.credentials = credentials
+            self.calls: list[str] = []
+
+        def access_secret_version(self, *, name: str) -> FakeSecretResponse:
+            self.calls.append(name)
+            if name not in secretmanager_module._STORE:
+                raise exceptions_module.NotFound()
+            return FakeSecretResponse(secretmanager_module._STORE[name])
+
+    secretmanager_module.SecretManagerServiceClient = FakeSecretManagerServiceClient
+    sys.modules["google.cloud.secretmanager"] = secretmanager_module
+else:
+    secretmanager_module = sys.modules["google.cloud.secretmanager"]
+
+if "google.oauth2" not in sys.modules:
+    oauth_module = types.ModuleType("google.oauth2")
+    sys.modules["google.oauth2"] = oauth_module
+else:
+    oauth_module = sys.modules["google.oauth2"]
+
+if "google.oauth2.service_account" not in sys.modules:
+    service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class FakeServiceAccountCredentials:
+        def __init__(self, info: dict[str, Any]) -> None:
+            self.info = dict(info)
+
+        @classmethod
+        def from_service_account_info(cls, info: dict[str, Any]) -> "FakeServiceAccountCredentials":
+            return cls(info)
+
+    service_account_module.Credentials = FakeServiceAccountCredentials
+    sys.modules["google.oauth2.service_account"] = service_account_module
+    oauth_module.service_account = service_account_module
+
+
+from mvp_config_driven.adapters.gcp.job_dataproc import DataprocJobBackend
+from mvp_config_driven.adapters.gcp.secret_manager import SecretManagerAdapter
+from mvp_config_driven.adapters.gcp.storage_gcs import GCSStorageAdapter
+
+
+class DummySecretProvider:
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self._secrets = secrets
+        self.calls: list[str] = []
+
+    def get_secret(self, key: str) -> str | None:
+        self.calls.append(key)
+        return self._secrets.get(key)
+
+
+def _reset_stores() -> None:
+    shared_store: dict[tuple[str, str], bytes] = {}
+    sys.modules["gcsfs"]._STORE = shared_store
+    sys.modules["google.cloud.storage"]._STORE = shared_store
+    sys.modules["google.cloud.secretmanager"]._STORE.clear()
+
+
+def test_gcs_storage_adapter_roundtrip() -> None:
+    _reset_stores()
+    store = sys.modules["google.cloud.storage"]._STORE
+    provider = DummySecretProvider({})
+    adapter = GCSStorageAdapter(
+        project="demo",
+        secret_provider=provider,
+        gcsfs_options={},
+        client=storage_module.Client(project="demo"),
+    )
+
+    uri = "gs://configs/env.yml"
+    adapter.write_text(uri, "timezone: UTC")
+
+    assert adapter.exists(uri)
+    assert adapter.read_text(uri) == "timezone: UTC"
+    assert not adapter.exists("gs://configs/missing.yml")
+
+
+def test_gcs_storage_adapter_resolves_credentials_secret() -> None:
+    _reset_stores()
+    payload = json.dumps({"type": "service_account", "project_id": "demo"})
+    provider = DummySecretProvider({"gcs": payload})
+
+    adapter = GCSStorageAdapter(
+        project="demo",
+        auth="service_account",
+        secret_provider=provider,
+        credentials_secret="gcs",
+        gcsfs_options={},
+        client=storage_module.Client(project="demo"),
+    )
+
+    filesystem = adapter._filesystem  # type: ignore[attr-defined]
+    assert isinstance(filesystem.options["token"].info, dict)  # type: ignore[index]
+    assert provider.calls == ["gcs"]
+
+
+def test_secret_manager_adapter_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_stores()
+    secretmanager_module._STORE[
+        "projects/demo/secrets/token/versions/latest"
+    ] = b"super-secret"
+
+    client = secretmanager_module.SecretManagerServiceClient()
+    adapter = SecretManagerAdapter(project_id="demo", client=client)
+
+    assert adapter.get_secret("token") == "super-secret"
+    assert adapter.get_secret("projects/demo/secrets/token/versions/latest") == "super-secret"
+    assert adapter.get_secret("missing") is None
+    # cache hit
+    assert adapter.get_secret("token") == "super-secret"
+    assert client.calls.count("projects/demo/secrets/token/versions/latest") == 2
+
+
+def test_dataproc_job_backend_builds_command(tmp_path: Path) -> None:
+    _reset_stores()
+    secrets = DummySecretProvider({
+        "runner": json.dumps({"type": "service_account", "client_email": "svc@demo"})
+    })
+
+    backend = DataprocJobBackend(
+        default_project="demo",
+        default_region="us-central1",
+        default_service_account="svc@demo",
+        secret_provider=secrets,
+        credentials_secret="runner",
+        workload_identity=False,
+    )
+
+    command, env = backend.build_batches_submit_command(
+        batch_id="pipeline-1",
+        main_python_file_uri="gs://scripts/entry.py",
+        jars=["gs://libs/pipeline.whl"],
+        properties={"spark.executor.instances": "2"},
+        labels={"env": "prod", "team": "data"},
+        args=["--layer", "raw"],
+    )
+
+    assert command[:6] == [
+        "gcloud",
+        "dataproc",
+        "batches",
+        "submit",
+        "pyspark",
+        "gs://scripts/entry.py",
+    ]
+    assert "--batch" in command
+    assert "--region" in command
+    assert "--project" in command
+    assert "--service-account" in command
+    assert command[-3:] == ["--", "--layer", "raw"]
+
+    cred_path = Path(env["GOOGLE_APPLICATION_CREDENTIALS"])
+    assert cred_path.exists()
+    data = cred_path.read_text(encoding="utf-8")
+    assert json.loads(data)["client_email"] == "svc@demo"
+    os.unlink(cred_path)
+    assert secrets.calls == ["runner"]
+
+
+def test_build_adapters_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_stores()
+    secretmanager_module._STORE[
+        "projects/demo/secrets/gcs/versions/latest"
+    ] = json.dumps({"type": "service_account", "project_id": "demo"}).encode("utf-8")
+    secretmanager_module._STORE[
+        "projects/demo/secrets/runner/versions/latest"
+    ] = json.dumps({"type": "service_account", "client_email": "svc@demo"}).encode("utf-8")
+
+    import mvp_config_driven.adapters as adapters_module
+
+    monkeypatch.setattr(adapters_module, "_FACTORIES", {})
+    monkeypatch.setattr(adapters_module, "_INITIALIZED", False)
+
+    adapters = adapters_module.build_adapters(
+        platform="gcp",
+        config={
+            "secrets": {"project_id": "demo"},
+            "storage": {"project": "demo", "auth": "service_account", "credentials_secret": "gcs"},
+            "job_backend": {
+                "project": "demo",
+                "region": "us-central1",
+                "service_account": "svc@demo",
+                "credentials_secret": "runner",
+            },
+        },
+    )
+
+    from mvp_config_driven.adapters.gcp.job_dataproc import DataprocJobBackend as BackendCls
+    from mvp_config_driven.adapters.gcp.secret_manager import SecretManagerAdapter as SecretsCls
+    from mvp_config_driven.adapters.gcp.storage_gcs import GCSStorageAdapter as StorageCls
+
+    assert isinstance(adapters["secrets"], SecretsCls)
+    assert isinstance(adapters["storage"], StorageCls)
+    assert isinstance(adapters["job_backend"], BackendCls)
+
+    command, env = adapters["job_backend"].build_batches_submit_command(
+        batch_id="run-1", main_python_file_uri="gs://scripts/entry.py", args=["--layer", "raw"]
+    )
+    assert command[0] == "gcloud"
+    cred_path = Path(env.get("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/missing"))
+    if cred_path.exists():
+        os.unlink(cred_path)


### PR DESCRIPTION
## Summary
- implement Google Cloud Storage adapter that integrates with gcsfs and secret-provided credentials
- add Secret Manager and Dataproc job backend implementations plus adapter factory wiring
- cover the new adapters with pytest suites using local stubs for Google Cloud services

## Testing
- pytest tests/test_adapters_gcp.py

------
https://chatgpt.com/codex/tasks/task_e_690219fd9a348320b51cf7bd04a99cfc