### PR TITLE
Add documentation for architecture, config, deployment, and local e2e

### DIFF
--- a/docs/architecture/adr-001-ports-and-adapters.md
+++ b/docs/architecture/adr-001-ports-and-adapters.md
@@ -1,0 +1,36 @@
+# ADR-001: Ports and Adapters Architecture
+
+- **Status:** Accepted
+- **Date:** 2025-10-29
+
+## Context
+
+The MVP configuration-driven platform needs to ingest configuration bundles, orchestrate processing pipelines, and expose integrations with third-party services. Previous prototypes mixed domain logic with infrastructure concerns, making the system difficult to test, extend, and deploy across heterogeneous environments.
+
+## Decision
+
+Adopt a Ports and Adapters (Hexagonal) architecture with three primary layers:
+
+1. **Domain Core** – Pure business rules implemented in `src/mvp_core` (entities, value objects, domain services). These components are infrastructure-agnostic and operate only on domain abstractions.
+2. **Application Services** – Use cases living under `src/mvp_app` that orchestrate domain operations. They depend on ports that describe required infrastructure capabilities (e.g., configuration repositories, orchestration runners, secret stores).
+3. **Adapters** – Infrastructure implementations located in `src/mvp_infra` and `tools/`. Adapters implement the ports for persistence, messaging, CLI orchestration, and provider-specific deployment tasks. They are composed via dependency injection using configuration defined in `cfg/` and `config/`.
+
+Data flows from adapters into the domain through input ports, while application services invoke output ports to interact with external systems. This structure allows the CLI and automation scripts in `scripts/` to reuse domain and application services without importing infrastructure details directly.
+
+## Rationale
+
+- **Testability:** Domain and application layers can be tested with in-memory doubles by mocking the ports.
+- **Replaceability:** Provider-specific adapters (AWS, Azure, GCP) can be swapped without changing domain logic.
+- **Configurability:** Configuration-driven wiring lets deployments select adapters via YAML manifests, aligning with the project's goal of configurable behavior.
+- **Parallel Development:** Teams can work on domain logic and adapters independently, converging through well-defined ports.
+
+## Consequences
+
+- Requires disciplined boundary management to prevent domain leakage of infrastructure concerns.
+- Onboarding must include education about port interfaces and adapter registration patterns.
+- Additional scaffolding is necessary for dependency injection and configuration resolution, but provides long-term maintainability benefits.
+
+## Related Documents
+
+- [`docs/config/config-spec.md`](../config/config-spec.md) — Defines configuration manifests that bind adapters to ports.
+- [`docs/deploy`](../deploy) — Provider-specific deployment guides that rely on adapters implementing deployment ports.

--- a/docs/config/config-spec.md
+++ b/docs/config/config-spec.md
@@ -1,0 +1,136 @@
+# Configuration Specification
+
+This document describes the configuration model used by the MVP configuration-driven platform. It covers the YAML manifest shape, the canonical JSON Schema, and the override resolution order that binds adapters to ports.
+
+## YAML Manifest Structure
+
+Configuration bundles live under `cfg/` and are typically loaded via the CLI (`scripts/configure.py`). Each bundle contains:
+
+```yaml
+version: 1
+metadata:
+  name: sample-pipeline
+  environment: dev
+  labels:
+    owner: data-platform
+adapters:
+  orchestrator:
+    type: airflow
+    connection: file://orchestration/airflow.cfg
+  storage:
+    type: s3
+    bucket: my-config-bucket
+  secrets:
+    type: aws-secrets-manager
+    region: us-east-1
+pipelines:
+  - id: ingest-customers
+    schedule: "0 * * * *"
+    entrypoint: src/mvp_app/pipelines/customers:run
+    inputs:
+      - port: storage
+        path: customers/raw/
+    outputs:
+      - port: storage
+        path: customers/processed/
+    hooks:
+      on_success:
+        - type: notifier
+          port: orchestrator
+          template: templates/success-email.j2
+```
+
+### Field Summary
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `version` | integer | yes | Configuration schema version. Used for compatibility checks. |
+| `metadata` | object | yes | Identifiers and labels applied to deployments. |
+| `adapters` | object | yes | Maps port names to adapter definitions. Each adapter declares a `type` and arbitrary settings. |
+| `pipelines` | array | yes | List of pipeline definitions orchestrated by the application services. |
+| `pipelines[].inputs` / `outputs` | array | no | Declares how pipelines consume and emit data through configured ports. |
+| `pipelines[].hooks` | object | no | Optional lifecycle hooks bound to adapters. |
+
+## JSON Schema
+
+The following JSON Schema governs validation. It is shipped with the codebase at `config/schema/config.v1.json` and mirrored here for reference (abridged for readability).
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MVP Configuration Bundle",
+  "type": "object",
+  "required": ["version", "metadata", "adapters", "pipelines"],
+  "properties": {
+    "version": {"type": "integer", "enum": [1]},
+    "metadata": {
+      "type": "object",
+      "required": ["name", "environment"],
+      "properties": {
+        "name": {"type": "string"},
+        "environment": {"type": "string"},
+        "labels": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      },
+      "additionalProperties": false
+    },
+    "adapters": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "pipelines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "entrypoint"],
+        "properties": {
+          "id": {"type": "string"},
+          "schedule": {"type": "string"},
+          "entrypoint": {"type": "string"},
+          "inputs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["port"],
+              "properties": {
+                "port": {"type": "string"},
+                "path": {"type": "string"}
+              },
+              "additionalProperties": true
+            }
+          },
+          "outputs": {"$ref": "#/properties/pipelines/items/properties/inputs"},
+          "hooks": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## Override Resolution
+
+Configuration values can be overridden at runtime by combining multiple sources. The resolver applies the following precedence (highest priority first):
+
+1. **Command-line flags** – `scripts/configure.py --set key=value` or `scripts/run_pipeline.py --override` inject values into the effective configuration.
+2. **Environment variables** – Prefixed with `MVP_CFG__` and parsed into nested keys (double underscores become path separators).
+3. **Profile-specific YAML** – Files named `<bundle>.<profile>.yaml` located in `cfg/overrides/` merge onto the base bundle when `--profile` is provided.
+4. **Base bundle YAML** – The canonical configuration checked into version control.
+
+Overrides are merged using deep dictionary semantics: scalars replace existing values, lists are replaced in full unless the CLI flag `--merge-lists` is passed (which concatenates unique entries), and objects are merged recursively. All overrides are validated against the JSON Schema before the configuration is instantiated into port adapters.

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -1,0 +1,80 @@
+# AWS Deployment Guide
+
+This guide describes how to install prerequisites, authenticate, and deploy the MVP configuration-driven platform on AWS.
+
+## Prerequisites
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+brew install awscli || sudo apt-get install -y awscli
+```
+
+Ensure Terraform is installed if infrastructure provisioning is required:
+
+```bash
+brew install terraform || sudo apt-get install -y terraform
+```
+
+## Authentication
+
+1. Configure AWS credentials for the deployment account:
+   ```bash
+   aws configure --profile mvp-deployer
+   ```
+   Provide the Access Key ID, Secret Access Key, default region, and output format.
+2. Export the profile for CLI tools:
+   ```bash
+   export AWS_PROFILE=mvp-deployer
+   export AWS_DEFAULT_REGION=us-east-1
+   ```
+3. If using SSO, log in with:
+   ```bash
+   aws sso login --profile mvp-deployer
+   ```
+
+## Deployment Steps
+
+### 1. Package Configuration Bundle
+
+```bash
+scripts/package_bundle.py --bundle cfg/bundles/prod.yaml --output build/bundle-aws.tar.gz
+```
+
+### 2. Provision Infrastructure (optional)
+
+```bash
+cd deploy/terraform/aws
+terraform init
+terraform apply -var-file=prod.tfvars
+cd -
+```
+
+### 3. Deploy Adapters and Services
+
+```bash
+scripts/deploy.py \
+  --bundle build/bundle-aws.tar.gz \
+  --provider aws \
+  --orchestrator ecs \
+  --storage s3://mvp-artifacts-prod \
+  --secrets arn:aws:secretsmanager:us-east-1:123456789012:secret:mvp/config
+```
+
+### 4. Verify Deployment
+
+```bash
+aws ecs list-services --cluster mvp-prod
+aws logs tail /aws/ecs/mvp-prod --follow
+```
+
+## Example End-to-End Command
+
+```bash
+AWS_PROFILE=mvp-deployer \
+scripts/run_pipeline.py \
+  --bundle cfg/bundles/prod.yaml \
+  --pipeline ingest-customers \
+  --context aws
+```

--- a/docs/deploy/azure.md
+++ b/docs/deploy/azure.md
@@ -1,0 +1,81 @@
+# Azure Deployment Guide
+
+Follow this guide to deploy the MVP configuration-driven platform to Microsoft Azure using the provided CLI tooling.
+
+## Prerequisites
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+brew install azure-cli || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+```
+
+Install optional infrastructure tooling:
+
+```bash
+brew install terraform || sudo apt-get install -y terraform
+```
+
+## Authentication
+
+1. Log in with Azure CLI:
+   ```bash
+   az login
+   ```
+2. Set the active subscription:
+   ```bash
+   az account set --subscription "MVP Production"
+   ```
+3. For service principals, use:
+   ```bash
+   az login --service-principal \
+     --username "$AZURE_CLIENT_ID" \
+     --password "$AZURE_CLIENT_SECRET" \
+     --tenant "$AZURE_TENANT_ID"
+   ```
+
+## Deployment Steps
+
+### 1. Package Configuration Bundle
+
+```bash
+scripts/package_bundle.py --bundle cfg/bundles/prod.yaml --output build/bundle-azure.tar.gz
+```
+
+### 2. Provision Infrastructure (optional)
+
+```bash
+cd deploy/terraform/azure
+terraform init
+terraform apply -var-file=prod.tfvars
+cd -
+```
+
+### 3. Deploy Adapters and Services
+
+```bash
+scripts/deploy.py \
+  --bundle build/bundle-azure.tar.gz \
+  --provider azure \
+  --orchestrator data-factory \
+  --storage https://mvpstorageprod.blob.core.windows.net/config \
+  --secrets https://mvp-kv-prod.vault.azure.net/
+```
+
+### 4. Verify Deployment
+
+```bash
+az datafactory pipeline list --factory-name mvp-prod --resource-group mvp-rg
+az monitor metrics list --resource /subscriptions/<SUB>/resourceGroups/mvp-rg/providers/Microsoft.Web/sites/mvp-orchestrator
+```
+
+## Example End-to-End Command
+
+```bash
+AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv) \
+scripts/run_pipeline.py \
+  --bundle cfg/bundles/prod.yaml \
+  --pipeline ingest-customers \
+  --context azure
+```

--- a/docs/deploy/gcp.md
+++ b/docs/deploy/gcp.md
@@ -1,0 +1,83 @@
+# GCP Deployment Guide
+
+Use this guide to deploy the MVP configuration-driven platform on Google Cloud Platform.
+
+## Prerequisites
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+brew install --cask google-cloud-sdk || sudo apt-get install -y google-cloud-sdk
+```
+
+Install optional tooling:
+
+```bash
+brew install terraform || sudo apt-get install -y terraform
+```
+
+## Authentication
+
+1. Initialize the gcloud CLI:
+   ```bash
+   gcloud init
+   ```
+2. Set the project:
+   ```bash
+   gcloud config set project mvp-prod
+   ```
+3. For service accounts, activate credentials:
+   ```bash
+   gcloud auth activate-service-account mvp-deployer@mvp-prod.iam.gserviceaccount.com \
+     --key-file ~/.config/gcloud/mvp-deployer.json
+   ```
+4. Configure Application Default Credentials for libraries:
+   ```bash
+   gcloud auth application-default login
+   ```
+
+## Deployment Steps
+
+### 1. Package Configuration Bundle
+
+```bash
+scripts/package_bundle.py --bundle cfg/bundles/prod.yaml --output build/bundle-gcp.tar.gz
+```
+
+### 2. Provision Infrastructure (optional)
+
+```bash
+cd deploy/terraform/gcp
+terraform init
+terraform apply -var-file=prod.tfvars
+cd -
+```
+
+### 3. Deploy Adapters and Services
+
+```bash
+scripts/deploy.py \
+  --bundle build/bundle-gcp.tar.gz \
+  --provider gcp \
+  --orchestrator composer \
+  --storage gs://mvp-artifacts-prod \
+  --secrets projects/mvp-prod/secrets/mvp-config
+```
+
+### 4. Verify Deployment
+
+```bash
+gcloud composer environments list --locations us-central1
+gcloud logging read "resource.type=cloud_composer_environment" --limit 50
+```
+
+## Example End-to-End Command
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/mvp-deployer.json \
+scripts/run_pipeline.py \
+  --bundle cfg/bundles/prod.yaml \
+  --pipeline ingest-customers \
+  --context gcp
+```

--- a/docs/running/local_e2e.md
+++ b/docs/running/local_e2e.md
@@ -1,0 +1,103 @@
+# Local End-to-End Execution
+
+This document outlines how to run a full end-to-end (E2E) workflow locally using the file-based (`file://`) adapters and the CLI orchestration tools included in this repository.
+
+## Overview
+
+Local E2E runs simulate production execution while keeping dependencies minimal. The setup uses:
+
+- File-backed storage adapters (`file://data/...`) for inputs and outputs.
+- The local orchestrator adapter that schedules pipelines via the CLI.
+- In-memory or `.env`-based secret adapters for credentials.
+
+## Prerequisites
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Ensure the sample data set is available:
+
+```bash
+make seed-sample-data
+```
+
+## Configure the Bundle
+
+1. Copy the sample bundle:
+   ```bash
+   cp cfg/bundles/dev.yaml cfg/bundles/local-e2e.yaml
+   ```
+2. Update `cfg/bundles/local-e2e.yaml` to use file-based adapters:
+   ```yaml
+   adapters:
+     orchestrator:
+       type: local-cli
+     storage:
+       type: filesystem
+       base_path: file://data/local
+     secrets:
+       type: dotenv
+       path: .env.local
+   ```
+3. Add any pipeline-specific overrides in `cfg/overrides/local-e2e.yaml` if required.
+
+## Launch the Orchestrator
+
+The local orchestrator translates bundle definitions into CLI invocations.
+
+```bash
+scripts/orchestrator.py \
+  --bundle cfg/bundles/local-e2e.yaml \
+  --watch
+```
+
+- `--watch` monitors the filesystem for new inputs under `data/local/inbox/` and triggers the corresponding pipelines.
+- Logs are written to `run/logs/local/` for inspection.
+
+## Execute a Pipeline Manually
+
+You can also drive a pipeline directly:
+
+```bash
+scripts/run_pipeline.py \
+  --bundle cfg/bundles/local-e2e.yaml \
+  --pipeline ingest-customers \
+  --input file://data/local/inbox/customers.csv \
+  --output file://data/local/outbox/customers.parquet
+```
+
+The CLI resolves configuration in the following order:
+
+1. Command-line flags passed to `run_pipeline.py`.
+2. Environment variables prefixed with `MVP_CFG__`.
+3. Overrides in `cfg/overrides/local-e2e.yaml`.
+4. Base bundle at `cfg/bundles/local-e2e.yaml`.
+
+## Validate Results
+
+1. Inspect the output files:
+   ```bash
+   ls data/local/outbox
+   ```
+2. Tail the orchestrator logs:
+   ```bash
+   tail -f run/logs/local/orchestrator.log
+   ```
+3. Run automated assertions:
+   ```bash
+   pytest tests/e2e/test_local_pipeline.py -k ingest_customers
+   ```
+
+## Cleanup
+
+After testing, reset the workspace:
+
+```bash
+rm -rf data/local/outbox/*
+rm -rf run/logs/local/*
+```
+
+This restores the environment for the next E2E iteration.


### PR DESCRIPTION
## Summary
- add ADR describing the project's ports-and-adapters architecture
- document configuration bundle structure, validation schema, and override behavior
- provide deployment guides for AWS, Azure, GCP, and local end-to-end execution

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_6902240fefb883209c7d82261290b1dc