### PR TITLE
feat(io,ops,validation): multi-source/multi-sink + ops declarativas + validations++

### DIFF
--- a/datacore/cli/main.py
+++ b/datacore/cli/main.py
@@ -35,19 +35,36 @@ def cmd_run(args: argparse.Namespace) -> None:
     data = _load_config(args.config)
     validate_config(data)
     configure_logging(level=args.log_level)
-    run_layer_plan(
+    results = run_layer_plan(
         layer=args.layer,
         config=data,
         platform_name=args.platform,
         environment=args.env,
         dry_run=args.dry_run,
+        fail_fast=args.fail_fast,
     )
+    if args.dry_run:
+        print(json.dumps({"plan": results}, indent=2, default=str))
+    else:
+        LOGGER.info("Resultados de ejecución: %s", results)
 
 
 def cmd_plan(args: argparse.Namespace) -> None:
     data = _load_config(args.config)
     validate_config(data)
-    print(json.dumps({"datasets": [d.get("name") for d in data.get("datasets", [])]}, indent=2))
+    layers = sorted({d.get("layer") for d in data.get("datasets", [])})
+    plans: list[dict[str, Any]] = []
+    for layer in layers:
+        plans.extend(
+            run_layer_plan(
+                layer=layer,
+                config=data,
+                platform_name=args.platform,
+                environment=args.env,
+                dry_run=True,
+            )
+        )
+    print(json.dumps({"datasets": plans}, indent=2, default=str))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -76,10 +93,13 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--env", required=False, help="Entorno (dev/test/prod)")
     run_parser.add_argument("--log-level", default="INFO", help="Nivel de logging")
     run_parser.add_argument("--dry-run", action="store_true", help="Solo genera el plan")
+    run_parser.add_argument("--fail-fast", action="store_true", help="Detener al primer error")
     run_parser.set_defaults(func=cmd_run)
 
     plan_parser = subparsers.add_parser("plan", help="Muestra el plan de datasets")
     plan_parser.add_argument("--config", required=True, help="Archivo YAML del proyecto")
+    plan_parser.add_argument("--platform", required=False, help="Plataforma cloud (azure/aws/gcp)")
+    plan_parser.add_argument("--env", required=False, help="Entorno (dev/test/prod)")
     plan_parser.set_defaults(func=cmd_plan)
 
     return parser

--- a/datacore/cli/main.py
+++ b/datacore/cli/main.py
@@ -46,7 +46,6 @@ def cmd_run(args: argparse.Namespace) -> None:
     if args.dry_run:
         payload = {
             "run_id": results["run_id"],
-            "layer": args.layer,
             "datasets": results["datasets"],
         }
         print(json.dumps(payload, indent=2, default=str))

--- a/datacore/cli/main.py
+++ b/datacore/cli/main.py
@@ -47,6 +47,7 @@ def cmd_run(args: argparse.Namespace) -> None:
         payload = {
             "run_id": results["run_id"],
             "datasets": results["datasets"],
+            "plan": results["datasets"],
         }
         print(json.dumps(payload, indent=2, default=str))
     else:
@@ -65,6 +66,7 @@ def cmd_plan(args: argparse.Namespace) -> None:
             platform_name=args.platform,
             environment=args.env,
             dry_run=True,
+            fail_fast=args.fail_fast,
         )
         layer_plans.append(
             {
@@ -109,6 +111,7 @@ def build_parser() -> argparse.ArgumentParser:
     plan_parser.add_argument("--config", required=True, help="Archivo YAML del proyecto")
     plan_parser.add_argument("--platform", required=False, help="Plataforma cloud (azure/aws/gcp)")
     plan_parser.add_argument("--env", required=False, help="Entorno (dev/test/prod)")
+    plan_parser.add_argument("--fail-fast", action="store_true", help="Detener al primer error")
     plan_parser.set_defaults(func=cmd_plan)
 
     return parser

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -23,22 +23,72 @@
           "name": {"type": "string"},
           "layer": {"enum": ["raw", "bronze", "silver", "gold"]},
           "source": {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {"type": "string"},
-              "format": {"type": "string"},
-              "uri": {"type": "string"},
-              "options": {"type": "object"}
-            },
-            "additionalProperties": true
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "storage",
+                      "jdbc",
+                      "api_rest",
+                      "api_graphql",
+                      "kafka",
+                      "event_hubs",
+                      "nosql"
+                    ]
+                  },
+                  "format": {"type": "string"},
+                  "uri": {"type": "string"},
+                  "options": {"type": "object"},
+                  "infer_schema": {"type": "boolean"},
+                  "record_path": {"type": ["string", "array"]},
+                  "flatten": {"type": "boolean"}
+                },
+                "additionalProperties": true
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": {"type": "string"},
+                    "format": {"type": "string"},
+                    "uri": {"type": "string"},
+                    "options": {"type": "object"}
+                  },
+                  "additionalProperties": true
+                }
+              }
+            ]
           },
           "transform": {
             "type": "object",
             "properties": {
               "sql": {"type": "array", "items": {"type": "string"}},
               "udf": {"type": "array", "items": {"type": "string"}},
-              "validation": {"type": "object"}
+              "add_ingestion_ts": {"type": "boolean"},
+              "ops": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {"type": "string"},
+                    {
+                      "type": "object",
+                      "minProperties": 1,
+                      "maxProperties": 1,
+                      "additionalProperties": true
+                    }
+                  ]
+                }
+              },
+              "validation": {
+                "type": "object",
+                "additionalProperties": true
+              }
             },
             "additionalProperties": true
           },
@@ -46,13 +96,18 @@
             "type": "object",
             "required": ["type"],
             "properties": {
-              "type": {"type": "string"},
+              "type": {
+                "type": "string",
+                "enum": ["storage", "warehouse", "nosql", "kafka", "event_hubs"]
+              },
               "format": {"type": "string"},
               "uri": {"type": "string"},
               "engine": {"type": "string"},
               "table": {"type": "string"},
               "mode": {"type": "string"},
-              "partition_by": {"type": "array", "items": {"type": "string"}}
+              "partition_by": {"type": "array", "items": {"type": "string"}},
+              "mergeSchema": {"type": "boolean"},
+              "merge_schema": {"type": "boolean"}
             },
             "additionalProperties": true
           },
@@ -61,6 +116,7 @@
             "properties": {
               "mode": {"enum": ["append", "merge"]},
               "keys": {"type": "array", "items": {"type": "string"}},
+              "order_by": {"type": "array", "items": {"type": "string"}},
               "watermark_column": {"type": "string"}
             },
             "additionalProperties": false
@@ -69,7 +125,19 @@
             "type": "object",
             "properties": {
               "enabled": {"type": "boolean"},
-              "trigger": {"type": "string"}
+              "trigger": {"type": "string"},
+              "watermark": {"type": "string"},
+              "watermark_column": {"type": "string"},
+              "checkpoint": {"type": "string"}
+            },
+            "additionalProperties": false
+          },
+          "merge_strategy": {
+            "type": "object",
+            "properties": {
+              "keys": {"type": "array", "items": {"type": "string"}},
+              "prefer": {"enum": ["newest", "left", "coalesce"]},
+              "order_by": {"type": "array", "items": {"type": "string"}}
             },
             "additionalProperties": false
           }

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -35,6 +35,7 @@
                       "jdbc",
                       "api_rest",
                       "api_graphql",
+                      "endpoint",
                       "kafka",
                       "event_hubs",
                       "nosql"
@@ -43,6 +44,7 @@
                   "format": {"type": "string"},
                   "uri": {"type": "string"},
                   "options": {"type": "object"},
+                  "read_options": {"type": "object"},
                   "infer_schema": {"type": "boolean"},
                   "record_path": {"type": ["string", "array"]},
                   "flatten": {"type": "boolean"}
@@ -58,7 +60,8 @@
                     "type": {"type": "string"},
                     "format": {"type": "string"},
                     "uri": {"type": "string"},
-                    "options": {"type": "object"}
+                    "options": {"type": "object"},
+                    "read_options": {"type": "object"}
                   },
                   "additionalProperties": true
                 }
@@ -87,6 +90,13 @@
               },
               "validation": {
                 "type": "object",
+                "properties": {
+                  "rules": {
+                    "type": "array",
+                    "items": {"type": "object"}
+                  },
+                  "quarantine_sink": {"type": "object"}
+                },
                 "additionalProperties": true
               }
             },
@@ -107,19 +117,21 @@
               "mode": {"type": "string"},
               "partition_by": {"type": "array", "items": {"type": "string"}},
               "mergeSchema": {"type": "boolean"},
-              "merge_schema": {"type": "boolean"}
+              "merge_schema": {"type": "boolean"},
+              "write_options": {"type": "object"},
+              "read_options": {"type": "object"}
             },
             "additionalProperties": true
           },
           "incremental": {
             "type": "object",
             "properties": {
-              "mode": {"enum": ["append", "merge"]},
+              "mode": {"enum": ["full", "append", "merge"]},
               "keys": {"type": "array", "items": {"type": "string"}},
               "order_by": {"type": "array", "items": {"type": "string"}},
               "watermark_column": {"type": "string"}
             },
-            "additionalProperties": false
+            "additionalProperties": true
           },
           "streaming": {
             "type": "object",

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -77,16 +77,7 @@
         "lower_bound": {"type": ["number", "integer"]},
         "upper_bound": {"type": ["number", "integer"]},
         "num_partitions": {"type": "integer", "minimum": 1},
-        "fetchsize": {"type": "integer", "minimum": 1},
-        "watermark": {
-          "type": "object",
-          "properties": {
-            "column": {"type": "string"},
-            "delay_threshold": {"type": "string"}
-          },
-          "required": ["column"],
-          "additionalProperties": false
-        }
+        "fetchsize": {"type": "integer", "minimum": 1}
       }
     },
     "sink": {
@@ -114,7 +105,15 @@
           "oneOf": [
             {"type": "integer", "minimum": 1},
             {"$ref": "#/definitions/string_array"},
-            {"type": "object"}
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "columns": {"$ref": "#/definitions/string_array"},
+                "numPartitions": {"type": "integer", "minimum": 1}
+              },
+              "required": ["columns"]
+            }
           ]
         },
         "target_file_size_mb": {"type": "integer", "minimum": 1},
@@ -180,16 +179,7 @@
         "enabled": {"type": "boolean"},
         "trigger": {"type": "string"},
         "checkpoint": {"type": "string"},
-        "checkpoint_location": {"type": "string"},
-        "watermark": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "column": {"type": "string"},
-            "delay_threshold": {"type": "string"}
-          },
-          "required": ["column"]
-        }
+        "checkpoint_location": {"type": "string"}
       }
     },
     "dataset": {
@@ -211,7 +201,7 @@
         },
         "transform": {
           "type": "object",
-          "additionalProperties": true,
+          "additionalProperties": false,
           "properties": {
             "sql": {"type": "array", "items": {"type": "string"}},
             "udf": {"type": "array", "items": {"type": "string"}},
@@ -229,8 +219,7 @@
                   }
                 ]
               }
-            },
-            "validation": {"$ref": "#/definitions/validation"}
+            }
           }
         },
         "validation": {"$ref": "#/definitions/validation"},

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -2,161 +2,233 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["project", "environment", "platform", "datasets"],
+  "additionalProperties": false,
   "properties": {
     "project": {"type": "string"},
     "environment": {"enum": ["dev", "test", "prod"]},
     "platform": {"enum": ["azure", "aws", "gcp"]},
     "spark": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "shuffle_partitions": {"type": "integer"},
-        "extra_conf": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}}
-      },
-      "additionalProperties": false
+        "extra_conf": {
+          "type": "object",
+          "additionalProperties": {"type": ["string", "number", "boolean"]}
+        }
+      }
     },
     "datasets": {
       "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name", "layer", "source", "sink"],
-        "properties": {
-          "name": {"type": "string"},
-          "layer": {"enum": ["raw", "bronze", "silver", "gold"]},
-          "source": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["type"],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "storage",
-                      "jdbc",
-                      "api_rest",
-                      "api_graphql",
-                      "endpoint",
-                      "kafka",
-                      "event_hubs",
-                      "nosql"
-                    ]
-                  },
-                  "format": {"type": "string"},
-                  "uri": {"type": "string"},
-                  "options": {"type": "object"},
-                  "read_options": {"type": "object"},
-                  "infer_schema": {"type": "boolean"},
-                  "record_path": {"type": ["string", "array"]},
-                  "flatten": {"type": "boolean"}
-                },
-                "additionalProperties": true
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["type"],
-                  "properties": {
-                    "type": {"type": "string"},
-                    "format": {"type": "string"},
-                    "uri": {"type": "string"},
-                    "options": {"type": "object"},
-                    "read_options": {"type": "object"}
-                  },
-                  "additionalProperties": true
-                }
-              }
-            ]
-          },
-          "transform": {
-            "type": "object",
-            "properties": {
-              "sql": {"type": "array", "items": {"type": "string"}},
-              "udf": {"type": "array", "items": {"type": "string"}},
-              "add_ingestion_ts": {"type": "boolean"},
-              "ops": {
-                "type": "array",
-                "items": {
-                  "oneOf": [
-                    {"type": "string"},
-                    {
-                      "type": "object",
-                      "minProperties": 1,
-                      "maxProperties": 1,
-                      "additionalProperties": true
-                    }
-                  ]
-                }
-              },
-              "validation": {
-                "type": "object",
-                "properties": {
-                  "rules": {
-                    "type": "array",
-                    "items": {"type": "object"}
-                  },
-                  "quarantine_sink": {"type": "object"}
-                },
-                "additionalProperties": true
-              }
-            },
-            "additionalProperties": true
-          },
-          "sink": {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["storage", "warehouse", "nosql", "kafka", "event_hubs"]
-              },
-              "format": {"type": "string"},
-              "uri": {"type": "string"},
-              "engine": {"type": "string"},
-              "table": {"type": "string"},
-              "mode": {"type": "string"},
-              "partition_by": {"type": "array", "items": {"type": "string"}},
-              "mergeSchema": {"type": "boolean"},
-              "merge_schema": {"type": "boolean"},
-              "write_options": {"type": "object"},
-              "read_options": {"type": "object"}
-            },
-            "additionalProperties": true
-          },
-          "incremental": {
-            "type": "object",
-            "properties": {
-              "mode": {"enum": ["full", "append", "merge"]},
-              "keys": {"type": "array", "items": {"type": "string"}},
-              "order_by": {"type": "array", "items": {"type": "string"}},
-              "watermark_column": {"type": "string"}
-            },
-            "additionalProperties": true
-          },
-          "streaming": {
-            "type": "object",
-            "properties": {
-              "enabled": {"type": "boolean"},
-              "trigger": {"type": "string"},
-              "watermark": {"type": "string"},
-              "watermark_column": {"type": "string"},
-              "checkpoint": {"type": "string"}
-            },
-            "additionalProperties": false
-          },
-          "merge_strategy": {
-            "type": "object",
-            "properties": {
-              "keys": {"type": "array", "items": {"type": "string"}},
-              "prefer": {"enum": ["newest", "left", "coalesce"]},
-              "order_by": {"type": "array", "items": {"type": "string"}}
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": true
-      }
+      "items": {"$ref": "#/definitions/dataset"}
     }
   },
-  "additionalProperties": false
+  "definitions": {
+    "string_map": {
+      "type": "object",
+      "additionalProperties": {"type": ["string", "number", "boolean"]}
+    },
+    "string_array": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "storage",
+            "jdbc",
+            "endpoint",
+            "api_rest",
+            "api_graphql",
+            "kafka",
+            "event_hubs",
+            "nosql"
+          ]
+        },
+        "format": {"type": "string"},
+        "backend": {"type": "string"},
+        "uri": {"type": "string"},
+        "url": {"type": "string"},
+        "table": {"type": "string"},
+        "query": {"type": "string"},
+        "options": {"$ref": "#/definitions/string_map"},
+        "read_options": {"$ref": "#/definitions/string_map"},
+        "infer_schema": {"type": "boolean"},
+        "record_path": {
+          "oneOf": [
+            {"type": "string"},
+            {"$ref": "#/definitions/string_array"}
+          ]
+        },
+        "flatten": {"type": "boolean"},
+        "flatten_depth": {"type": "integer", "minimum": 0},
+        "schema": {"type": ["object", "string"]},
+        "payload_format": {"type": "string"},
+        "pagination": {"type": "object"},
+        "auth": {"type": "object"},
+        "pushdown": {"type": "boolean"},
+        "predicate_pushdown": {"type": "boolean"},
+        "partition_column": {"type": "string"},
+        "lower_bound": {"type": ["number", "integer"]},
+        "upper_bound": {"type": ["number", "integer"]},
+        "num_partitions": {"type": "integer", "minimum": 1},
+        "fetchsize": {"type": "integer", "minimum": 1},
+        "watermark": {
+          "type": "object",
+          "properties": {
+            "column": {"type": "string"},
+            "delay_threshold": {"type": "string"}
+          },
+          "required": ["column"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "sink": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["storage", "warehouse", "nosql", "kafka", "event_hubs"]
+        },
+        "format": {"type": "string"},
+        "backend": {"type": "string"},
+        "uri": {"type": "string"},
+        "engine": {"type": "string"},
+        "table": {"type": "string"},
+        "mode": {"type": "string"},
+        "partition_by": {"$ref": "#/definitions/string_array"},
+        "merge_schema": {"type": "boolean"},
+        "options": {"$ref": "#/definitions/string_map"},
+        "write_options": {"$ref": "#/definitions/string_map"},
+        "compression": {"type": "string"},
+        "coalesce": {"type": "integer", "minimum": 1},
+        "repartition": {
+          "oneOf": [
+            {"type": "integer", "minimum": 1},
+            {"$ref": "#/definitions/string_array"},
+            {"type": "object"}
+          ]
+        },
+        "file_size_mb": {"type": "integer", "minimum": 1},
+        "atomic": {"type": "boolean"},
+        "temporary_gcs_bucket": {"type": "string"},
+        "intermediate_format": {"type": "string"},
+        "checkpoint_location": {"type": "string"}
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["check"],
+            "properties": {
+              "check": {"type": "string"},
+              "columns": {"$ref": "#/definitions/string_array"},
+              "column": {"type": "string"},
+              "severity": {"enum": ["error", "warn"]},
+              "threshold": {"type": "number", "minimum": 0, "maximum": 1},
+              "params": {"type": "object"},
+              "on_fail": {"type": "string"}
+            },
+            "additionalProperties": true
+          }
+        },
+        "quarantine_sink": {"$ref": "#/definitions/sink"}
+      }
+    },
+    "incremental": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": {"enum": ["full", "append", "merge"]},
+        "keys": {"$ref": "#/definitions/string_array"},
+        "order_by": {"$ref": "#/definitions/string_array"},
+        "watermark": {
+          "type": "object",
+          "properties": {
+            "column": {"type": "string"},
+            "delay_threshold": {"type": "string"}
+          },
+          "required": ["column"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "streaming": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "trigger": {"type": "string"},
+        "checkpoint": {"type": "string"}
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "required": ["name", "layer", "source", "sink"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {"type": "string"},
+        "layer": {"enum": ["raw", "bronze", "silver", "gold"]},
+        "source": {
+          "oneOf": [
+            {"$ref": "#/definitions/source"},
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {"$ref": "#/definitions/source"}
+            }
+          ]
+        },
+        "transform": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "sql": {"type": "array", "items": {"type": "string"}},
+            "udf": {"type": "array", "items": {"type": "string"}},
+            "add_ingestion_ts": {"type": "boolean"},
+            "ops": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {"type": "string"},
+                  {
+                    "type": "object",
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "additionalProperties": true
+                  }
+                ]
+              }
+            },
+            "validation": {"$ref": "#/definitions/validation"}
+          }
+        },
+        "sink": {"$ref": "#/definitions/sink"},
+        "incremental": {"$ref": "#/definitions/incremental"},
+        "streaming": {"$ref": "#/definitions/streaming"},
+        "merge_strategy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keys": {"$ref": "#/definitions/string_array"},
+            "prefer": {"enum": ["newest", "left", "coalesce"]},
+            "order_by": {"$ref": "#/definitions/string_array"}
+          }
+        }
+      }
+    }
+  }
 }

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -103,7 +103,7 @@
         "uri": {"type": "string"},
         "engine": {"type": "string"},
         "table": {"type": "string"},
-        "mode": {"type": "string"},
+        "mode": {"type": "string", "enum": ["append", "overwrite", "overwrite_partitions", "merge"]},
         "partition_by": {"$ref": "#/definitions/string_array"},
         "merge_schema": {"type": "boolean"},
         "options": {"$ref": "#/definitions/string_map"},
@@ -117,11 +117,18 @@
             {"type": "object"}
           ]
         },
+        "target_file_size_mb": {"type": "integer", "minimum": 1},
         "file_size_mb": {"type": "integer", "minimum": 1},
         "atomic": {"type": "boolean"},
         "temporary_gcs_bucket": {"type": "string"},
         "intermediate_format": {"type": "string"},
-        "checkpoint_location": {"type": "string"}
+        "checkpoint_location": {"type": "string"},
+        "reject_options": {"$ref": "#/definitions/string_map"},
+        "metrics_compression": {"type": "string"},
+        "batch_size": {"type": "integer", "minimum": 1},
+        "truncate_safe": {"type": "boolean"},
+        "isolation_level": {"type": "string"},
+        "create_table_options": {"type": "string"}
       }
     },
     "validation": {
@@ -140,7 +147,7 @@
               "severity": {"enum": ["error", "warn"]},
               "threshold": {"type": "number", "minimum": 0, "maximum": 1},
               "params": {"type": "object"},
-              "on_fail": {"type": "string"}
+              "on_fail": {"type": "string", "enum": ["quarantine", "reject", "none"]}
             },
             "additionalProperties": true
           }
@@ -172,7 +179,17 @@
       "properties": {
         "enabled": {"type": "boolean"},
         "trigger": {"type": "string"},
-        "checkpoint": {"type": "string"}
+        "checkpoint": {"type": "string"},
+        "checkpoint_location": {"type": "string"},
+        "watermark": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "column": {"type": "string"},
+            "delay_threshold": {"type": "string"}
+          },
+          "required": ["column"]
+        }
       }
     },
     "dataset": {
@@ -216,6 +233,7 @@
             "validation": {"$ref": "#/definitions/validation"}
           }
         },
+        "validation": {"$ref": "#/definitions/validation"},
         "sink": {"$ref": "#/definitions/sink"},
         "incremental": {"$ref": "#/definitions/incremental"},
         "streaming": {"$ref": "#/definitions/streaming"},

--- a/datacore/config/schemas/plan.schema.json
+++ b/datacore/config/schemas/plan.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["run_id", "datasets"],
+  "properties": {
+    "run_id": {"type": "string"},
+    "datasets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "layer",
+          "status",
+          "run_id",
+          "source_plan",
+          "transform_plan",
+          "validation_plan",
+          "incremental_plan",
+          "streaming_plan",
+          "sink_plan",
+          "issues"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "name": {"type": "string"},
+          "layer": {"type": "string", "enum": ["raw", "bronze", "silver", "gold"]},
+          "status": {"type": "string"},
+          "run_id": {"type": "string"},
+          "issues": {"type": "array", "items": {"type": "string"}},
+          "source_plan": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "type": {"type": "string"},
+                    "format": {"type": ["string", "null"]},
+                    "uri": {"type": ["string", "null"]},
+                    "table": {"type": ["string", "null"]},
+                    "url": {"type": ["string", "null"]},
+                    "options": {"type": "object"},
+                    "read_options": {"type": "object"},
+                    "partitioning": {"type": "object"}
+                  }
+                }
+              },
+              "merge_strategy": {"type": ["object", "null"]}
+            }
+          },
+          "transform_plan": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "sql": {"type": "array"},
+              "ops": {"type": "array"},
+              "udf": {"type": "array"},
+              "add_ingestion_ts": {"type": "boolean"}
+            }
+          },
+          "validation_plan": {"type": "object"},
+          "incremental_plan": {"type": "object"},
+          "streaming_plan": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {"type": "boolean"},
+              "trigger": {"type": ["string", "null"]},
+              "checkpoint_location": {"type": ["string", "null"]},
+              "watermark": {"type": ["object", "null"]}
+            }
+          },
+          "sink_plan": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "type": {"type": "string"},
+              "format": {"type": ["string", "null"]},
+              "uri": {"type": ["string", "null"]},
+              "engine": {"type": ["string", "null"]},
+              "table": {"type": ["string", "null"]},
+              "mode": {"type": ["string", "null"]},
+              "partition_by": {"type": ["array", "null"]},
+              "merge_schema": {"type": ["boolean", "null"]},
+              "compression": {"type": ["string", "null"]},
+              "coalesce": {"type": ["integer", "null"]},
+              "repartition": {},
+              "target_file_size_mb": {"type": ["integer", "null"]},
+              "checkpoint_location": {"type": ["string", "null"]},
+              "options": {"type": "object"},
+              "write_options": {"type": "object"}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/datacore/config/schemas/plan.schema.json
+++ b/datacore/config/schemas/plan.schema.json
@@ -7,94 +7,101 @@
     "run_id": {"type": "string"},
     "datasets": {
       "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "name",
-          "layer",
-          "status",
-          "run_id",
-          "source_plan",
-          "transform_plan",
-          "validation_plan",
-          "incremental_plan",
-          "streaming_plan",
-          "sink_plan",
-          "issues"
-        ],
-        "additionalProperties": true,
-        "properties": {
-          "name": {"type": "string"},
-          "layer": {"type": "string", "enum": ["raw", "bronze", "silver", "gold"]},
-          "status": {"type": "string"},
-          "run_id": {"type": "string"},
-          "issues": {"type": "array", "items": {"type": "string"}},
-          "source_plan": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "sources": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "type": {"type": "string"},
-                    "format": {"type": ["string", "null"]},
-                    "uri": {"type": ["string", "null"]},
-                    "table": {"type": ["string", "null"]},
-                    "url": {"type": ["string", "null"]},
-                    "options": {"type": "object"},
-                    "read_options": {"type": "object"},
-                    "partitioning": {"type": "object"}
-                  }
+      "items": {"$ref": "#/definitions/dataset_plan"}
+    },
+    "plan": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/dataset_plan"}
+    }
+  },
+  "definitions": {
+    "dataset_plan": {
+      "type": "object",
+      "required": [
+        "name",
+        "layer",
+        "status",
+        "run_id",
+        "source_plan",
+        "transform_plan",
+        "validation_plan",
+        "incremental_plan",
+        "streaming_plan",
+        "sink_plan",
+        "issues"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "name": {"type": "string"},
+        "layer": {"type": "string", "enum": ["raw", "bronze", "silver", "gold"]},
+        "status": {"type": "string"},
+        "run_id": {"type": "string"},
+        "issues": {"type": "array", "items": {"type": "string"}},
+        "source_plan": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "type": {"type": "string"},
+                  "format": {"type": ["string", "null"]},
+                  "uri": {"type": ["string", "null"]},
+                  "table": {"type": ["string", "null"]},
+                  "url": {"type": ["string", "null"]},
+                  "options": {"type": "object"},
+                  "read_options": {"type": "object"},
+                  "partitioning": {"type": "object"}
                 }
-              },
-              "merge_strategy": {"type": ["object", "null"]}
-            }
-          },
-          "transform_plan": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "sql": {"type": "array"},
-              "ops": {"type": "array"},
-              "udf": {"type": "array"},
-              "add_ingestion_ts": {"type": "boolean"}
-            }
-          },
-          "validation_plan": {"type": "object"},
-          "incremental_plan": {"type": "object"},
-          "streaming_plan": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "enabled": {"type": "boolean"},
-              "trigger": {"type": ["string", "null"]},
-              "checkpoint_location": {"type": ["string", "null"]},
-              "watermark": {"type": ["object", "null"]}
-            }
-          },
-          "sink_plan": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "type": {"type": "string"},
-              "format": {"type": ["string", "null"]},
-              "uri": {"type": ["string", "null"]},
-              "engine": {"type": ["string", "null"]},
-              "table": {"type": ["string", "null"]},
-              "mode": {"type": ["string", "null"]},
-              "partition_by": {"type": ["array", "null"]},
-              "merge_schema": {"type": ["boolean", "null"]},
-              "compression": {"type": ["string", "null"]},
-              "coalesce": {"type": ["integer", "null"]},
-              "repartition": {},
-              "target_file_size_mb": {"type": ["integer", "null"]},
-              "checkpoint_location": {"type": ["string", "null"]},
-              "options": {"type": "object"},
-              "write_options": {"type": "object"}
-            }
+              }
+            },
+            "merge_strategy": {"type": ["object", "null"]}
+          }
+        },
+        "transform_plan": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "sql": {"type": "array"},
+            "ops": {"type": "array"},
+            "udf": {"type": "array"},
+            "add_ingestion_ts": {"type": "boolean"}
+          }
+        },
+        "validation_plan": {"type": "object"},
+        "incremental_plan": {"type": "object"},
+        "streaming_plan": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "trigger": {"type": ["string", "null"]},
+            "checkpoint_location": {"type": ["string", "null"]},
+            "watermark": {"type": ["object", "null"]}
+          }
+        },
+        "sink_plan": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {"type": "string"},
+            "format": {"type": ["string", "null"]},
+            "uri": {"type": ["string", "null"]},
+            "engine": {"type": ["string", "null"]},
+            "table": {"type": ["string", "null"]},
+            "mode": {"type": ["string", "null"]},
+            "partition_by": {"type": ["array", "null"]},
+            "merge_schema": {"type": ["boolean", "null"]},
+            "compression": {"type": ["string", "null"]},
+            "coalesce": {"type": ["integer", "null"]},
+            "repartition": {},
+            "target_file_size_mb": {"type": ["integer", "null"]},
+            "checkpoint_location": {"type": ["string", "null"]},
+            "options": {"type": "object"},
+            "write_options": {"type": "object"}
           }
         }
       }

--- a/datacore/config/schemas/project.schema.json
+++ b/datacore/config/schemas/project.schema.json
@@ -22,14 +22,104 @@
         "properties": {
           "name": {"type": "string"},
           "layer": {"enum": ["raw", "bronze", "silver", "gold"]},
-          "source": {"type": "object"},
-          "transform": {"type": "object"},
-          "sink": {"type": "object"},
+          "source": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "storage",
+                      "jdbc",
+                      "api_rest",
+                      "api_graphql",
+                      "kafka",
+                      "event_hubs",
+                      "nosql"
+                    ]
+                  },
+                  "format": {"type": "string"},
+                  "uri": {"type": "string"},
+                  "options": {"type": "object"},
+                  "infer_schema": {"type": "boolean"},
+                  "record_path": {"type": ["string", "array"]},
+                  "flatten": {"type": "boolean"}
+                },
+                "additionalProperties": true
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": {"type": "string"},
+                    "format": {"type": "string"},
+                    "uri": {"type": "string"},
+                    "options": {"type": "object"},
+                    "infer_schema": {"type": "boolean"},
+                    "record_path": {"type": ["string", "array"]},
+                    "flatten": {"type": "boolean"}
+                  },
+                  "additionalProperties": true
+                }
+              }
+            ]
+          },
+          "transform": {
+            "type": "object",
+            "properties": {
+              "sql": {"type": "array", "items": {"type": "string"}},
+              "udf": {"type": "array", "items": {"type": "string"}},
+              "add_ingestion_ts": {"type": "boolean"},
+              "ops": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {"type": "string"},
+                    {
+                      "type": "object",
+                      "minProperties": 1,
+                      "maxProperties": 1,
+                      "additionalProperties": true
+                    }
+                  ]
+                }
+              },
+              "validation": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "sink": {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["storage", "warehouse", "nosql", "kafka", "event_hubs"]
+              },
+              "format": {"type": "string"},
+              "uri": {"type": "string"},
+              "engine": {"type": "string"},
+              "table": {"type": "string"},
+              "mode": {"type": "string"},
+              "partition_by": {"type": "array", "items": {"type": "string"}},
+              "mergeSchema": {"type": "boolean"},
+              "merge_schema": {"type": "boolean"}
+            },
+            "additionalProperties": true
+          },
           "incremental": {
             "type": "object",
             "properties": {
               "mode": {"enum": ["append", "merge"]},
               "keys": {"type": "array", "items": {"type": "string"}},
+              "order_by": {"type": "array", "items": {"type": "string"}},
               "watermark_column": {"type": "string"}
             },
             "additionalProperties": false
@@ -38,7 +128,19 @@
             "type": "object",
             "properties": {
               "enabled": {"type": "boolean"},
-              "trigger": {"type": "string"}
+              "trigger": {"type": "string"},
+              "watermark": {"type": "string"},
+              "watermark_column": {"type": "string"},
+              "checkpoint": {"type": "string"}
+            },
+            "additionalProperties": false
+          },
+          "merge_strategy": {
+            "type": "object",
+            "properties": {
+              "keys": {"type": "array", "items": {"type": "string"}},
+              "prefer": {"enum": ["newest", "left", "coalesce"]},
+              "order_by": {"type": "array", "items": {"type": "string"}}
             },
             "additionalProperties": false
           }

--- a/datacore/config/schemas/project.schema.json
+++ b/datacore/config/schemas/project.schema.json
@@ -35,6 +35,7 @@
                       "jdbc",
                       "api_rest",
                       "api_graphql",
+                      "endpoint",
                       "kafka",
                       "event_hubs",
                       "nosql"
@@ -43,6 +44,7 @@
                   "format": {"type": "string"},
                   "uri": {"type": "string"},
                   "options": {"type": "object"},
+                  "read_options": {"type": "object"},
                   "infer_schema": {"type": "boolean"},
                   "record_path": {"type": ["string", "array"]},
                   "flatten": {"type": "boolean"}
@@ -59,6 +61,7 @@
                     "format": {"type": "string"},
                     "uri": {"type": "string"},
                     "options": {"type": "object"},
+                    "read_options": {"type": "object"},
                     "infer_schema": {"type": "boolean"},
                     "record_path": {"type": ["string", "array"]},
                     "flatten": {"type": "boolean"}
@@ -90,6 +93,13 @@
               },
               "validation": {
                 "type": "object",
+                "properties": {
+                  "rules": {
+                    "type": "array",
+                    "items": {"type": "object"}
+                  },
+                  "quarantine_sink": {"type": "object"}
+                },
                 "additionalProperties": true
               }
             },
@@ -110,19 +120,21 @@
               "mode": {"type": "string"},
               "partition_by": {"type": "array", "items": {"type": "string"}},
               "mergeSchema": {"type": "boolean"},
-              "merge_schema": {"type": "boolean"}
+              "merge_schema": {"type": "boolean"},
+              "write_options": {"type": "object"},
+              "read_options": {"type": "object"}
             },
             "additionalProperties": true
           },
           "incremental": {
             "type": "object",
             "properties": {
-              "mode": {"enum": ["append", "merge"]},
+              "mode": {"enum": ["full", "append", "merge"]},
               "keys": {"type": "array", "items": {"type": "string"}},
               "order_by": {"type": "array", "items": {"type": "string"}},
               "watermark_column": {"type": "string"}
             },
-            "additionalProperties": false
+            "additionalProperties": true
           },
           "streaming": {
             "type": "object",

--- a/datacore/config/schemas/project.schema.json
+++ b/datacore/config/schemas/project.schema.json
@@ -2,164 +2,252 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["project", "environment", "platform", "datasets"],
+  "additionalProperties": false,
   "properties": {
     "project": {"type": "string"},
     "environment": {"enum": ["dev", "test", "prod"]},
     "platform": {"enum": ["azure", "aws", "gcp"]},
     "spark": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "shuffle_partitions": {"type": "integer"},
-        "extra_conf": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}}
-      },
-      "additionalProperties": false
+        "extra_conf": {
+          "type": "object",
+          "additionalProperties": {"type": ["string", "number", "boolean"]}
+        }
+      }
     },
     "datasets": {
       "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name", "layer", "source", "sink"],
-        "properties": {
-          "name": {"type": "string"},
-          "layer": {"enum": ["raw", "bronze", "silver", "gold"]},
-          "source": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["type"],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "storage",
-                      "jdbc",
-                      "api_rest",
-                      "api_graphql",
-                      "endpoint",
-                      "kafka",
-                      "event_hubs",
-                      "nosql"
-                    ]
-                  },
-                  "format": {"type": "string"},
-                  "uri": {"type": "string"},
-                  "options": {"type": "object"},
-                  "read_options": {"type": "object"},
-                  "infer_schema": {"type": "boolean"},
-                  "record_path": {"type": ["string", "array"]},
-                  "flatten": {"type": "boolean"}
-                },
-                "additionalProperties": true
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["type"],
-                  "properties": {
-                    "type": {"type": "string"},
-                    "format": {"type": "string"},
-                    "uri": {"type": "string"},
-                    "options": {"type": "object"},
-                    "read_options": {"type": "object"},
-                    "infer_schema": {"type": "boolean"},
-                    "record_path": {"type": ["string", "array"]},
-                    "flatten": {"type": "boolean"}
-                  },
-                  "additionalProperties": true
-                }
-              }
-            ]
-          },
-          "transform": {
-            "type": "object",
-            "properties": {
-              "sql": {"type": "array", "items": {"type": "string"}},
-              "udf": {"type": "array", "items": {"type": "string"}},
-              "add_ingestion_ts": {"type": "boolean"},
-              "ops": {
-                "type": "array",
-                "items": {
-                  "oneOf": [
-                    {"type": "string"},
-                    {
-                      "type": "object",
-                      "minProperties": 1,
-                      "maxProperties": 1,
-                      "additionalProperties": true
-                    }
-                  ]
-                }
-              },
-              "validation": {
-                "type": "object",
-                "properties": {
-                  "rules": {
-                    "type": "array",
-                    "items": {"type": "object"}
-                  },
-                  "quarantine_sink": {"type": "object"}
-                },
-                "additionalProperties": true
-              }
-            },
-            "additionalProperties": true
-          },
-          "sink": {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["storage", "warehouse", "nosql", "kafka", "event_hubs"]
-              },
-              "format": {"type": "string"},
-              "uri": {"type": "string"},
-              "engine": {"type": "string"},
-              "table": {"type": "string"},
-              "mode": {"type": "string"},
-              "partition_by": {"type": "array", "items": {"type": "string"}},
-              "mergeSchema": {"type": "boolean"},
-              "merge_schema": {"type": "boolean"},
-              "write_options": {"type": "object"},
-              "read_options": {"type": "object"}
-            },
-            "additionalProperties": true
-          },
-          "incremental": {
-            "type": "object",
-            "properties": {
-              "mode": {"enum": ["full", "append", "merge"]},
-              "keys": {"type": "array", "items": {"type": "string"}},
-              "order_by": {"type": "array", "items": {"type": "string"}},
-              "watermark_column": {"type": "string"}
-            },
-            "additionalProperties": true
-          },
-          "streaming": {
-            "type": "object",
-            "properties": {
-              "enabled": {"type": "boolean"},
-              "trigger": {"type": "string"},
-              "watermark": {"type": "string"},
-              "watermark_column": {"type": "string"},
-              "checkpoint": {"type": "string"}
-            },
-            "additionalProperties": false
-          },
-          "merge_strategy": {
-            "type": "object",
-            "properties": {
-              "keys": {"type": "array", "items": {"type": "string"}},
-              "prefer": {"enum": ["newest", "left", "coalesce"]},
-              "order_by": {"type": "array", "items": {"type": "string"}}
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": true
-      }
+      "items": {"$ref": "#/definitions/dataset"}
     }
   },
-  "additionalProperties": false
+  "definitions": {
+    "string_map": {
+      "type": "object",
+      "additionalProperties": {"type": ["string", "number", "boolean"]}
+    },
+    "string_array": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "storage",
+            "jdbc",
+            "endpoint",
+            "api_rest",
+            "api_graphql",
+            "kafka",
+            "event_hubs",
+            "nosql"
+          ]
+        },
+        "format": {"type": "string"},
+        "backend": {"type": "string"},
+        "uri": {"type": "string"},
+        "url": {"type": "string"},
+        "table": {"type": "string"},
+        "query": {"type": "string"},
+        "options": {"$ref": "#/definitions/string_map"},
+        "read_options": {"$ref": "#/definitions/string_map"},
+        "infer_schema": {"type": "boolean"},
+        "record_path": {
+          "oneOf": [
+            {"type": "string"},
+            {"$ref": "#/definitions/string_array"}
+          ]
+        },
+        "flatten": {"type": "boolean"},
+        "flatten_depth": {"type": "integer", "minimum": 0},
+        "schema": {"type": ["object", "string"]},
+        "payload_format": {"type": "string"},
+        "pagination": {"type": "object"},
+        "auth": {"type": "object"},
+        "pushdown": {"type": "boolean"},
+        "predicate_pushdown": {"type": "boolean"},
+        "partition_column": {"type": "string"},
+        "lower_bound": {"type": ["number", "integer"]},
+        "upper_bound": {"type": ["number", "integer"]},
+        "num_partitions": {"type": "integer", "minimum": 1},
+        "fetchsize": {"type": "integer", "minimum": 1}
+      }
+    },
+    "sink": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["storage", "warehouse", "nosql", "kafka", "event_hubs"]
+        },
+        "format": {"type": "string"},
+        "backend": {"type": "string"},
+        "uri": {"type": "string"},
+        "engine": {"type": "string"},
+        "table": {"type": "string"},
+        "mode": {
+          "type": "string",
+          "enum": ["append", "overwrite", "overwrite_partitions", "merge"]
+        },
+        "partition_by": {"$ref": "#/definitions/string_array"},
+        "merge_schema": {"type": "boolean"},
+        "options": {"$ref": "#/definitions/string_map"},
+        "write_options": {"$ref": "#/definitions/string_map"},
+        "compression": {"type": "string"},
+        "coalesce": {"type": "integer", "minimum": 1},
+        "repartition": {
+          "oneOf": [
+            {"type": "integer", "minimum": 1},
+            {"$ref": "#/definitions/string_array"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "columns": {"$ref": "#/definitions/string_array"},
+                "numPartitions": {"type": "integer", "minimum": 1}
+              },
+              "required": ["columns"]
+            }
+          ]
+        },
+        "target_file_size_mb": {"type": "integer", "minimum": 1},
+        "file_size_mb": {"type": "integer", "minimum": 1},
+        "atomic": {"type": "boolean"},
+        "temporary_gcs_bucket": {"type": "string"},
+        "intermediate_format": {"type": "string"},
+        "checkpoint_location": {"type": "string"},
+        "reject_options": {"$ref": "#/definitions/string_map"},
+        "metrics_compression": {"type": "string"},
+        "batch_size": {"type": "integer", "minimum": 1},
+        "truncate_safe": {"type": "boolean"},
+        "isolation_level": {"type": "string"},
+        "create_table_options": {"type": "string"}
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["check"],
+            "properties": {
+              "check": {"type": "string"},
+              "columns": {"$ref": "#/definitions/string_array"},
+              "column": {"type": "string"},
+              "severity": {"enum": ["error", "warn"]},
+              "threshold": {"type": "number", "minimum": 0, "maximum": 1},
+              "params": {"type": "object"},
+              "on_fail": {"type": "string", "enum": ["quarantine", "reject", "none"]}
+            },
+            "additionalProperties": true
+          }
+        },
+        "quarantine_sink": {"$ref": "#/definitions/sink"}
+      }
+    },
+    "incremental": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": {"enum": ["full", "append", "merge"]},
+        "keys": {"$ref": "#/definitions/string_array"},
+        "order_by": {"$ref": "#/definitions/string_array"},
+        "watermark": {
+          "type": "object",
+          "properties": {
+            "column": {"type": "string"},
+            "delay_threshold": {"type": "string"}
+          },
+          "required": ["column"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "streaming": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "trigger": {"type": "string"},
+        "checkpoint": {"type": "string"},
+        "checkpoint_location": {"type": "string"},
+        "watermark": {
+          "type": "object",
+          "properties": {
+            "column": {"type": "string"},
+            "delay_threshold": {"type": "string"}
+          },
+          "required": ["column"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "required": ["name", "layer", "source", "sink"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {"type": "string"},
+        "layer": {"enum": ["raw", "bronze", "silver", "gold"]},
+        "source": {
+          "oneOf": [
+            {"$ref": "#/definitions/source"},
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {"$ref": "#/definitions/source"}
+            }
+          ]
+        },
+        "transform": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "sql": {"type": "array", "items": {"type": "string"}},
+            "udf": {"type": "array", "items": {"type": "string"}},
+            "add_ingestion_ts": {"type": "boolean"},
+            "ops": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {"type": "string"},
+                  {
+                    "type": "object",
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "additionalProperties": true
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "validation": {"$ref": "#/definitions/validation"},
+        "sink": {"$ref": "#/definitions/sink"},
+        "incremental": {"$ref": "#/definitions/incremental"},
+        "streaming": {"$ref": "#/definitions/streaming"},
+        "merge_strategy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keys": {"$ref": "#/definitions/string_array"},
+            "prefer": {"enum": ["newest", "left", "coalesce"]},
+            "order_by": {"$ref": "#/definitions/string_array"}
+          }
+        }
+      }
+    }
+  }
 }

--- a/datacore/connectors/db/jdbc.py
+++ b/datacore/connectors/db/jdbc.py
@@ -13,18 +13,70 @@ def _apply_reader_options(reader, options: dict[str, Any]):
     return reader
 
 
-def read(spark: SparkSession, config: dict[str, Any]) -> DataFrame:
-    base_options: dict[str, Any] = {
-        **config.get("options", {}),
-        "url": config["url"],
-        "dbtable": config["table"],
+def _bool_to_lower(value: Any) -> str:
+    return str(bool(value)).lower()
+
+
+def _collect_partitioning(config: dict[str, Any]) -> dict[str, Any]:
+    partitioning: dict[str, Any] = {}
+    raw_partitioning = config.get("partitioning", {})
+    alias_map = {
+        "partitionColumn": ["partition_column"],
+        "lowerBound": ["lower_bound"],
+        "upperBound": ["upper_bound"],
+        "numPartitions": ["num_partitions"],
     }
+    for canonical, aliases in alias_map.items():
+        value = config.get(canonical)
+        if value is None:
+            for alias in aliases:
+                if alias in config:
+                    value = config[alias]
+                    break
+        if value is None and canonical in raw_partitioning:
+            value = raw_partitioning[canonical]
+        if value is None:
+            for alias in aliases:
+                if alias in raw_partitioning:
+                    value = raw_partitioning[alias]
+                    break
+        if value is not None:
+            partitioning[canonical] = value
+    if "fetchsize" in config:
+        partitioning["fetchsize"] = config["fetchsize"]
+    elif "fetchsize" in raw_partitioning:
+        partitioning["fetchsize"] = raw_partitioning["fetchsize"]
+    return partitioning
+
+
+def _collect_pushdown(config: dict[str, Any]) -> dict[str, Any]:
+    pushdown_flags = {}
     if "pushdown" in config:
-        base_options["pushDownPredicate"] = str(config["pushdown"]).lower()
-    partitioning = config.get("partitioning", {})
-    for key in ["partitionColumn", "lowerBound", "upperBound", "numPartitions"]:
-        if key in partitioning:
-            base_options[key] = partitioning[key]
+        pushdown_flags["pushDownPredicate"] = _bool_to_lower(config["pushdown"])
+    if "predicate_pushdown" in config:
+        pushdown_flags["pushDownPredicate"] = _bool_to_lower(config["predicate_pushdown"])
+    options = config.get("options", {})
+    if "pushdown" in options:
+        pushdown_flags.setdefault("pushDownPredicate", _bool_to_lower(options["pushdown"]))
+    if "predicate_pushdown" in options:
+        pushdown_flags.setdefault(
+            "pushDownPredicate", _bool_to_lower(options["predicate_pushdown"])
+        )
+    return pushdown_flags
+
+
+def read(spark: SparkSession, config: dict[str, Any]) -> DataFrame:
+    base_options: dict[str, Any] = {}
+    base_options.update(config.get("options", {}))
+    base_options.update(config.get("read_options", {}))
+    base_options.setdefault("url", config["url"])
+    if "table" in config:
+        base_options.setdefault("dbtable", config["table"])
+    if "query" in config:
+        base_options.setdefault("query", config["query"])
+    base_options.update(_collect_pushdown(config))
+    base_options.update(_collect_partitioning(config))
+
     reader = spark.read.format("jdbc")
     reader = _apply_reader_options(reader, base_options)
     return reader.load()

--- a/datacore/connectors/db/jdbc.py
+++ b/datacore/connectors/db/jdbc.py
@@ -89,13 +89,17 @@ def write(df: DataFrame, config: dict[str, Any]) -> None:
         "url": config["url"],
         "dbtable": config["table"],
     }
-    if config.get("batchsize"):
-        options["batchsize"] = config["batchsize"]
-    if config.get("isolationLevel"):
-        options["isolationLevel"] = config["isolationLevel"]
-    if config.get("createTableOptions"):
-        options["createTableOptions"] = config["createTableOptions"]
-    if config.get("truncate"):
+    batch_size = config.get("batch_size") or config.get("batchsize")
+    if batch_size:
+        options["batchsize"] = batch_size
+    isolation = config.get("isolation_level") or config.get("isolationLevel")
+    if isolation:
+        options["isolationLevel"] = isolation
+    create_opts = config.get("create_table_options") or config.get("createTableOptions")
+    if create_opts:
+        options["createTableOptions"] = create_opts
+    truncate_flag = config.get("truncate_safe") or config.get("truncate")
+    if truncate_flag:
         mode = "overwrite"
         options["truncate"] = "true"
     writer = df.write.format("jdbc").mode(mode)

--- a/datacore/connectors/db/jdbc.py
+++ b/datacore/connectors/db/jdbc.py
@@ -20,6 +20,12 @@ def _bool_to_lower(value: Any) -> str:
 def _collect_partitioning(config: dict[str, Any]) -> dict[str, Any]:
     partitioning: dict[str, Any] = {}
     raw_partitioning = config.get("partitioning", {})
+    option_blocks = [
+        config,
+        raw_partitioning,
+        config.get("options", {}),
+        config.get("read_options", {}),
+    ]
     alias_map = {
         "partitionColumn": ["partition_column"],
         "lowerBound": ["lower_bound"],
@@ -27,59 +33,105 @@ def _collect_partitioning(config: dict[str, Any]) -> dict[str, Any]:
         "numPartitions": ["num_partitions"],
     }
     for canonical, aliases in alias_map.items():
-        value = config.get(canonical)
-        if value is None:
+        value = None
+        for block in option_blocks:
+            if canonical in block:
+                value = block[canonical]
+                break
             for alias in aliases:
-                if alias in config:
-                    value = config[alias]
+                if alias in block:
+                    value = block[alias]
                     break
-        if value is None and canonical in raw_partitioning:
-            value = raw_partitioning[canonical]
-        if value is None:
-            for alias in aliases:
-                if alias in raw_partitioning:
-                    value = raw_partitioning[alias]
-                    break
+            if value is not None:
+                break
         if value is not None:
             partitioning[canonical] = value
-    if "fetchsize" in config:
-        partitioning["fetchsize"] = config["fetchsize"]
-    elif "fetchsize" in raw_partitioning:
-        partitioning["fetchsize"] = raw_partitioning["fetchsize"]
+
+    for block in option_blocks:
+        if "fetchsize" in block:
+            partitioning["fetchsize"] = block["fetchsize"]
+            break
+
     return partitioning
 
 
 def _collect_pushdown(config: dict[str, Any]) -> dict[str, Any]:
     pushdown_flags = {}
-    if "pushdown" in config:
-        pushdown_flags["pushDownPredicate"] = _bool_to_lower(config["pushdown"])
-    if "predicate_pushdown" in config:
-        pushdown_flags["pushDownPredicate"] = _bool_to_lower(config["predicate_pushdown"])
-    options = config.get("options", {})
-    if "pushdown" in options:
-        pushdown_flags.setdefault("pushDownPredicate", _bool_to_lower(options["pushdown"]))
-    if "predicate_pushdown" in options:
-        pushdown_flags.setdefault(
-            "pushDownPredicate", _bool_to_lower(options["predicate_pushdown"])
-        )
+    blocks = [config, config.get("options", {}), config.get("read_options", {})]
+    for block in blocks:
+        if "pushdown" in block:
+            pushdown_flags["pushDownPredicate"] = _bool_to_lower(block["pushdown"])
+        if "predicate_pushdown" in block:
+            pushdown_flags["pushDownPredicate"] = _bool_to_lower(block["predicate_pushdown"])
     return pushdown_flags
 
 
 def read(spark: SparkSession, config: dict[str, Any]) -> DataFrame:
-    base_options: dict[str, Any] = {}
-    base_options.update(config.get("options", {}))
-    base_options.update(config.get("read_options", {}))
-    base_options.setdefault("url", config["url"])
-    if "table" in config:
-        base_options.setdefault("dbtable", config["table"])
-    if "query" in config:
-        base_options.setdefault("query", config["query"])
-    base_options.update(_collect_pushdown(config))
-    base_options.update(_collect_partitioning(config))
+    options: dict[str, Any] = {}
+    options.update(config.get("options", {}))
+    options.update(config.get("read_options", {}))
 
-    reader = spark.read.format("jdbc")
-    reader = _apply_reader_options(reader, base_options)
-    return reader.load()
+    url = options.pop("url", config.get("url"))
+    if not url:
+        raise ValueError("La configuración JDBC requiere 'url'")
+
+    table = config.get("table") or options.pop("dbtable", None)
+    query = config.get("query") or options.pop("query", None)
+    if query:
+        table = f"({query}) tmp"
+    if not table:
+        raise ValueError("Se requiere 'table' o 'query' para leer vía JDBC")
+
+    partitioning = _collect_partitioning(config)
+    pushdown = _collect_pushdown(config)
+
+    for key in [
+        "partitionColumn",
+        "lowerBound",
+        "upperBound",
+        "numPartitions",
+        "fetchsize",
+        "partition_column",
+        "lower_bound",
+        "upper_bound",
+        "num_partitions",
+        "pushdown",
+        "predicate_pushdown",
+    ]:
+        options.pop(key, None)
+
+    properties: dict[str, str] = {}
+    for key, value in options.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            properties[key] = _bool_to_lower(value)
+        else:
+            properties[key] = str(value)
+
+    fetchsize = partitioning.pop("fetchsize", None)
+    if fetchsize is not None:
+        properties["fetchsize"] = str(fetchsize)
+
+    for key, value in pushdown.items():
+        properties[key] = str(value)
+
+    reader = spark.read
+
+    if partitioning.get("partitionColumn") and all(
+        bound in partitioning for bound in ("lowerBound", "upperBound", "numPartitions")
+    ):
+        return reader.jdbc(
+            url=url,
+            table=table,
+            column=partitioning["partitionColumn"],
+            lowerBound=partitioning["lowerBound"],
+            upperBound=partitioning["upperBound"],
+            numPartitions=partitioning["numPartitions"],
+            properties=properties,
+        )
+
+    return reader.jdbc(url=url, table=table, properties=properties)
 
 
 def write(df: DataFrame, config: dict[str, Any]) -> None:

--- a/datacore/connectors/http.py
+++ b/datacore/connectors/http.py
@@ -1,0 +1,134 @@
+"""Conector HTTP con autenticación, reintentos y paginación."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable
+from typing import Any
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+
+class HttpError(RuntimeError):
+    """Error controlado al consumir un endpoint HTTP."""
+
+
+def _apply_auth(session: requests.Session, config: dict[str, Any]) -> dict[str, str]:
+    headers = {**config.get("headers", {})}
+    auth_conf = config.get("auth") or {}
+    auth_type = (auth_conf.get("type") or "").lower()
+    if auth_type == "bearer":
+        token = auth_conf.get("token") or auth_conf.get("token_env")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+    elif auth_type == "basic":
+        user = auth_conf.get("username") or auth_conf.get("user")
+        password = auth_conf.get("password")
+        if user is not None and password is not None:
+            session.auth = (user, password)
+    return headers
+
+
+def _extract_cursor(payload: Any, path: str | None) -> str | None:
+    if not path:
+        return None
+    current = payload
+    for segment in path.replace("$", "").strip(".").split("."):
+        if not segment:
+            continue
+        if isinstance(current, dict):
+            current = current.get(segment)
+        else:
+            return None
+    if isinstance(current, str):
+        return current or None
+    return None
+
+
+def _next_link_from_header(response: requests.Response) -> str | None:
+    link_header = response.headers.get("Link")
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        section = part.strip()
+        if "rel=\"next\"" in section:
+            start = section.find("<")
+            end = section.find(">", start + 1)
+            if start != -1 and end != -1:
+                return section[start + 1 : end]
+    return None
+
+
+def fetch_pages(config: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Genera páginas JSON aplicando autenticación, reintentos y paginación."""
+
+    session = requests.Session()
+    method = config.get("method", "GET").upper()
+    url = config["url"]
+    params = {**config.get("params", {})}
+    body = config.get("body")
+    pagination = config.get("pagination", {})
+    strategy = (pagination.get("strategy") or "").lower()
+    page_param = pagination.get("param", "page")
+    cursor_path = pagination.get("cursor_path")
+    max_pages = pagination.get("max_pages", 1 if not strategy else 1000)
+    delay = float(config.get("retry", {}).get("backoff", pagination.get("backoff", 1.0)))
+    max_attempts = int(config.get("retry", {}).get("max_attempts", 3))
+    headers = _apply_auth(session, config)
+
+    current_page = pagination.get("start", 1)
+    next_cursor: str | None = pagination.get("start_cursor")
+    next_url: str | None = None
+
+    for _ in range(int(max_pages)):
+        attempt = 0
+        response: requests.Response | None = None
+        while attempt < max_attempts:
+            payload_params = {**params}
+            if strategy == "page":
+                payload_params[page_param] = current_page
+            if strategy == "cursor" and next_cursor is not None:
+                payload_params[page_param] = next_cursor
+            target_url = next_url or url
+            try:
+                response = session.request(
+                    method,
+                    target_url,
+                    headers=headers,
+                    params=payload_params,
+                    json=body if isinstance(body, dict) else None,
+                    data=body if isinstance(body, str) else None,
+                    timeout=config.get("timeout", 60),
+                )
+                if response.status_code >= 500:
+                    raise HttpError(f"{response.status_code}: {response.text[:120]}")
+                response.raise_for_status()
+                break
+            except Exception as exc:  # pragma: no cover - errores transitorios
+                attempt += 1
+                LOGGER.warning("Fallo HTTP %s (intento %s/%s)", exc, attempt, max_attempts)
+                if attempt >= max_attempts:
+                    raise
+                time.sleep(delay * attempt)
+        if response is None:
+            raise HttpError("Respuesta HTTP vacía")
+        data = response.json()
+        yield data
+
+        if strategy == "page":
+            current_page += 1
+            if pagination.get("stop_on_empty") and not data:
+                break
+        elif strategy == "cursor":
+            next_cursor = _extract_cursor(data, cursor_path)
+            if not next_cursor:
+                break
+        elif strategy == "link":
+            next_url = _next_link_from_header(response)
+            if not next_url:
+                break
+        else:
+            break

--- a/datacore/connectors/storage/abfs.py
+++ b/datacore/connectors/storage/abfs.py
@@ -5,17 +5,38 @@ from __future__ import annotations
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
 
 
-def read(spark: SparkSession, uri: str, fmt: str, options: dict[str, Any]) -> DataFrame:
+def read(
+    spark: SparkSession,
+    uri: str,
+    fmt: str,
+    options: dict[str, Any],
+    schema: StructType | None = None,
+) -> DataFrame:
     reader = spark.read.format(fmt)
     for key, value in options.items():
         reader = reader.option(key, value)
+    if schema is not None:
+        reader = reader.schema(schema)
     return reader.load(uri)
 
 
-def write(df: DataFrame, uri: str, fmt: str, mode: str, options: dict[str, Any]) -> None:
+def write(
+    df: DataFrame,
+    uri: str,
+    fmt: str,
+    mode: str,
+    options: dict[str, Any],
+    partition_by: list[str] | None = None,
+    merge_schema: bool | None = None,
+) -> None:
     writer = df.write.mode(mode).format(fmt)
+    if partition_by:
+        writer = writer.partitionBy(*partition_by)
+    if merge_schema is not None:
+        writer = writer.option("mergeSchema", str(merge_schema).lower())
     for key, value in options.items():
         writer = writer.option(key, value)
     writer.save(uri)

--- a/datacore/connectors/storage/gcs.py
+++ b/datacore/connectors/storage/gcs.py
@@ -5,17 +5,38 @@ from __future__ import annotations
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
 
 
-def read(spark: SparkSession, uri: str, fmt: str, options: dict[str, Any]) -> DataFrame:
+def read(
+    spark: SparkSession,
+    uri: str,
+    fmt: str,
+    options: dict[str, Any],
+    schema: StructType | None = None,
+) -> DataFrame:
     reader = spark.read.format(fmt)
     for key, value in options.items():
         reader = reader.option(key, value)
+    if schema is not None:
+        reader = reader.schema(schema)
     return reader.load(uri)
 
 
-def write(df: DataFrame, uri: str, fmt: str, mode: str, options: dict[str, Any]) -> None:
+def write(
+    df: DataFrame,
+    uri: str,
+    fmt: str,
+    mode: str,
+    options: dict[str, Any],
+    partition_by: list[str] | None = None,
+    merge_schema: bool | None = None,
+) -> None:
     writer = df.write.mode(mode).format(fmt)
+    if partition_by:
+        writer = writer.partitionBy(*partition_by)
+    if merge_schema is not None:
+        writer = writer.option("mergeSchema", str(merge_schema).lower())
     for key, value in options.items():
         writer = writer.option(key, value)
     writer.save(uri)

--- a/datacore/connectors/storage/local.py
+++ b/datacore/connectors/storage/local.py
@@ -5,17 +5,38 @@ from __future__ import annotations
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
 
 
-def read(spark: SparkSession, uri: str, fmt: str, options: dict[str, Any]) -> DataFrame:
+def read(
+    spark: SparkSession,
+    uri: str,
+    fmt: str,
+    options: dict[str, Any],
+    schema: StructType | None = None,
+) -> DataFrame:
     reader = spark.read.format(fmt)
     for key, value in options.items():
         reader = reader.option(key, value)
+    if schema is not None:
+        reader = reader.schema(schema)
     return reader.load(uri)
 
 
-def write(df: DataFrame, uri: str, fmt: str, mode: str, options: dict[str, Any]) -> None:
+def write(
+    df: DataFrame,
+    uri: str,
+    fmt: str,
+    mode: str,
+    options: dict[str, Any],
+    partition_by: list[str] | None = None,
+    merge_schema: bool | None = None,
+) -> None:
     writer = df.write.mode(mode).format(fmt)
+    if partition_by:
+        writer = writer.partitionBy(*partition_by)
+    if merge_schema is not None:
+        writer = writer.option("mergeSchema", str(merge_schema).lower())
     for key, value in options.items():
         writer = writer.option(key, value)
     writer.save(uri)

--- a/datacore/connectors/storage/s3.py
+++ b/datacore/connectors/storage/s3.py
@@ -5,17 +5,38 @@ from __future__ import annotations
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
 
 
-def read(spark: SparkSession, uri: str, fmt: str, options: dict[str, Any]) -> DataFrame:
+def read(
+    spark: SparkSession,
+    uri: str,
+    fmt: str,
+    options: dict[str, Any],
+    schema: StructType | None = None,
+) -> DataFrame:
     reader = spark.read.format(fmt)
     for key, value in options.items():
         reader = reader.option(key, value)
+    if schema is not None:
+        reader = reader.schema(schema)
     return reader.load(uri)
 
 
-def write(df: DataFrame, uri: str, fmt: str, mode: str, options: dict[str, Any]) -> None:
+def write(
+    df: DataFrame,
+    uri: str,
+    fmt: str,
+    mode: str,
+    options: dict[str, Any],
+    partition_by: list[str] | None = None,
+    merge_schema: bool | None = None,
+) -> None:
     writer = df.write.mode(mode).format(fmt)
+    if partition_by:
+        writer = writer.partitionBy(*partition_by)
+    if merge_schema is not None:
+        writer = writer.option("mergeSchema", str(merge_schema).lower())
     for key, value in options.items():
         writer = writer.option(key, value)
     writer.save(uri)

--- a/datacore/core/engine.py
+++ b/datacore/core/engine.py
@@ -230,7 +230,7 @@ def _build_plan(dataset: dict[str, Any]) -> dict[str, Any]:
         "add_ingestion_ts": transform_cfg.get("add_ingestion_ts", True),
     }
 
-    validation_cfg = dataset.get("validation") or transform_cfg.get("validation", {})
+    validation_cfg = dataset.get("validation", {})
     streaming_cfg = dataset.get("streaming", {})
     incremental_cfg = dataset.get("incremental", {})
 
@@ -284,7 +284,7 @@ def _handle_batch_dataset(
 ) -> dict[str, Any]:
     df = _read_dataset_source(spark, platform, dataset, layer=layer, environment=environment)
     transformed = _apply_transformations(df, dataset.get("transform", {}))
-    validation_cfg = dataset.get("validation") or dataset.get("transform", {}).get("validation", {})
+    validation_cfg = dataset.get("validation", {})
     validation_result = validation.apply_validation(transformed, validation_cfg)
     metrics = dict(validation_result.metrics)
     metrics.update(

--- a/datacore/core/engine.py
+++ b/datacore/core/engine.py
@@ -1,11 +1,13 @@
-"""Motor de ejecución por capas."""
+"""Motor de ejecución por capas con planificación y validaciones enriquecidas."""
 
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
+from pyspark.sql.window import Window
 
 from datacore.core import transforms, validation
 from datacore.core.incremental import handle_incremental
@@ -33,7 +35,7 @@ def _resolve_platform(name: str | None, config: dict[str, Any]) -> PlatformBase:
     return platform_cls(config=config)
 
 
-def _prepare_spark(platform: PlatformBase, config: dict[str, Any]) -> Any:
+def _prepare_spark(platform: PlatformBase, config: dict[str, Any]):
     spark_conf: dict[str, Any] = {}
     spark_section = config.get("spark", {})
     if "shuffle_partitions" in spark_section:
@@ -43,17 +45,210 @@ def _prepare_spark(platform: PlatformBase, config: dict[str, Any]) -> Any:
     return platform.build_spark_session(spark_conf)
 
 
+def _resolve_references(value: Any, platform: PlatformBase):
+    if isinstance(value, dict):
+        return {key: _resolve_references(val, platform) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_resolve_references(item, platform) for item in value]
+    if isinstance(value, str):
+        return platform.resolve_secret_reference(value)
+    return value
+
+
 def _apply_transformations(df: DataFrame, transform_config: dict[str, Any]) -> DataFrame:
     sql_steps = transform_config.get("sql", [])
-    for statement in sql_steps:
-        df.createOrReplaceTempView("_src")
+    for idx, statement in enumerate(sql_steps):
+        view_name = f"_src_{idx}"
+        df.createOrReplaceTempView(view_name)
         df = df.sparkSession.sql(statement)
-    registered = transform_config.get("udf", [])
-    if registered:
-        df = transforms.apply_registered(df, registered)
-    if transform_config.get("add_ingestion_ts", True):
+    add_ingestion = transform_config.get("add_ingestion_ts", True)
+    if add_ingestion and "_ingestion_ts" not in df.columns:
+        df = df.withColumn("_ingestion_ts", F.current_timestamp())
+    udf_steps = transform_config.get("udf", [])
+    if udf_steps:
+        df = transforms.apply_registered(df, udf_steps)
+    ops_steps = transform_config.get("ops", [])
+    if ops_steps:
+        df = transforms.apply_ops(df, ops_steps)
+    if add_ingestion and "_ingestion_ts" not in df.columns:
         df = df.withColumn("_ingestion_ts", F.current_timestamp())
     return df
+
+
+def _merge_strategy(df: DataFrame, strategy: dict[str, Any]) -> DataFrame:
+    keys = strategy.get("keys")
+    if not keys:
+        raise ValueError("merge_strategy requiere keys definidos")
+    prefer = strategy.get("prefer", "newest")
+    order_by = strategy.get("order_by", ["_ingestion_ts DESC"])
+    if prefer == "coalesce":
+        non_keys = [col for col in df.columns if col not in keys and col != "__dc_source_ordinal"]
+        aggregations = [F.first(F.col(col), ignorenulls=True).alias(col) for col in non_keys]
+        return df.groupBy(*keys).agg(*aggregations)
+    if prefer == "left":
+        order_by = ["__dc_source_ordinal ASC", *order_by]
+    window = Window.partitionBy(*[F.col(key) for key in keys]).orderBy(*[F.expr(expr) for expr in order_by])
+    ranked = df.withColumn("__dc_union_rank", F.row_number().over(window))
+    return ranked.filter(F.col("__dc_union_rank") == 1).drop("__dc_union_rank")
+
+
+def _read_dataset_source(
+    spark,
+    platform: PlatformBase,
+    dataset: dict[str, Any],
+    *,
+    layer: str,
+    environment: str,
+) -> DataFrame:
+    source_conf = dataset["source"]
+    if isinstance(source_conf, list):
+        dataframes: list[DataFrame] = []
+        for idx, source in enumerate(source_conf):
+            df = readers.read_batch(
+                spark,
+                platform,
+                source,
+                layer=layer,
+                dataset=dataset["name"],
+                environment=environment,
+            )
+            df = df.withColumn("__dc_source_ordinal", F.lit(idx))
+            dataframes.append(df)
+        combined = dataframes[0]
+        for frame in dataframes[1:]:
+            combined = combined.unionByName(frame, allowMissingColumns=True)
+        if dataset.get("merge_strategy"):
+            combined = _merge_strategy(combined, dataset["merge_strategy"])
+        return combined.drop("__dc_source_ordinal")
+    return readers.read_batch(
+        spark,
+        platform,
+        source_conf,
+        layer=layer,
+        dataset=dataset["name"],
+        environment=environment,
+    )
+
+
+def _detect_dataset_issues(dataset: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    incremental_cfg = dataset.get("incremental", {})
+    if incremental_cfg.get("mode") == "merge" and not incremental_cfg.get("keys"):
+        issues.append("incremental.merge requiere keys definidos")
+    if isinstance(dataset.get("source"), list) and not dataset.get("merge_strategy"):
+        issues.append("source múltiple requiere merge_strategy para resolver duplicados")
+    sink = dataset.get("sink", {})
+    if sink.get("type") == "storage" and sink.get("format") not in {"delta", "parquet", "csv", "json", "avro", "orc"}:
+        issues.append(f"Formato de sink {sink.get('format')} no soportado para storage")
+    return issues
+
+
+def _build_plan(dataset: dict[str, Any]) -> dict[str, Any]:
+    sources = dataset.get("source")
+    if isinstance(sources, list):
+        source_types = [src.get("type") for src in sources]
+    else:
+        source_types = [dataset.get("source", {}).get("type")]
+    transform_cfg = dataset.get("transform", {})
+    plan = {
+        "name": dataset["name"],
+        "layer": dataset.get("layer"),
+        "source_types": source_types,
+        "sink": {
+            "type": dataset.get("sink", {}).get("type"),
+            "format": dataset.get("sink", {}).get("format"),
+            "partition_by": dataset.get("sink", {}).get("partition_by"),
+        },
+        "transform": {
+            "sql": transform_cfg.get("sql", []),
+            "ops": transform_cfg.get("ops", []),
+        },
+        "validation": transform_cfg.get("validation", {}),
+        "incremental": dataset.get("incremental", {}),
+        "streaming": dataset.get("streaming", {}),
+    }
+    plan["issues"] = _detect_dataset_issues(dataset)
+    return plan
+
+
+def _apply_streaming_options(df: DataFrame, dataset: dict[str, Any]) -> DataFrame:
+    streaming_cfg = dataset.get("streaming", {})
+    watermark_column = (
+        streaming_cfg.get("watermark_column")
+        or dataset.get("incremental", {}).get("watermark_column")
+    )
+    watermark = streaming_cfg.get("watermark")
+    if watermark_column and watermark:
+        df = df.withWatermark(watermark_column, watermark)
+    return df
+
+
+def _handle_batch_dataset(
+    layer: str,
+    dataset: dict[str, Any],
+    platform: PlatformBase,
+    environment: str,
+    spark,
+) -> dict[str, Any]:
+    df = _read_dataset_source(spark, platform, dataset, layer=layer, environment=environment)
+    transformed = _apply_transformations(df, dataset.get("transform", {}))
+    validation_cfg = dataset.get("transform", {}).get("validation", {})
+    validation_result = validation.apply_validation(transformed, validation_cfg)
+
+    if validation_result.metrics.get("invalid_rows", 0) > 0:
+        writers.write_rejects(
+            validation_result.invalid_df,
+            platform,
+            dataset["sink"],
+            layer=layer,
+            dataset=dataset["name"],
+            environment=environment,
+        )
+
+    metrics = validation_result.metrics
+    writers.write_metrics(
+        spark,
+        platform,
+        dataset["sink"],
+        layer=layer,
+        dataset=dataset["name"],
+        environment=environment,
+        metrics=metrics,
+    )
+
+    incremental_cfg = dataset.get("incremental", {})
+    handled = False
+    if incremental_cfg.get("mode") == "merge":
+        handled = handle_incremental(validation_result.valid_df, dataset["sink"], incremental_cfg)
+    if not handled:
+        writers.write_batch(validation_result.valid_df, platform, dataset["sink"])
+    return {"name": dataset["name"], "status": "completed", "metrics": metrics}
+
+
+def _handle_streaming_dataset(
+    layer: str,
+    dataset: dict[str, Any],
+    platform: PlatformBase,
+    environment: str,
+    spark,
+) -> dict[str, Any]:
+    df_stream = readers.read_stream(
+        spark,
+        platform,
+        dataset["source"],
+        layer=layer,
+        dataset=dataset["name"],
+        environment=environment,
+    )
+    df_stream = _apply_streaming_options(df_stream, dataset)
+    transformed = _apply_transformations(df_stream, dataset.get("transform", {}))
+    checkpoint = dataset.get("streaming", {}).get(
+        "checkpoint",
+        platform.checkpoint_dir(layer, dataset["name"], environment),
+    )
+    trigger = dataset.get("streaming", {}).get("trigger")
+    writers.write_stream(transformed, platform, dataset["sink"], checkpoint, trigger=trigger)
+    return {"name": dataset["name"], "status": "streaming"}
 
 
 def _process_dataset(
@@ -61,32 +256,19 @@ def _process_dataset(
     dataset: dict[str, Any],
     platform: PlatformBase,
     environment: str,
-    spark_session,
+    spark,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    LOGGER.info("Procesando dataset %s", dataset["name"])
+    dataset_cfg = _resolve_references(dataset, platform)
+    LOGGER.info("Procesando dataset %s", dataset_cfg["name"])
     if dry_run:
-        return {"name": dataset["name"], "status": "planned"}
-    streaming_cfg = dataset.get("streaming", {"enabled": False})
+        plan = _build_plan(dataset_cfg)
+        plan["status"] = "planned"
+        return plan
+    streaming_cfg = dataset_cfg.get("streaming", {})
     if streaming_cfg.get("enabled"):
-        df_stream = readers.read_stream(spark_session, platform, dataset["source"])
-        transformed = _apply_transformations(df_stream, dataset.get("transform", {}))
-        checkpoint = platform.checkpoint_dir(layer, dataset["name"], environment)
-        writers.write_stream(transformed, platform, dataset["sink"], checkpoint)
-        return {"name": dataset["name"], "status": "streaming"}
-    df = readers.read_batch(spark_session, platform, dataset["source"])
-    transformed = _apply_transformations(df, dataset.get("transform", {}))
-    metrics = validation.apply_validation(
-        transformed,
-        dataset.get("transform", {}).get("validation", {}),
-    )
-    incremental_cfg = dataset.get("incremental", {"mode": "append"})
-    mode = incremental_cfg.get("mode", "append")
-    if mode == "merge" and incremental_cfg.get("keys"):
-        handle_incremental(transformed, dataset["sink"], mode, incremental_cfg["keys"])
-    else:
-        writers.write_batch(transformed, platform, dataset["sink"])
-    return {"name": dataset["name"], "status": "completed", "metrics": metrics}
+        return _handle_streaming_dataset(layer, dataset_cfg, platform, environment, spark)
+    return _handle_batch_dataset(layer, dataset_cfg, platform, environment, spark)
 
 
 def run_layer_plan(
@@ -95,6 +277,7 @@ def run_layer_plan(
     platform_name: str | None = None,
     environment: str | None = None,
     dry_run: bool = False,
+    fail_fast: bool = False,
 ) -> list[dict[str, Any]]:
     platform = _resolve_platform(platform_name, config)
     spark = _prepare_spark(platform, config)
@@ -103,6 +286,21 @@ def run_layer_plan(
     for dataset in config.get("datasets", []):
         if dataset.get("layer") != layer:
             continue
-        results.append(_process_dataset(layer, dataset, platform, env, spark, dry_run=dry_run))
+        try:
+            results.append(
+                _process_dataset(
+                    layer,
+                    dataset,
+                    platform,
+                    env,
+                    spark,
+                    dry_run=dry_run,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - control de fallos
+            LOGGER.error("Fallo en dataset %s: %s", dataset.get("name"), exc)
+            if fail_fast:
+                raise
+            results.append({"name": dataset.get("name"), "status": "failed", "error": str(exc)})
     LOGGER.info("Ejecución de capa %s completada", layer)
     return results

--- a/datacore/core/engine.py
+++ b/datacore/core/engine.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import copy
+from datetime import datetime
+from time import perf_counter
 from typing import Any
 
 from pyspark.sql import DataFrame
@@ -10,13 +11,14 @@ from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 
 from datacore.core import transforms, validation
-from datacore.core.incremental import handle_incremental
+from datacore.core.incremental import prepare_incremental
 from datacore.io import readers, writers
 from datacore.platforms.aws_glue import AwsGluePlatform
 from datacore.platforms.azure_databricks import AzureDatabricksPlatform
 from datacore.platforms.base import LocalPlatform, PlatformBase
 from datacore.platforms.gcp_dataproc import GcpDataprocPlatform
 from datacore.utils.logging import get_logger
+from datacore.utils import observability
 
 LOGGER = get_logger(__name__)
 
@@ -26,6 +28,8 @@ PLATFORM_MAP = {
     "gcp": GcpDataprocPlatform,
     "local": LocalPlatform,
 }
+
+_SENSITIVE_KEYS = {"password", "token", "secret", "key", "connectionstring", "apikey"}
 
 
 def _resolve_platform(name: str | None, config: dict[str, Any]) -> PlatformBase:
@@ -53,6 +57,19 @@ def _resolve_references(value: Any, platform: PlatformBase):
     if isinstance(value, str):
         return platform.resolve_secret_reference(value)
     return value
+
+
+def _sanitize_options(options: dict[str, Any] | None) -> dict[str, Any]:
+    if not options:
+        return {}
+    sanitized: dict[str, Any] = {}
+    for key, value in options.items():
+        lowered = key.lower()
+        if any(token in lowered for token in _SENSITIVE_KEYS):
+            sanitized[key] = "***"
+        else:
+            sanitized[key] = value
+    return sanitized
 
 
 def _apply_transformations(df: DataFrame, transform_config: dict[str, Any]) -> DataFrame:
@@ -133,36 +150,79 @@ def _read_dataset_source(
 def _detect_dataset_issues(dataset: dict[str, Any]) -> list[str]:
     issues: list[str] = []
     incremental_cfg = dataset.get("incremental", {})
-    if incremental_cfg.get("mode") == "merge" and not incremental_cfg.get("keys"):
+    mode = incremental_cfg.get("mode")
+    if mode and mode not in {"full", "append", "merge"}:
+        issues.append(f"incremental.mode {mode} no soportado")
+    if mode == "merge" and not incremental_cfg.get("keys"):
         issues.append("incremental.merge requiere keys definidos")
     if isinstance(dataset.get("source"), list) and not dataset.get("merge_strategy"):
         issues.append("source múltiple requiere merge_strategy para resolver duplicados")
     sink = dataset.get("sink", {})
     if sink.get("type") == "storage" and sink.get("format") not in {"delta", "parquet", "csv", "json", "avro", "orc"}:
         issues.append(f"Formato de sink {sink.get('format')} no soportado para storage")
+    if mode == "merge" and sink.get("type") not in {"storage", "warehouse", "nosql"}:
+        issues.append("incremental.merge requiere un sink de tipo storage/warehouse/nosql")
     return issues
 
 
 def _build_plan(dataset: dict[str, Any]) -> dict[str, Any]:
-    sources = dataset.get("source")
-    if isinstance(sources, list):
-        source_types = [src.get("type") for src in sources]
+    sources_conf = dataset.get("source")
+    if isinstance(sources_conf, list):
+        sources = sources_conf
+    elif sources_conf:
+        sources = [sources_conf]
     else:
-        source_types = [dataset.get("source", {}).get("type")]
+        sources = []
+
+    source_summaries = []
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        summary = {
+            "type": source.get("type"),
+            "format": source.get("format"),
+            "uri": source.get("uri"),
+        }
+        if source.get("table"):
+            summary["table"] = source.get("table")
+        if source.get("url"):
+            summary["url"] = source.get("url")
+        if source.get("partitioning"):
+            summary["partitioning"] = source.get("partitioning")
+        summary["options"] = _sanitize_options(source.get("options"))
+        if source.get("read_options"):
+            summary["read_options"] = _sanitize_options(source.get("read_options"))
+        source_summaries.append(summary)
+
+    sink_conf = dataset.get("sink", {})
+    sink_summary = {
+        "type": sink_conf.get("type"),
+        "format": sink_conf.get("format"),
+        "uri": sink_conf.get("uri"),
+        "engine": sink_conf.get("engine"),
+        "table": sink_conf.get("table"),
+        "mode": sink_conf.get("mode", "append"),
+        "partition_by": sink_conf.get("partition_by"),
+        "merge_schema": sink_conf.get("mergeSchema") or sink_conf.get("merge_schema"),
+        "options": _sanitize_options(sink_conf.get("options")),
+    }
+    if sink_conf.get("write_options"):
+        sink_summary["write_options"] = _sanitize_options(sink_conf.get("write_options"))
+
     transform_cfg = dataset.get("transform", {})
+    transform_summary = {
+        "sql": transform_cfg.get("sql", []),
+        "ops": transform_cfg.get("ops", []),
+        "udf": transform_cfg.get("udf", []),
+        "add_ingestion_ts": transform_cfg.get("add_ingestion_ts", True),
+    }
+
     plan = {
         "name": dataset["name"],
         "layer": dataset.get("layer"),
-        "source_types": source_types,
-        "sink": {
-            "type": dataset.get("sink", {}).get("type"),
-            "format": dataset.get("sink", {}).get("format"),
-            "partition_by": dataset.get("sink", {}).get("partition_by"),
-        },
-        "transform": {
-            "sql": transform_cfg.get("sql", []),
-            "ops": transform_cfg.get("ops", []),
-        },
+        "sources": source_summaries,
+        "sink": sink_summary,
+        "transform": transform_summary,
         "validation": transform_cfg.get("validation", {}),
         "incremental": dataset.get("incremental", {}),
         "streaming": dataset.get("streaming", {}),
@@ -189,13 +249,25 @@ def _handle_batch_dataset(
     platform: PlatformBase,
     environment: str,
     spark,
+    run_id: str,
 ) -> dict[str, Any]:
     df = _read_dataset_source(spark, platform, dataset, layer=layer, environment=environment)
     transformed = _apply_transformations(df, dataset.get("transform", {}))
-    validation_cfg = dataset.get("transform", {}).get("validation", {})
+    validation_cfg = dataset.get("validation") or dataset.get("transform", {}).get("validation", {})
     validation_result = validation.apply_validation(transformed, validation_cfg)
+    metrics = dict(validation_result.metrics)
+    metrics.update(
+        {
+            "dataset": dataset["name"],
+            "layer": layer,
+            "environment": environment,
+            "run_id": run_id,
+            "timestamp_utc": datetime.utcnow().isoformat(timespec="seconds"),
+        }
+    )
 
-    if validation_result.metrics.get("invalid_rows", 0) > 0:
+    invalid_rows = metrics.get("invalid_rows", 0)
+    if invalid_rows:
         writers.write_rejects(
             validation_result.invalid_df,
             platform,
@@ -205,7 +277,28 @@ def _handle_batch_dataset(
             environment=environment,
         )
 
-    metrics = validation_result.metrics
+    quarantine_sink = (validation_result.extras or {}).get("quarantine_sink")
+    quarantine_rows = 0
+    if quarantine_sink is None:
+        quarantine_sink = validation_cfg.get("quarantine_sink")
+    if quarantine_sink:
+        quarantine_rows = validation_result.quarantine_df.count()
+        metrics["quarantine_rows"] = quarantine_rows
+        if quarantine_rows > 0:
+            writers.write_batch(validation_result.quarantine_df, platform, quarantine_sink)
+    else:
+        metrics["quarantine_rows"] = quarantine_rows
+
+    incremental_cfg = dataset.get("incremental")
+    valid_df, sink_to_use, handled = prepare_incremental(
+        validation_result.valid_df,
+        dataset["sink"],
+        incremental_cfg,
+        platform,
+    )
+    if not handled:
+        writers.write_batch(valid_df, platform, sink_to_use)
+
     writers.write_metrics(
         spark,
         platform,
@@ -216,13 +309,12 @@ def _handle_batch_dataset(
         metrics=metrics,
     )
 
-    incremental_cfg = dataset.get("incremental", {})
-    handled = False
-    if incremental_cfg.get("mode") == "merge":
-        handled = handle_incremental(validation_result.valid_df, dataset["sink"], incremental_cfg)
-    if not handled:
-        writers.write_batch(validation_result.valid_df, platform, dataset["sink"])
-    return {"name": dataset["name"], "status": "completed", "metrics": metrics}
+    return {
+        "name": dataset["name"],
+        "status": "completed",
+        "metrics": metrics,
+        "quarantine_rows": quarantine_rows,
+    }
 
 
 def _handle_streaming_dataset(
@@ -231,6 +323,7 @@ def _handle_streaming_dataset(
     platform: PlatformBase,
     environment: str,
     spark,
+    run_id: str,
 ) -> dict[str, Any]:
     df_stream = readers.read_stream(
         spark,
@@ -248,7 +341,7 @@ def _handle_streaming_dataset(
     )
     trigger = dataset.get("streaming", {}).get("trigger")
     writers.write_stream(transformed, platform, dataset["sink"], checkpoint, trigger=trigger)
-    return {"name": dataset["name"], "status": "streaming"}
+    return {"name": dataset["name"], "status": "streaming", "run_id": run_id}
 
 
 def _process_dataset(
@@ -257,18 +350,50 @@ def _process_dataset(
     platform: PlatformBase,
     environment: str,
     spark,
+    run_id: str,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     dataset_cfg = _resolve_references(dataset, platform)
-    LOGGER.info("Procesando dataset %s", dataset_cfg["name"])
+    LOGGER.info("Procesando dataset %s (run_id=%s)", dataset_cfg["name"], run_id)
     if dry_run:
         plan = _build_plan(dataset_cfg)
         plan["status"] = "planned"
+        plan["run_id"] = run_id
         return plan
     streaming_cfg = dataset_cfg.get("streaming", {})
-    if streaming_cfg.get("enabled"):
-        return _handle_streaming_dataset(layer, dataset_cfg, platform, environment, spark)
-    return _handle_batch_dataset(layer, dataset_cfg, platform, environment, spark)
+    start_time = perf_counter()
+    try:
+        if streaming_cfg.get("enabled"):
+            result = _handle_streaming_dataset(layer, dataset_cfg, platform, environment, spark, run_id)
+        else:
+            result = _handle_batch_dataset(layer, dataset_cfg, platform, environment, spark, run_id)
+        duration = perf_counter() - start_time
+        result.setdefault("run_id", run_id)
+        result["duration_seconds"] = duration
+        observability.record_dataset(
+            dataset_cfg["name"],
+            result.get("status", "completed"),
+            duration,
+            result.get("metrics"),
+        )
+        lineage_cfg = dataset_cfg.get("lineage")
+        if lineage_cfg:
+            observability.emit_openlineage(
+                {
+                    "dataset": dataset_cfg["name"],
+                    "layer": layer,
+                    "status": result.get("status"),
+                    "run_id": run_id,
+                    "duration": duration,
+                    "metrics": result.get("metrics"),
+                },
+                lineage_cfg,
+            )
+        return result
+    except Exception:
+        duration = perf_counter() - start_time
+        observability.record_dataset(dataset_cfg["name"], "failed", duration, None)
+        raise
 
 
 def run_layer_plan(
@@ -278,11 +403,12 @@ def run_layer_plan(
     environment: str | None = None,
     dry_run: bool = False,
     fail_fast: bool = False,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     platform = _resolve_platform(platform_name, config)
     spark = _prepare_spark(platform, config)
     results: list[dict[str, Any]] = []
     env = environment or config.get("environment", "dev")
+    run_id = observability.new_run_id()
     for dataset in config.get("datasets", []):
         if dataset.get("layer") != layer:
             continue
@@ -294,6 +420,7 @@ def run_layer_plan(
                     platform,
                     env,
                     spark,
+                    run_id,
                     dry_run=dry_run,
                 )
             )
@@ -301,6 +428,14 @@ def run_layer_plan(
             LOGGER.error("Fallo en dataset %s: %s", dataset.get("name"), exc)
             if fail_fast:
                 raise
-            results.append({"name": dataset.get("name"), "status": "failed", "error": str(exc)})
+            results.append(
+                {
+                    "name": dataset.get("name"),
+                    "status": "failed",
+                    "error": str(exc),
+                    "run_id": run_id,
+                    "duration_seconds": None,
+                }
+            )
     LOGGER.info("Ejecución de capa %s completada", layer)
-    return results
+    return {"run_id": run_id, "datasets": results}

--- a/datacore/core/incremental.py
+++ b/datacore/core/incremental.py
@@ -1,12 +1,14 @@
-"""Lógica incremental."""
+"""Lógica incremental para storage y warehouses."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import row_number
+from pyspark.sql import functions as F
 from pyspark.sql.window import Window
+
+from datacore.connectors.db import jdbc
 
 
 def merge_delta(target_path: str, df: DataFrame, keys: list[str]) -> None:
@@ -18,10 +20,10 @@ def merge_delta(target_path: str, df: DataFrame, keys: list[str]) -> None:
     spark = df.sparkSession
     if DeltaTable.isDeltaTable(spark, target_path):
         delta_table = DeltaTable.forPath(spark, target_path)
-        merge_condition = " AND ".join([f"target.{k} = source.{k}" for k in keys])
+        condition = " AND ".join([f"target.{k} = source.{k}" for k in keys])
         (
             delta_table.alias("target")
-            .merge(df.alias("source"), merge_condition)
+            .merge(df.alias("source"), condition)
             .whenMatchedUpdateAll()
             .whenNotMatchedInsertAll()
             .execute()
@@ -30,32 +32,76 @@ def merge_delta(target_path: str, df: DataFrame, keys: list[str]) -> None:
         df.write.format("delta").mode("overwrite").save(target_path)
 
 
+def _deduplicate(df: DataFrame, keys: list[str], order_by: list[str]) -> DataFrame:
+    def _to_order(expr: str):
+        parts = expr.strip().split()
+        column = parts[0]
+        direction = parts[1].lower() if len(parts) > 1 else "asc"
+        col_expr = F.col(column)
+        return col_expr.desc() if direction == "desc" else col_expr.asc()
+
+    window = Window.partitionBy(*[F.col(key) for key in keys]).orderBy(*[_to_order(expr) for expr in order_by])
+    ranked = df.withColumn("__dc_merge_rank", F.row_number().over(window))
+    return ranked.filter(F.col("__dc_merge_rank") == 1).drop("__dc_merge_rank")
+
+
 def _path_exists(spark: SparkSession, path: str) -> bool:
     jvm = spark._jvm
     fs = jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
     return fs.exists(jvm.org.apache.hadoop.fs.Path(path))
 
 
-def merge_generic(spark: SparkSession, df: DataFrame, target_path: str, keys: list[str]) -> None:
-    if not _path_exists(spark, target_path):
-        df.write.mode("overwrite").parquet(target_path)
+def merge_storage(
+    spark: SparkSession,
+    df: DataFrame,
+    sink: dict[str, Any],
+    keys: list[str],
+    order_by: list[str],
+) -> None:
+    uri = sink["uri"]
+    fmt = sink.get("format", "parquet")
+    options = sink.get("options", {})
+    if fmt == "delta":
+        merge_delta(uri, df, keys)
         return
-    existing = spark.read.parquet(target_path)
+
+    if not _path_exists(spark, uri):
+        df.write.format(fmt).mode("overwrite").options(**options).save(uri)
+        return
+
+    existing = spark.read.format(fmt).options(**options).load(uri).withColumn("__dc_is_new", F.lit(0))
+    incoming = df.withColumn("__dc_is_new", F.lit(1))
+    combined = existing.unionByName(incoming, allowMissingColumns=True)
+    order_with_flag = [*order_by, "__dc_is_new DESC"]
+    deduped = _deduplicate(combined, keys, order_with_flag).drop("__dc_is_new")
+    deduped.write.format(fmt).mode("overwrite").options(**options).save(uri)
+
+
+def merge_jdbc(df: DataFrame, sink: dict[str, Any], keys: list[str], order_by: list[str]) -> None:
+    spark = df.sparkSession
+    existing = jdbc.read(spark, sink)
     combined = existing.unionByName(df, allowMissingColumns=True)
+    deduped = _deduplicate(combined, keys, order_by)
+    overwrite_conf = {**sink, "mode": "overwrite", "truncate": True}
+    jdbc.write(deduped, overwrite_conf)
 
-    window = Window.partitionBy(*keys).orderBy("_ingestion_ts")
-    deduped = combined.withColumn("_rn", row_number().over(window)).filter("_rn = 1").drop("_rn")
-    deduped.write.mode("overwrite").parquet(target_path)
 
-
-def handle_incremental(df: DataFrame, sink: dict[str, Any], mode: str, keys: list[str]) -> None:
-    if mode == "append":
-        df.write.mode("append").format(sink.get("format", "parquet")).save(sink["uri"])
-        return
-    if mode == "merge":
-        if sink.get("format") == "delta":
-            merge_delta(sink["uri"], df, keys)
-        else:
-            merge_generic(df.sparkSession, df, sink["uri"], keys)
-        return
-    raise ValueError(f"Modo incremental no soportado: {mode}")
+def handle_incremental(
+    df: DataFrame,
+    sink: dict[str, Any],
+    incremental_cfg: dict[str, Any],
+) -> bool:
+    mode = incremental_cfg.get("mode", "append")
+    if mode != "merge":
+        return False
+    keys = incremental_cfg.get("keys", [])
+    if not keys:
+        raise ValueError("Se requieren keys para modo merge")
+    order_by = incremental_cfg.get("order_by", ["_ingestion_ts DESC"])
+    if sink["type"] == "storage":
+        merge_storage(df.sparkSession, df, sink, keys, order_by)
+        return True
+    if sink["type"] == "warehouse":
+        merge_jdbc(df, sink, keys, order_by)
+        return True
+    raise ValueError(f"Merge incremental no soportado para sink {sink['type']}")

--- a/datacore/core/ops.py
+++ b/datacore/core/ops.py
@@ -1,0 +1,158 @@
+"""Transformaciones declarativas puras."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from pyspark.sql import DataFrame, Window
+from pyspark.sql import functions as F
+from pyspark.sql.types import StructType
+
+Operation = Callable[[DataFrame, Any], DataFrame]
+
+
+def op_drop_columns(df: DataFrame, columns: list[str]) -> DataFrame:
+    return df.drop(*columns)
+
+
+def op_rename(df: DataFrame, mapping: dict[str, str]) -> DataFrame:
+    result = df
+    for old, new in mapping.items():
+        result = result.withColumnRenamed(old, new)
+    return result
+
+
+def op_cast(df: DataFrame, mapping: dict[str, str]) -> DataFrame:
+    result = df
+    for column, dtype in mapping.items():
+        result = result.withColumn(column, F.col(column).cast(dtype))
+    return result
+
+
+def op_trim(df: DataFrame, columns: list[str]) -> DataFrame:
+    result = df
+    for column in columns:
+        result = result.withColumn(column, F.trim(F.col(column)))
+    return result
+
+
+def op_uppercase(df: DataFrame, columns: list[str]) -> DataFrame:
+    result = df
+    for column in columns:
+        result = result.withColumn(column, F.upper(F.col(column)))
+    return result
+
+
+def op_lowercase(df: DataFrame, columns: list[str]) -> DataFrame:
+    result = df
+    for column in columns:
+        result = result.withColumn(column, F.lower(F.col(column)))
+    return result
+
+
+def op_normalize_whitespace(df: DataFrame, columns: list[str]) -> DataFrame:
+    result = df
+    for column in columns:
+        normalized = F.regexp_replace(F.col(column), r"\s+", " ")
+        result = result.withColumn(column, F.trim(normalized))
+    return result
+
+
+def op_standardize_dates(df: DataFrame, config: dict[str, Any]) -> DataFrame:
+    cols = config.get("cols", [])
+    fmt_in = config.get("format_in")
+    fmt_out = config.get("format_out", "yyyy-MM-dd HH:mm:ss")
+    timezone = config.get("tz")
+    result = df
+    for column in cols:
+        ts = F.to_timestamp(F.col(column), fmt_in) if fmt_in else F.to_timestamp(F.col(column))
+        if timezone:
+            ts = F.from_utc_timestamp(ts, timezone)
+        result = result.withColumn(column, F.date_format(ts, fmt_out))
+    return result
+
+
+def op_deduplicate(df: DataFrame, config: dict[str, Any]) -> DataFrame:
+    keys = config.get("keys", [])
+    order_by = config.get("order_by", ["_ingestion_ts DESC"])
+    def _to_order(expr: str):
+        parts = expr.strip().split()
+        column = parts[0]
+        direction = parts[1].lower() if len(parts) > 1 else "asc"
+        col_expr = F.col(column)
+        return col_expr.desc() if direction == "desc" else col_expr.asc()
+
+    window = Window.partitionBy(*[F.col(key) for key in keys]).orderBy(*[_to_order(expr) for expr in order_by])
+    ranked = df.withColumn("__dc_rn", F.row_number().over(window))
+    return ranked.filter(F.col("__dc_rn") == 1).drop("__dc_rn")
+
+
+def op_explode(df: DataFrame, config: dict[str, Any]) -> DataFrame:
+    column = config["col"]
+    outer = bool(config.get("outer", False))
+    explode_fn = F.explode_outer if outer else F.explode
+    return df.withColumn(column, explode_fn(F.col(column)))
+
+
+def _flatten_once(df: DataFrame, prefix: str) -> DataFrame:
+    struct_columns = [field for field in df.schema.fields if isinstance(field.dataType, StructType)]
+    if not struct_columns:
+        return df
+    select_exprs = [F.col(c) for c in df.columns if c not in {field.name for field in struct_columns}]
+    for field in struct_columns:
+        if prefix and not field.name.startswith(prefix):
+            base = f"{prefix}{field.name}"
+        else:
+            base = field.name
+        for nested in field.dataType.fields:
+            alias = f"{base}_{nested.name}".replace("__", "_")
+            select_exprs.append(F.col(f"{field.name}.{nested.name}").alias(alias))
+    return df.select(*select_exprs)
+
+
+def op_flatten_json(df: DataFrame, config: dict[str, Any]) -> DataFrame:
+    prefix = config.get("prefix", "")
+    depth = config.get("depth")
+    result = df
+    level = 0
+    while True:
+        struct_columns = [field for field in result.schema.fields if isinstance(field.dataType, StructType)]
+        if not struct_columns:
+            break
+        if depth is not None and level >= depth:
+            break
+        result = _flatten_once(result, prefix)
+        level += 1
+    return result
+
+
+OPERATIONS: dict[str, Operation] = {
+    "drop_columns": op_drop_columns,
+    "rename": op_rename,
+    "cast": op_cast,
+    "trim": op_trim,
+    "uppercase": op_uppercase,
+    "lowercase": op_lowercase,
+    "normalize_whitespace": op_normalize_whitespace,
+    "standardize_dates": op_standardize_dates,
+    "deduplicate": op_deduplicate,
+    "explode": op_explode,
+    "flatten_json": op_flatten_json,
+}
+
+
+def apply_ops(df: DataFrame, ops: list[dict[str, Any] | str]) -> DataFrame:
+    result = df
+    for op in ops:
+        if isinstance(op, str):
+            if op not in OPERATIONS:
+                raise KeyError(f"Operación declarativa no registrada: {op}")
+            result = OPERATIONS[op](result, {})
+            continue
+        if len(op) != 1:
+            raise ValueError(f"Las operaciones deben definirse como dicts de un solo elemento: {op}")
+        name, params = next(iter(op.items()))
+        if name not in OPERATIONS:
+            raise KeyError(f"Operación declarativa no registrada: {name}")
+        result = OPERATIONS[name](result, params)
+    return result

--- a/datacore/core/transforms.py
+++ b/datacore/core/transforms.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 
 from pyspark.sql import DataFrame
 
+from datacore.core import ops
+
 _TRANSFORMS: dict[str, Callable[[DataFrame], DataFrame]] = {}
 
 
@@ -20,3 +22,9 @@ def apply_registered(df: DataFrame, names: list[str]) -> DataFrame:
             raise KeyError(f"Transformación {name} no registrada")
         result = _TRANSFORMS[name](result)
     return result
+
+
+def apply_ops(df: DataFrame, operations: list[dict[str, object] | str]) -> DataFrame:
+    if not operations:
+        return df
+    return ops.apply_ops(df, operations)

--- a/datacore/core/validation.py
+++ b/datacore/core/validation.py
@@ -1,37 +1,233 @@
-"""Validaciones de datasets."""
+"""Validaciones de datasets con métricas y rejects."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import col
+from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
+from pyspark.sql.window import Window
 
 from datacore.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
 
+ALIAS_MAP = {
+    "expect_column_values_to_be_unique": "expect_unique",
+}
 
-def apply_validation(df: DataFrame, rules: dict[str, Any]) -> dict[str, int]:
-    metrics = {"input_rows": df.count()}
-    if not rules:
-        metrics["valid_rows"] = metrics["input_rows"]
-        metrics["invalid_rows"] = 0
-        return metrics
 
-    invalid_df = df
-    if "expect_not_null" in rules:
-        for column in rules["expect_not_null"]:
-            invalid_df = invalid_df.filter(col(column).isNull())
-    if "expect_unique" in rules:
-        for column in rules["expect_unique"]:
-            duplicates = df.groupBy(column).count().filter(col("count") > 1).count()
-            metrics[f"duplicates_{column}"] = duplicates
-    if "expect_domain" in rules:
-        for column, allowed in rules["expect_domain"].items():
-            invalid_df = invalid_df.filter(~col(column).isin(*allowed))
-    invalid_count = invalid_df.count()
-    metrics["invalid_rows"] = invalid_count
-    metrics["valid_rows"] = metrics["input_rows"] - invalid_count
+@dataclass
+class ValidationResult:
+    """Resultado completo de validación."""
+
+    valid_df: DataFrame
+    invalid_df: DataFrame
+    metrics: dict[str, Any]
+
+
+def _normalize_rules(rules: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for key, value in rules.items():
+        normalized_key = ALIAS_MAP.get(key, key)
+        normalized[normalized_key] = value
+    return normalized
+
+
+def _not_null(df: DataFrame, column: str) -> tuple[DataFrame, str]:
+    col_name = f"__rule_not_null_{column}"
+    return df.withColumn(col_name, F.col(column).isNotNull()), col_name
+
+
+def _unique(df: DataFrame, column: str) -> tuple[DataFrame, str]:
+    col_name = f"__rule_unique_{column}"
+    window = Window.partitionBy(F.col(column))
+    df = df.withColumn(col_name, F.when(F.col(column).isNull(), F.lit(False)).otherwise(F.count("*").over(window) == 1))
+    return df, col_name
+
+
+def _domain(df: DataFrame, column: str, allowed: list[Any]) -> tuple[DataFrame, str]:
+    col_name = f"__rule_domain_{column}"
+    return df.withColumn(col_name, F.col(column).isin(*allowed)), col_name
+
+
+def _between(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]:
+    column = config["col"]
+    col_name = f"__rule_between_{column}"
+    minimum = config.get("min")
+    maximum = config.get("max")
+    condition = F.lit(True)
+    if minimum is not None:
+        condition = condition & (F.col(column) >= F.lit(minimum))
+    if maximum is not None:
+        condition = condition & (F.col(column) <= F.lit(maximum))
+    return df.withColumn(col_name, condition), col_name
+
+
+def _regex(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]:
+    column = config["col"]
+    pattern = config["pattern"]
+    col_name = f"__rule_regex_{column}"
+    return df.withColumn(col_name, F.col(column).rlike(pattern)), col_name
+
+
+def _email(df: DataFrame, column: str) -> tuple[DataFrame, str]:
+    col_name = f"__rule_email_{column}"
+    pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    return df.withColumn(col_name, F.col(column).rlike(pattern)), col_name
+
+
+def _length(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]:
+    column = config["col"]
+    col_name = f"__rule_length_{column}"
+    min_length = config.get("min")
+    max_length = config.get("max")
+    length_col = F.length(F.col(column))
+    condition = F.lit(True)
+    if min_length is not None:
+        condition = condition & (length_col >= F.lit(min_length))
+    if max_length is not None:
+        condition = condition & (length_col <= F.lit(max_length))
+    return df.withColumn(col_name, condition), col_name
+
+
+def _set_membership(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]:
+    column = config["col"]
+    allowed = config.get("allowed", [])
+    col_name = f"__rule_set_{column}"
+    return df.withColumn(col_name, F.col(column).isin(*allowed)), col_name
+
+
+def _foreign_key(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]:
+    column = config["col"]
+    ref_table = config.get("ref_table")
+    ref_col = config.get("ref_col")
+    col_name = f"__rule_fk_{column}"
+    if not ref_table or not ref_col:
+        LOGGER.warning("Regla expect_foreign_key sin ref_table/ref_col, se omite")
+        return df.withColumn(col_name, F.lit(True)), col_name
+    try:
+        reference = df.sparkSession.table(ref_table).select(F.col(ref_col).alias("__fk_ref")).distinct()
+    except AnalysisException:
+        LOGGER.warning("No se pudo resolver tabla de referencia %s, se omite validación", ref_table)
+        return df.withColumn(col_name, F.lit(True)), col_name
+    joined = df.join(reference, df[column] == reference["__fk_ref"], "left")
+    result = joined.withColumn(col_name, reference["__fk_ref"].isNotNull()).drop("__fk_ref")
+    return result, col_name
+
+
+RULE_BUILDERS = {
+    "expect_not_null": lambda df, cols: [ _not_null(df, column) for column in cols ],
+}
+
+
+def _apply_rules(df: DataFrame, rules: dict[str, Any]) -> tuple[DataFrame, list[str], list[tuple[str, str]]]:
+    result = df
+    rule_columns: list[str] = []
+    rule_reasons: list[tuple[str, str]] = []
+
+    for column in rules.get("expect_not_null", []):
+        result, rule_col = _not_null(result, column)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_not_null:{column}"))
+
+    for column in rules.get("expect_unique", []):
+        result, rule_col = _unique(result, column)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_unique:{column}"))
+
+    for column, allowed in rules.get("expect_domain", {}).items():
+        result, rule_col = _domain(result, column, allowed)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_domain:{column}"))
+
+    for config in rules.get("expect_between", []):
+        result, rule_col = _between(result, config)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_between:{config['col']}"))
+
+    for config in rules.get("expect_regex", []):
+        result, rule_col = _regex(result, config)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_regex:{config['col']}"))
+
+    for column in rules.get("expect_email", []):
+        result, rule_col = _email(result, column)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_email:{column}"))
+
+    for config in rules.get("expect_length", []):
+        result, rule_col = _length(result, config)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_length:{config['col']}"))
+
+    for config in rules.get("expect_set", []):
+        result, rule_col = _set_membership(result, config)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_set:{config['col']}"))
+
+    for config in rules.get("expect_foreign_key", []):
+        result, rule_col = _foreign_key(result, config)
+        rule_columns.append(rule_col)
+        rule_reasons.append((rule_col, f"expect_foreign_key:{config['col']}"))
+
+    return result, rule_columns, rule_reasons
+
+
+def apply_validation(df: DataFrame, rules: dict[str, Any]) -> ValidationResult:
+    normalized = _normalize_rules(rules)
+    if not normalized:
+        input_rows = df.count()
+        metrics = {"input_rows": input_rows, "valid_rows": input_rows, "invalid_rows": 0, "rules": {}}
+        return ValidationResult(valid_df=df, invalid_df=df.limit(0), metrics=metrics)
+
+    with_checks, rule_columns, rule_reasons = _apply_rules(df, normalized)
+    if not rule_columns:
+        input_rows = df.count()
+        metrics = {"input_rows": input_rows, "valid_rows": input_rows, "invalid_rows": 0, "rules": {}}
+        return ValidationResult(valid_df=df, invalid_df=df.limit(0), metrics=metrics)
+
+    validity_expr = F.lit(True)
+    for column in rule_columns:
+        validity_expr = validity_expr & F.col(column)
+    enriched = with_checks.withColumn("__dc_valid", validity_expr)
+
+    reasons = [F.when(~F.col(rule_col), F.lit(reason)) for rule_col, reason in rule_reasons]
+    reasons = [expr for expr in reasons if expr is not None]
+    if reasons:
+        enriched = enriched.withColumn("__dc_reasons", F.array(*reasons))
+        cleaned = F.array_distinct(F.expr("filter(__dc_reasons, x -> x is not null)"))
+        enriched = enriched.withColumn(
+            "_reject_reason",
+            F.when(F.size(cleaned) > 0, F.array_join(cleaned, "; ")).otherwise(F.lit("")),
+        )
+    else:
+        enriched = enriched.withColumn("_reject_reason", F.lit(""))
+
+    input_rows = df.count()
+    invalid_rows = enriched.filter(~F.col("__dc_valid")).count()
+    valid_rows = input_rows - invalid_rows
+
+    metrics_exprs = [
+        F.sum(F.when(~F.col(column), F.lit(1)).otherwise(F.lit(0))).alias(reason)
+        for column, reason in rule_reasons
+    ]
+    if metrics_exprs:
+        metrics_row = enriched.agg(*metrics_exprs).collect()[0].asDict()
+    else:
+        metrics_row = {}
+
+    metrics = {
+        "input_rows": input_rows,
+        "valid_rows": valid_rows,
+        "invalid_rows": invalid_rows,
+        "rules": metrics_row,
+    }
+
+    valid_df = enriched.filter(F.col("__dc_valid")).drop(*rule_columns, "__dc_valid", "__dc_reasons")
+    invalid_df = enriched.filter(~F.col("__dc_valid")).drop(*rule_columns, "__dc_valid", "__dc_reasons")
+
     LOGGER.info("Validación completada. métricas=%s", metrics)
-    return metrics
+    return ValidationResult(valid_df=valid_df, invalid_df=invalid_df, metrics=metrics)

--- a/datacore/core/validation.py
+++ b/datacore/core/validation.py
@@ -16,6 +16,10 @@ LOGGER = get_logger(__name__)
 
 ALIAS_MAP = {
     "expect_column_values_to_be_unique": "expect_unique",
+    "expect_domain": "values_in_set",
+    "expect_set": "values_in_set",
+    "expect_between": "range",
+    "expect_regex": "regex",
 }
 
 
@@ -25,15 +29,19 @@ class ValidationResult:
 
     valid_df: DataFrame
     invalid_df: DataFrame
+    quarantine_df: DataFrame
     metrics: dict[str, Any]
+    extras: dict[str, Any] | None = None
 
 
-def _normalize_rules(rules: dict[str, Any]) -> dict[str, Any]:
-    normalized: dict[str, Any] = {}
-    for key, value in rules.items():
-        normalized_key = ALIAS_MAP.get(key, key)
-        normalized[normalized_key] = value
-    return normalized
+@dataclass
+class RuleConfig:
+    name: str
+    identifier: str
+    params: dict[str, Any]
+    severity: str = "error"
+    threshold: float = 0.0
+    on_fail: str | None = None
 
 
 def _not_null(df: DataFrame, column: str) -> tuple[DataFrame, str]:
@@ -46,11 +54,6 @@ def _unique(df: DataFrame, column: str) -> tuple[DataFrame, str]:
     window = Window.partitionBy(F.col(column))
     df = df.withColumn(col_name, F.when(F.col(column).isNull(), F.lit(False)).otherwise(F.count("*").over(window) == 1))
     return df, col_name
-
-
-def _domain(df: DataFrame, column: str, allowed: list[Any]) -> tuple[DataFrame, str]:
-    col_name = f"__rule_domain_{column}"
-    return df.withColumn(col_name, F.col(column).isin(*allowed)), col_name
 
 
 def _between(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]:
@@ -119,84 +122,233 @@ def _foreign_key(df: DataFrame, config: dict[str, Any]) -> tuple[DataFrame, str]
 
 
 RULE_BUILDERS = {
-    "expect_not_null": lambda df, cols: [ _not_null(df, column) for column in cols ],
+    "expect_not_null": lambda df, column: _not_null(df, column),
+    "expect_unique": lambda df, column: _unique(df, column),
+    "values_in_set": lambda df, conf: _set_membership(df, conf),
+    "range": lambda df, conf: _between(df, conf),
+    "regex": lambda df, conf: _regex(df, conf),
+    "expect_email": lambda df, column: _email(df, column),
+    "expect_length": lambda df, conf: _length(df, conf),
+    "expect_foreign_key": lambda df, conf: _foreign_key(df, conf),
 }
 
 
-def _apply_rules(df: DataFrame, rules: dict[str, Any]) -> tuple[DataFrame, list[str], list[tuple[str, str]]]:
-    result = df
-    rule_columns: list[str] = []
-    rule_reasons: list[tuple[str, str]] = []
+def _ensure_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
 
-    for column in rules.get("expect_not_null", []):
-        result, rule_col = _not_null(result, column)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_not_null:{column}"))
 
-    for column in rules.get("expect_unique", []):
-        result, rule_col = _unique(result, column)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_unique:{column}"))
+def _legacy_to_rules(config: dict[str, Any]) -> list[RuleConfig]:
+    rules: list[RuleConfig] = []
+    normalized = {ALIAS_MAP.get(key, key): value for key, value in config.items() if key != "quarantine_sink"}
+    for column in _ensure_list(normalized.get("expect_not_null")):
+        rules.append(RuleConfig("expect_not_null", f"expect_not_null:{column}", {"column": column}))
+    for column in _ensure_list(normalized.get("expect_unique")):
+        rules.append(RuleConfig("expect_unique", f"expect_unique:{column}", {"column": column}))
+    domain_conf = normalized.get("values_in_set") or normalized.get("expect_set") or {}
+    if isinstance(domain_conf, dict):
+        items = domain_conf.items()
+    else:
+        items = []
+        for entry in _ensure_list(domain_conf):
+            if isinstance(entry, dict) and "col" in entry:
+                items.append((entry.get("col"), entry.get("allowed")))
+    for column, allowed in items:
+        if column is None:
+            continue
+        rules.append(
+            RuleConfig("values_in_set", f"values_in_set:{column}", {"col": column, "allowed": allowed})
+        )
+    between_conf = normalized.get("range") or normalized.get("expect_between") or []
+    for entry in _ensure_list(between_conf):
+        if isinstance(entry, dict) and "col" in entry:
+            rules.append(RuleConfig("range", f"range:{entry['col']}", entry))
+    regex_conf = normalized.get("regex") or normalized.get("expect_regex") or []
+    for entry in _ensure_list(regex_conf):
+        if isinstance(entry, dict) and "col" in entry:
+            rules.append(RuleConfig("regex", f"regex:{entry['col']}", entry))
+    for column in _ensure_list(normalized.get("expect_email")):
+        rules.append(RuleConfig("expect_email", f"expect_email:{column}", {"column": column}))
+    length_conf = normalized.get("expect_length") or []
+    for entry in _ensure_list(length_conf):
+        if isinstance(entry, dict) and "col" in entry:
+            rules.append(RuleConfig("expect_length", f"expect_length:{entry['col']}", entry))
+    fk_conf = normalized.get("expect_foreign_key") or []
+    for entry in _ensure_list(fk_conf):
+        if isinstance(entry, dict) and "col" in entry:
+            rules.append(RuleConfig("expect_foreign_key", f"expect_foreign_key:{entry['col']}", entry))
+    return rules
 
-    for column, allowed in rules.get("expect_domain", {}).items():
-        result, rule_col = _domain(result, column, allowed)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_domain:{column}"))
 
-    for config in rules.get("expect_between", []):
-        result, rule_col = _between(result, config)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_between:{config['col']}"))
+def _modern_to_rules(config: dict[str, Any]) -> list[RuleConfig]:
+    rules: list[RuleConfig] = []
+    for entry in config.get("rules", []):
+        if not isinstance(entry, dict):
+            continue
+        check = ALIAS_MAP.get(entry.get("check"), entry.get("check"))
+        if not check:
+            continue
+        severity = str(entry.get("severity", "error")).lower()
+        threshold = float(entry.get("threshold", 0.0))
+        on_fail = entry.get("on_fail")
+        identifier = entry.get("name")
+        if check in {"expect_not_null", "expect_unique", "expect_email"}:
+            for column in _ensure_list(entry.get("columns") or entry.get("column")):
+                rule_id = identifier or f"{check}:{column}"
+                params = {"column": column}
+                rules.append(
+                    RuleConfig(check, rule_id, params, severity=severity, threshold=threshold, on_fail=on_fail)
+                )
+        elif check in {"values_in_set"}:
+            column = entry.get("column") or entry.get("col")
+            allowed = entry.get("allowed") or entry.get("values")
+            if column is not None:
+                rule_id = identifier or f"{check}:{column}"
+                params = {"col": column, "allowed": allowed}
+                rules.append(
+                    RuleConfig(check, rule_id, params, severity=severity, threshold=threshold, on_fail=on_fail)
+                )
+        elif check in {"range"}:
+            column = entry.get("column") or entry.get("col")
+            if column is not None:
+                rule_id = identifier or f"{check}:{column}"
+                params = {"col": column, "min": entry.get("min"), "max": entry.get("max")}
+                rules.append(
+                    RuleConfig(check, rule_id, params, severity=severity, threshold=threshold, on_fail=on_fail)
+                )
+        elif check in {"regex"}:
+            column = entry.get("column") or entry.get("col")
+            pattern = entry.get("pattern")
+            if column is not None and pattern is not None:
+                rule_id = identifier or f"{check}:{column}"
+                params = {"col": column, "pattern": pattern}
+                rules.append(
+                    RuleConfig(check, rule_id, params, severity=severity, threshold=threshold, on_fail=on_fail)
+                )
+        elif check in {"expect_length"}:
+            column = entry.get("column") or entry.get("col")
+            if column is not None:
+                rule_id = identifier or f"{check}:{column}"
+                params = {
+                    "col": column,
+                    "min": entry.get("min"),
+                    "max": entry.get("max"),
+                }
+                rules.append(
+                    RuleConfig(check, rule_id, params, severity=severity, threshold=threshold, on_fail=on_fail)
+                )
+        elif check in {"expect_foreign_key"}:
+            column = entry.get("column") or entry.get("col")
+            if column is not None:
+                rule_id = identifier or f"{check}:{column}"
+                params = {
+                    "col": column,
+                    "ref_table": entry.get("ref_table"),
+                    "ref_col": entry.get("ref_col"),
+                }
+                rules.append(
+                    RuleConfig(check, rule_id, params, severity=severity, threshold=threshold, on_fail=on_fail)
+                )
+    return rules
 
-    for config in rules.get("expect_regex", []):
-        result, rule_col = _regex(result, config)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_regex:{config['col']}"))
 
-    for column in rules.get("expect_email", []):
-        result, rule_col = _email(result, column)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_email:{column}"))
-
-    for config in rules.get("expect_length", []):
-        result, rule_col = _length(result, config)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_length:{config['col']}"))
-
-    for config in rules.get("expect_set", []):
-        result, rule_col = _set_membership(result, config)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_set:{config['col']}"))
-
-    for config in rules.get("expect_foreign_key", []):
-        result, rule_col = _foreign_key(result, config)
-        rule_columns.append(rule_col)
-        rule_reasons.append((rule_col, f"expect_foreign_key:{config['col']}"))
-
-    return result, rule_columns, rule_reasons
+def _extract_rules(config: dict[str, Any]) -> tuple[list[RuleConfig], dict[str, Any]]:
+    if not config:
+        return [], {}
+    if "rules" in config:
+        rules = _modern_to_rules(config)
+    else:
+        rules = _legacy_to_rules(config)
+    extras = {}
+    if "quarantine_sink" in config:
+        extras["quarantine_sink"] = config["quarantine_sink"]
+    return rules, extras
 
 
 def apply_validation(df: DataFrame, rules: dict[str, Any]) -> ValidationResult:
-    normalized = _normalize_rules(rules)
-    if not normalized:
+    rule_configs, extras = _extract_rules(rules)
+    if not rule_configs:
         input_rows = df.count()
+        empty = df.limit(0)
         metrics = {"input_rows": input_rows, "valid_rows": input_rows, "invalid_rows": 0, "rules": {}}
-        return ValidationResult(valid_df=df, invalid_df=df.limit(0), metrics=metrics)
+        return ValidationResult(
+            valid_df=df,
+            invalid_df=empty,
+            quarantine_df=empty,
+            metrics=metrics,
+            extras=extras,
+        )
 
-    with_checks, rule_columns, rule_reasons = _apply_rules(df, normalized)
-    if not rule_columns:
+    enriched = df
+    runtime: list[tuple[RuleConfig, str]] = []
+    for rule in rule_configs:
+        builder = RULE_BUILDERS.get(rule.name)
+        if not builder:
+            LOGGER.warning("Regla %s no soportada, se omite", rule.name)
+            continue
+        if rule.name in {"expect_not_null", "expect_unique", "expect_email"}:
+            enriched, column = builder(enriched, rule.params["column"])
+        else:
+            enriched, column = builder(enriched, rule.params)
+        runtime.append((rule, column))
+
+    if not runtime:
         input_rows = df.count()
+        empty = df.limit(0)
         metrics = {"input_rows": input_rows, "valid_rows": input_rows, "invalid_rows": 0, "rules": {}}
-        return ValidationResult(valid_df=df, invalid_df=df.limit(0), metrics=metrics)
+        return ValidationResult(
+            valid_df=df,
+            invalid_df=empty,
+            quarantine_df=empty,
+            metrics=metrics,
+            extras=extras,
+        )
+
+    input_rows = df.count()
+    metrics_exprs = [
+        F.sum(F.when(~F.col(column), F.lit(1)).otherwise(F.lit(0))).alias(column) for _, column in runtime
+    ]
+    counts_row = enriched.agg(*metrics_exprs).collect()[0] if metrics_exprs else None
+
+    rule_metrics: dict[str, Any] = {}
+    reject_reasons: list[tuple[str, str]] = []
+    quarantine_frames: list[DataFrame] = []
+
+    for rule, column in runtime:
+        invalid_count = counts_row[column] if counts_row else 0
+        ratio = (invalid_count / input_rows) if input_rows else 0.0
+        failed = ratio > rule.threshold if rule.threshold is not None else invalid_count > 0
+        action = (rule.on_fail or "").lower() if rule.on_fail else None
+        rule_metrics[rule.identifier] = {
+            "invalid_rows": int(invalid_count),
+            "ratio": ratio,
+            "threshold": rule.threshold,
+            "failed": bool(failed),
+            "severity": rule.severity,
+            "action": action,
+        }
+
+        if failed and action == "quarantine":
+            quarantine_frames.append(
+                enriched.filter(~F.col(column)).withColumn("_quarantine_reason", F.lit(rule.identifier))
+            )
+
+        should_reject = failed and rule.severity == "error"
+        if should_reject:
+            reject_reasons.append((column, rule.identifier))
+        else:
+            enriched = enriched.withColumn(column, F.lit(True))
 
     validity_expr = F.lit(True)
-    for column in rule_columns:
+    for _, column in runtime:
         validity_expr = validity_expr & F.col(column)
-    enriched = with_checks.withColumn("__dc_valid", validity_expr)
+    enriched = enriched.withColumn("__dc_valid", validity_expr)
 
-    reasons = [F.when(~F.col(rule_col), F.lit(reason)) for rule_col, reason in rule_reasons]
-    reasons = [expr for expr in reasons if expr is not None]
-    if reasons:
+    if reject_reasons:
+        reasons = [F.when(~F.col(col), F.lit(reason)) for col, reason in reject_reasons]
         enriched = enriched.withColumn("__dc_reasons", F.array(*reasons))
         cleaned = F.array_distinct(F.expr("filter(__dc_reasons, x -> x is not null)"))
         enriched = enriched.withColumn(
@@ -206,28 +358,33 @@ def apply_validation(df: DataFrame, rules: dict[str, Any]) -> ValidationResult:
     else:
         enriched = enriched.withColumn("_reject_reason", F.lit(""))
 
-    input_rows = df.count()
     invalid_rows = enriched.filter(~F.col("__dc_valid")).count()
     valid_rows = input_rows - invalid_rows
 
-    metrics_exprs = [
-        F.sum(F.when(~F.col(column), F.lit(1)).otherwise(F.lit(0))).alias(reason)
-        for column, reason in rule_reasons
-    ]
-    if metrics_exprs:
-        metrics_row = enriched.agg(*metrics_exprs).collect()[0].asDict()
+    if quarantine_frames:
+        quarantine_df = quarantine_frames[0]
+        for frame in quarantine_frames[1:]:
+            quarantine_df = quarantine_df.unionByName(frame)
     else:
-        metrics_row = {}
+        quarantine_df = enriched.limit(0)
+
+    drop_columns = [col for _, col in runtime]
+    valid_df = enriched.filter(F.col("__dc_valid")).drop(*drop_columns, "__dc_valid", "__dc_reasons")
+    invalid_df = enriched.filter(~F.col("__dc_valid")).drop(*drop_columns, "__dc_valid", "__dc_reasons")
+    quarantine_df = quarantine_df.drop(*drop_columns, "__dc_valid", "__dc_reasons")
 
     metrics = {
         "input_rows": input_rows,
         "valid_rows": valid_rows,
         "invalid_rows": invalid_rows,
-        "rules": metrics_row,
+        "rules": rule_metrics,
     }
 
-    valid_df = enriched.filter(F.col("__dc_valid")).drop(*rule_columns, "__dc_valid", "__dc_reasons")
-    invalid_df = enriched.filter(~F.col("__dc_valid")).drop(*rule_columns, "__dc_valid", "__dc_reasons")
-
     LOGGER.info("Validación completada. métricas=%s", metrics)
-    return ValidationResult(valid_df=valid_df, invalid_df=invalid_df, metrics=metrics)
+    return ValidationResult(
+        valid_df=valid_df,
+        invalid_df=invalid_df,
+        quarantine_df=quarantine_df,
+        metrics=metrics,
+        extras=extras,
+    )

--- a/datacore/io/readers.py
+++ b/datacore/io/readers.py
@@ -1,43 +1,300 @@
-"""Lectores genéricos."""
+"""Lectores genéricos para múltiples orígenes."""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.types import StructType
 
+from datacore.connectors.api import graphql, rest
 from datacore.connectors.db import jdbc
 from datacore.connectors.storage import abfs, gcs, local, s3
 from datacore.platforms.base import PlatformBase
 
+FORMAT_DEFAULTS: dict[str, dict[str, Any]] = {
+    "csv": {"header": "true", "inferSchema": "true", "delimiter": ","},
+    "json": {"multiLine": "true"},
+    "parquet": {},
+    "avro": {},
+    "orc": {},
+}
 
-def read_batch(spark: SparkSession, platform: PlatformBase, source: dict[str, Any]) -> DataFrame:
-    source_type = source["type"]
+
+def _apply_options(reader, options: dict[str, Any]):
+    for key, value in options.items():
+        reader = reader.option(key, value)
+    return reader
+
+
+def _schema_cache_path(
+    platform: PlatformBase, layer: str, dataset: str, environment: str
+) -> Path:
+    checkpoint = Path(platform.checkpoint_dir(layer, dataset, environment))
+    cache_dir = checkpoint / "_schema_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / "schema.json"
+
+
+def _load_schema(cache_path: Path) -> StructType | None:
+    if not cache_path.exists():
+        return None
+    with cache_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return StructType.fromJson(payload)
+
+
+def _store_schema(cache_path: Path, schema: StructType) -> None:
+    cache_path.write_text(
+        json.dumps(schema.jsonValue(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _merge_format_options(fmt: str, options: dict[str, Any], infer_schema: bool) -> dict[str, Any]:
+    defaults = FORMAT_DEFAULTS.get(fmt, {})
+    merged = {**defaults, **options}
+    if infer_schema and fmt == "csv":
+        merged.setdefault("inferSchema", "true")
+    return merged
+
+
+def _storage_connector(backend: str):
+    connectors = {
+        "aws": s3,
+        "azure": abfs,
+        "gcp": gcs,
+        "local": local,
+    }
+    return connectors.get(backend, local)
+
+
+def _read_storage(
+    spark: SparkSession,
+    platform: PlatformBase,
+    source: dict[str, Any],
+    *,
+    layer: str,
+    dataset: str,
+    environment: str,
+) -> DataFrame:
     fmt = source.get("format", "parquet")
     options = source.get("options", {})
+    infer_schema = bool(source.get("infer_schema"))
+    merged_options = _merge_format_options(fmt, options, infer_schema)
+    backend = source.get("backend", platform.name)
+    uri = platform.normalize_uri(source["uri"])
+    cache_path = _schema_cache_path(platform, layer, dataset, environment)
+    cached_schema = _load_schema(cache_path) if infer_schema else None
+    connector = _storage_connector(backend)
+    df = connector.read(spark, uri, fmt, merged_options, schema=cached_schema)
+    if infer_schema and cached_schema is None:
+        _store_schema(cache_path, df.schema)
+    return df
+
+
+def _record_path_to_list(record_path: str | list[str] | None) -> list[str] | None:
+    if record_path is None:
+        return None
+    if isinstance(record_path, list):
+        return record_path
+    return [segment for segment in record_path.split(".") if segment]
+
+
+def _extract_records(payload: Any, record_path: list[str] | None) -> list[dict[str, Any]]:
+    target = payload
+    if record_path:
+        for segment in record_path:
+            if isinstance(target, dict):
+                target = target.get(segment)
+            else:
+                target = None
+            if target is None:
+                return []
+    if isinstance(target, list):
+        return [item for item in target if isinstance(item, dict)]
+    if isinstance(target, dict):
+        return [target]
+    return []
+
+
+def _flatten_record(record: dict[str, Any], depth: int | None = None, prefix: str = "") -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    for key, value in record.items():
+        column = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+        if isinstance(value, dict) and (depth is None or depth > 0):
+            nested = _flatten_record(value, None if depth is None else depth - 1, column)
+            flattened.update(nested)
+        else:
+            flattened[column] = value
+    return flattened
+
+
+def _records_to_df(spark: SparkSession, records: list[dict[str, Any]]) -> DataFrame:
+    if not records:
+        return spark.createDataFrame([], StructType([]))
+    return spark.createDataFrame(records)
+
+
+def _read_api_rest(
+    spark: SparkSession,
+    platform: PlatformBase,
+    source: dict[str, Any],
+    *,
+    layer: str,
+    dataset: str,
+    environment: str,
+) -> DataFrame:
+    fetch_config = {**source.get("options", {}), **{k: v for k, v in source.items() if k in {"url", "headers", "params", "page_param", "start_page", "max_pages", "backoff", "bearer_token"}}}
+    record_path = _record_path_to_list(source.get("record_path"))
+    flatten = source.get("flatten", True)
+    depth = source.get("flatten_depth")
+    rows: list[dict[str, Any]] = []
+    for page in rest.fetch_pages(fetch_config):
+        for record in _extract_records(page, record_path):
+            rows.append(_flatten_record(record, depth=depth) if flatten else record)
+    df = _records_to_df(spark, rows)
+    if source.get("infer_schema"):
+        cache_path = _schema_cache_path(platform, layer, dataset, environment)
+        _store_schema(cache_path, df.schema)
+    return df
+
+
+def _read_api_graphql(
+    spark: SparkSession,
+    platform: PlatformBase,
+    source: dict[str, Any],
+    *,
+    layer: str,
+    dataset: str,
+    environment: str,
+) -> DataFrame:
+    payload = graphql.execute_query(
+        {
+            "url": source["url"],
+            "query": source["query"],
+            "variables": source.get("variables", {}),
+            "headers": source.get("headers", {}),
+        }
+    )
+    record_path = _record_path_to_list(source.get("record_path"))
+    flatten = source.get("flatten", True)
+    depth = source.get("flatten_depth")
+    rows = [
+        _flatten_record(record, depth=depth) if flatten else record
+        for record in _extract_records(payload, record_path)
+    ]
+    df = _records_to_df(spark, rows)
+    if source.get("infer_schema"):
+        cache_path = _schema_cache_path(platform, layer, dataset, environment)
+        _store_schema(cache_path, df.schema)
+    return df
+
+
+def _parse_stream_payload(df: DataFrame, source: dict[str, Any]) -> DataFrame:
+    payload_format = source.get("payload_format", "json").lower()
+    schema_conf = source.get("schema")
+    schema: StructType | None = None
+    if isinstance(schema_conf, dict):
+        schema = StructType.fromJson(schema_conf)
+    elif isinstance(schema_conf, str):
+        try:
+            schema = StructType.fromJson(json.loads(schema_conf))
+        except json.JSONDecodeError:
+            schema = StructType.fromDDL(schema_conf)
+    value_col = F.col("value").cast("string")
+    if payload_format == "json" and schema is not None:
+        parsed = F.from_json(value_col, schema).alias("payload")
+        return df.withColumn("payload", parsed).select("payload.*")
+    if payload_format == "csv" and schema is not None:
+        parsed = F.from_csv(value_col, schema).alias("payload")
+        return df.withColumn("payload", parsed).select("payload.*")
+    return df.withColumn("payload", value_col)
+
+
+def _read_kafka_batch(spark: SparkSession, source: dict[str, Any]) -> DataFrame:
+    reader = spark.read.format("kafka")
+    reader = _apply_options(reader, source.get("options", {}))
+    df = reader.load()
+    return _parse_stream_payload(df, source)
+
+
+def _read_event_hubs_batch(spark: SparkSession, source: dict[str, Any]) -> DataFrame:
+    reader = spark.read.format("eventhubs")
+    reader = _apply_options(reader, source.get("options", {}))
+    df = reader.load()
+    return _parse_stream_payload(df, source)
+
+
+def read_batch(
+    spark: SparkSession,
+    platform: PlatformBase,
+    source: dict[str, Any],
+    *,
+    layer: str,
+    dataset: str,
+    environment: str,
+) -> DataFrame:
+    source_type = source["type"]
     if source_type == "storage":
-        uri = platform.normalize_uri(source["uri"])
-        backend = source.get("backend", platform.name)
-        if backend == "aws":
-            return s3.read(spark, uri, fmt, options)
-        if backend == "azure":
-            return abfs.read(spark, uri, fmt, options)
-        if backend == "gcp":
-            return gcs.read(spark, uri, fmt, options)
-        return local.read(spark, uri, fmt, options)
+        return _read_storage(spark, platform, source, layer=layer, dataset=dataset, environment=environment)
     if source_type == "jdbc":
         return jdbc.read(spark, source)
+    if source_type == "api_rest":
+        return _read_api_rest(spark, platform, source, layer=layer, dataset=dataset, environment=environment)
+    if source_type == "api_graphql":
+        return _read_api_graphql(spark, platform, source, layer=layer, dataset=dataset, environment=environment)
+    if source_type == "kafka":
+        return _read_kafka_batch(spark, source)
+    if source_type == "event_hubs":
+        return _read_event_hubs_batch(spark, source)
     raise ValueError(f"Tipo de origen no soportado: {source_type}")
 
 
-def read_stream(spark: SparkSession, platform: PlatformBase, source: dict[str, Any]) -> DataFrame:
-    source_type = source["type"]
+def _read_storage_stream(
+    spark: SparkSession,
+    platform: PlatformBase,
+    source: dict[str, Any],
+) -> DataFrame:
     fmt = source.get("format", "parquet")
-    options = source.get("options", {})
+    options = _merge_format_options(fmt, source.get("options", {}), False)
+    uri = platform.normalize_uri(source["uri"])
+    reader = spark.readStream.format(fmt)
+    reader = _apply_options(reader, options)
+    return reader.load(uri)
+
+
+def _read_kafka_stream(spark: SparkSession, source: dict[str, Any]) -> DataFrame:
+    reader = spark.readStream.format("kafka")
+    reader = _apply_options(reader, source.get("options", {}))
+    df = reader.load()
+    return _parse_stream_payload(df, source)
+
+
+def _read_event_hubs_stream(spark: SparkSession, source: dict[str, Any]) -> DataFrame:
+    reader = spark.readStream.format("eventhubs")
+    reader = _apply_options(reader, source.get("options", {}))
+    df = reader.load()
+    return _parse_stream_payload(df, source)
+
+
+def read_stream(
+    spark: SparkSession,
+    platform: PlatformBase,
+    source: dict[str, Any],
+    *,
+    layer: str,
+    dataset: str,
+    environment: str,
+) -> DataFrame:
+    source_type = source["type"]
     if source_type == "storage":
-        uri = platform.normalize_uri(source["uri"])
-        reader = spark.readStream.format(fmt)
-        for key, value in options.items():
-            reader = reader.option(key, value)
-        return reader.load(uri)
+        return _read_storage_stream(spark, platform, source)
+    if source_type == "kafka":
+        return _read_kafka_stream(spark, source)
+    if source_type == "event_hubs":
+        return _read_event_hubs_stream(spark, source)
     raise ValueError(f"Streaming no soportado para {source_type}")

--- a/datacore/platforms/aws_glue.py
+++ b/datacore/platforms/aws_glue.py
@@ -25,8 +25,8 @@ class AwsGluePlatform(PlatformBase):
             builder = builder.config(key, value)
         return builder.getOrCreate()
 
-    def resolve_secret(self, name: str) -> str:
+    def _resolve_platform_secret(self, name: str) -> str:
         secrets = self.config.get("secrets", {})
         if name in secrets:
             return secrets[name]
-        raise KeyError(f"Secreto {name} no disponible en AWS config")
+        return ""

--- a/datacore/platforms/azure_databricks.py
+++ b/datacore/platforms/azure_databricks.py
@@ -21,8 +21,8 @@ class AzureDatabricksPlatform(PlatformBase):
             builder = builder.config(key, value)
         return builder.getOrCreate()
 
-    def resolve_secret(self, name: str) -> str:
+    def _resolve_platform_secret(self, name: str) -> str:
         secrets = self.config.get("secrets", {})
         if name in secrets:
             return secrets[name]
-        raise KeyError(f"Secreto {name} no disponible en Azure config")
+        return ""

--- a/datacore/platforms/base.py
+++ b/datacore/platforms/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import os
 from typing import Any
 
 from pyspark.sql import SparkSession
@@ -22,9 +23,37 @@ class PlatformBase(abc.ABC):
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
         """Crea la SparkSession con configuraciones específicas."""
 
-    @abc.abstractmethod
     def resolve_secret(self, name: str) -> str:
-        """Obtiene un secreto desde la plataforma."""
+        """Obtiene un secreto desde la plataforma o variables de entorno."""
+
+        if name.startswith("SECRET:"):
+            resolved = self._resolve_platform_secret(name.split(":", 1)[1])
+            if resolved:
+                return resolved
+        env_value = os.getenv(name)
+        if env_value:
+            return env_value
+        config_value = self.config.get("secrets", {}).get(name)
+        if config_value:
+            return config_value
+        return ""
+
+    @abc.abstractmethod
+    def _resolve_platform_secret(self, name: str) -> str:
+        """Implementado por cada plataforma para resolver secretos nativos."""
+
+    def resolve_secret_reference(self, value: str) -> str:
+        """Resuelve expresiones del tipo ${ENV} o ${SECRET:NAME}."""
+
+        if value.startswith("${") and value.endswith("}"):
+            inner = value[2:-1]
+            return self.resolve_secret(inner)
+        if value.startswith("SECRET:"):
+            return self.resolve_secret(value)
+        env_value = os.getenv(value)
+        if env_value:
+            return env_value
+        return value
 
     def normalize_uri(self, uri: str) -> str:
         return normalize_uri(uri)
@@ -43,5 +72,5 @@ class LocalPlatform(PlatformBase):
             builder = builder.config(key, value)
         return builder.getOrCreate()
 
-    def resolve_secret(self, name: str) -> str:
+    def _resolve_platform_secret(self, name: str) -> str:
         return self.config.get("secrets", {}).get(name, "")

--- a/datacore/platforms/base.py
+++ b/datacore/platforms/base.py
@@ -62,6 +62,25 @@ class PlatformBase(abc.ABC):
         base = self.config.get("checkpoint_base", f"/tmp/datacore/{env}")
         return f"{base}/{layer}/{dataset}"
 
+    # Adaptadores opcionales para merges específicos de plataforma.
+    def merge_into_warehouse(
+        self,
+        df,
+        sink: dict[str, Any],
+        keys: list[str],
+        order_by: list[str],
+    ) -> bool:  # pragma: no cover - comportamiento por defecto
+        return False
+
+    def merge_into_nosql(
+        self,
+        df,
+        sink: dict[str, Any],
+        keys: list[str],
+        order_by: list[str],
+    ) -> bool:  # pragma: no cover - comportamiento por defecto
+        return False
+
 
 class LocalPlatform(PlatformBase):
     name = "local"

--- a/datacore/platforms/gcp_dataproc.py
+++ b/datacore/platforms/gcp_dataproc.py
@@ -21,8 +21,8 @@ class GcpDataprocPlatform(PlatformBase):
             builder = builder.config(key, value)
         return builder.getOrCreate()
 
-    def resolve_secret(self, name: str) -> str:
+    def _resolve_platform_secret(self, name: str) -> str:
         secrets = self.config.get("secrets", {})
         if name in secrets:
             return secrets[name]
-        raise KeyError(f"Secreto {name} no disponible en GCP config")
+        return ""

--- a/datacore/utils/observability.py
+++ b/datacore/utils/observability.py
@@ -1,0 +1,92 @@
+"""Utilidades de observabilidad para ejecuciones de datasets."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any
+
+LOGGER = logging.getLogger(__name__)
+
+try:  # pragma: no cover - dependencias opcionales
+    from prometheus_client import Counter, Histogram  # type: ignore
+except ImportError:  # pragma: no cover - entorno sin prometheus
+    Counter = Histogram = None  # type: ignore
+
+if Counter is not None:  # pragma: no cover - solo se ejecuta si está disponible
+    DATASET_RUNS = Counter(
+        "prodi_dataset_runs_total",
+        "Total de ejecuciones de datasets",
+        ["dataset", "status"],
+    )
+else:  # pragma: no cover - entorno sin prometheus
+    DATASET_RUNS = None
+
+if Histogram is not None:  # pragma: no cover - solo se ejecuta si está disponible
+    DATASET_DURATION = Histogram(
+        "prodi_dataset_duration_seconds",
+        "Duración de ejecuciones de datasets",
+        ["dataset"],
+    )
+else:  # pragma: no cover
+    DATASET_DURATION = None
+
+
+def new_run_id() -> str:
+    """Genera un identificador único para la ejecución."""
+
+    return str(uuid.uuid4())
+
+
+def record_dataset(dataset: str, status: str, duration: float, metrics: dict[str, Any] | None) -> None:
+    """Registra métricas de observabilidad de forma defensiva."""
+
+    if DATASET_RUNS is not None:
+        DATASET_RUNS.labels(dataset=dataset, status=status).inc()
+    if DATASET_DURATION is not None:
+        DATASET_DURATION.labels(dataset=dataset).observe(duration)
+    LOGGER.debug(
+        "Observabilidad dataset=%s status=%s duration=%.3fs métricas=%s",
+        dataset,
+        status,
+        duration,
+        sorted(metrics.keys()) if metrics else [],
+    )
+
+
+def emit_openlineage(payload: dict[str, Any], config: dict[str, Any]) -> None:
+    """Emite eventos OpenLineage cuando la dependencia está disponible."""
+
+    if not config or not config.get("enabled", True):
+        return
+    endpoint = config.get("url")
+    if not endpoint:
+        LOGGER.debug("OpenLineage habilitado sin URL, se omite")
+        return
+    try:  # pragma: no cover - librería opcional
+        from openlineage.client import OpenLineageClient  # type: ignore
+        from openlineage.client.run import Job, Run, RunEvent, RunState  # type: ignore
+    except ImportError:  # pragma: no cover - librería no instalada
+        LOGGER.debug("Cliente OpenLineage no disponible, se omite evento")
+        return
+
+    client = OpenLineageClient(url=endpoint, api_key=config.get("api_key"))
+    namespace = config.get("namespace", "prodi")
+    dataset_name = payload.get("dataset", "desconocido")
+    run = Run(runId=payload.get("run_id"))
+    job = Job(namespace=namespace, name=f"{payload.get('layer', 'unknown')}::{dataset_name}")
+    status = payload.get("status", "COMPLETED").upper()
+    try:
+        state = RunState.from_string(status)
+    except ValueError:
+        state = RunState.COMPLETE
+    event = RunEvent(
+        eventType=state,
+        eventTime=datetime.utcnow().isoformat() + "Z",
+        run=run,
+        job=job,
+        inputs=[],
+        outputs=[],
+    )
+    client.emit(event)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ graph TD
   deduplicar, explotar arrays, flatten JSON, etc.).
 - Los pipelines pueden combinar `transform.sql`, `transform.udf` y `transform.ops`, manteniendo compatibilidad hacia atrás.
 - Se añade `transform.add_ingestion_ts` (true por defecto) y se soporta `merge_strategy` para múltiples fuentes.
+- **Breaking change**: el bloque `transform.validation` fue retirado; las reglas deben declararse en `dataset.validation`.
 
 ## Incremental y streaming
 - `incremental.mode` soporta `full`, `append` y `merge` genérico para cualquier formato, aprovechando Delta Lake cuando está disponible.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,11 +57,11 @@ graph TD
 - Se añade `transform.add_ingestion_ts` (true por defecto) y se soporta `merge_strategy` para múltiples fuentes.
 
 ## Incremental y streaming
-- `incremental.mode` soporta `append` y `merge` genérico para cualquier formato, aprovechando Delta Lake cuando está disponible.
+- `incremental.mode` soporta `full`, `append` y `merge` genérico para cualquier formato, aprovechando Delta Lake cuando está disponible.
 - Para sinks JDBC el motor realiza upserts por etapas (tablas temporales + transacciones) cuando se definen `keys`.
-- Las cargas streaming manejan `watermark_column`, triggers configurables y checkpoints por dataset.
+- Las cargas streaming manejan `watermark` (`column` + `delay_threshold`), triggers configurables y checkpoints por dataset.
 
 ## Observabilidad
-- El motor genera métricas JSON en `<sink>/_metrics/` y archivos `_rejects` con motivos.
-- `prodi plan` y `prodi run --dry-run` devuelven el plan completo (readers, transformaciones, sinks y opciones) sin ejecutar.
+- El motor genera métricas JSON en `<sink>/_metrics/<run_id>.json` y archivos `_rejects` con motivos.
+- `prodi plan` y `prodi run --dry-run` devuelven un contrato JSON estable con `{run_id, datasets: [...]}` incluyendo readers, transformaciones, incremental, streaming y sinks.
 - El flag `--fail-fast` permite abortar al primer error manteniendo logs contextualizados por capa/dataset.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,13 @@
 # Arquitectura Datacore
 
-La solución sigue el patrón hexagonal (puertos y adaptadores) para mantener el núcleo desacoplado de las integraciones con cada proveedor cloud.
+La solución sigue el patrón hexagonal (puertos y adaptadores) para mantener el núcleo desacoplado de las integraciones con cada
+proveedor cloud.
 
 ```mermaid
 graph TD
     CLI[CLI prodi] --> Engine
     Config[Config YAML + JSON Schema] --> Engine
-    Engine[Core Engine\n(raw/bronze/silver/gold)] --> Validation
+    Engine[Core Engine\\n(raw/bronze/silver/gold)] --> Validation
     Engine --> Incremental
     Engine --> Transforms
     Engine --> Readers
@@ -14,23 +15,53 @@ graph TD
     Readers --> StorageConnectors
     Readers --> APIConnectors
     Readers --> DBConnectors
+    Readers --> StreamingConnectors
     Writers --> StorageConnectors
     Writers --> DWConnectors
+    Writers --> NoSQLConnectors
+    Writers --> StreamingSinks
     StorageConnectors --> Platforms
     APIConnectors --> Platforms
     DBConnectors --> Platforms
+    NoSQLConnectors --> Platforms
+    StreamingConnectors --> Platforms
     Platforms --> SparkSession
 ```
 
 ## Componentes principales
-- **CLI (`datacore.cli`)**: expone comandos `prodi validate|run|plan`.
-- **Core (`datacore.core`)**: motor de ejecución por capas, registro de transformaciones y validaciones.
-- **Connectores (`datacore.connectors`)**: adaptadores para almacenamiento, APIs y bases de datos.
-- **Plataformas (`datacore.platforms`)**: inicialización de Spark y servicios auxiliares según nube.
-- **IO (`datacore.io`)**: lectura/escritura batch y streaming.
+- **CLI (`datacore.cli`)**: expone comandos `prodi validate|run|plan` con soporte para `--dry-run` y `--fail-fast`.
+- **Core (`datacore.core`)**: motor de ejecución por capas, registro de transformaciones, validaciones, incremental y métrica.
+- **Connectores (`datacore.connectors`)**: adaptadores para almacenamiento, APIs, bases de datos, NoSQL y streaming.
+- **Plataformas (`datacore.platforms`)**: inicialización de Spark, secretos y servicios auxiliares según nube.
+- **IO (`datacore.io`)**: lectura/escritura batch y streaming con inferencia de esquemas cacheada.
 
 ## Flujo general
 1. La CLI carga un archivo YAML y lo valida contra los esquemas JSON.
-2. El motor determina las capas a ejecutar y delega en los lectores/escritores adecuados.
-3. Los conectores traducen los parámetros a llamadas de Spark o APIs externas.
-4. Las reglas de validación e incremental se aplican de forma uniforme sin importar la nube.
+2. El motor determina las capas a ejecutar y construye un plan declarativo con las transformaciones y validaciones.
+3. Los lectores soportan múltiples fuentes por dataset (storage, JDBC, APIs REST/GraphQL, Kafka/Event Hubs, NoSQL) y unen los 
+   DataFrames mediante `unionByName(allowMissingColumns=True)`.
+4. Los conectores traducen los parámetros a llamadas de Spark o APIs externas, aplicando `pushdown`, particiones y paginación
+   cuando corresponde.
+5. Las reglas de validación, normalización y los contratos incrementales se aplican de forma uniforme sin importar la nube.
+6. Se generan métricas por dataset y, en caso de errores, los registros rechazados se escriben en `_rejects`.
+
+## Esquema e inferencia
+- Los formatos soportados incluyen `csv`, `json`, `parquet`, `avro` y `orc`, con opciones específicas por formato.
+- La inferencia de esquema es opcional; cuando está habilitada se cachea por dataset en el checkpoint de plataforma para evitar
+  recalcular tipos en ejecuciones futuras.
+
+## Transformaciones declarativas
+- El motor registra operaciones puras en `datacore.core.ops` (renombrar, castear, limpiar whitespace, normalizar fechas,
+  deduplicar, explotar arrays, flatten JSON, etc.).
+- Los pipelines pueden combinar `transform.sql`, `transform.udf` y `transform.ops`, manteniendo compatibilidad hacia atrás.
+- Se añade `transform.add_ingestion_ts` (true por defecto) y se soporta `merge_strategy` para múltiples fuentes.
+
+## Incremental y streaming
+- `incremental.mode` soporta `append` y `merge` genérico para cualquier formato, aprovechando Delta Lake cuando está disponible.
+- Para sinks JDBC el motor realiza upserts por etapas (tablas temporales + transacciones) cuando se definen `keys`.
+- Las cargas streaming manejan `watermark_column`, triggers configurables y checkpoints por dataset.
+
+## Observabilidad
+- El motor genera métricas JSON en `<sink>/_metrics/` y archivos `_rejects` con motivos.
+- `prodi plan` y `prodi run --dry-run` devuelven el plan completo (readers, transformaciones, sinks y opciones) sin ejecutar.
+- El flag `--fail-fast` permite abortar al primer error manteniendo logs contextualizados por capa/dataset.

--- a/docs/cli/plan.md
+++ b/docs/cli/plan.md
@@ -1,0 +1,66 @@
+# Contrato JSON de `prodi plan` y `prodi run --dry-run`
+
+Ambos comandos exponen un contrato JSON estable que se valida contra `datacore/config/schemas/plan.schema.json` para evitar rupturas involuntarias.
+
+## Estructura principal
+
+```json
+{
+  "run_id": "<uuid>",
+  "datasets": [
+    {
+      "name": "orders_silver",
+      "layer": "silver",
+      "status": "planned",
+      "run_id": "<uuid>",
+      "source_plan": {
+        "sources": [
+          {"type": "storage", "uri": "abfss://landing/orders/", "format": "csv"}
+        ],
+        "merge_strategy": {"keys": ["order_id"], "prefer": "newest"}
+      },
+      "transform_plan": {
+        "sql": [],
+        "ops": [
+          {"rename": {"orderId": "order_id"}},
+          {"cast": {"amount": "double"}}
+        ],
+        "udf": [],
+        "add_ingestion_ts": true
+      },
+      "validation_plan": {
+        "rules": [
+          {"check": "expect_not_null", "columns": ["order_id"], "severity": "error"}
+        ]
+      },
+      "incremental_plan": {
+        "mode": "merge",
+        "keys": ["order_id"],
+        "order_by": ["_ingestion_ts DESC"],
+        "watermark": {"column": "order_date", "delay_threshold": "1 day"}
+      },
+      "streaming_plan": {
+        "enabled": false,
+        "trigger": null,
+        "checkpoint_location": null,
+        "watermark": null
+      },
+      "sink_plan": {
+        "type": "storage",
+        "format": "parquet",
+        "uri": "abfss://silver/orders/",
+        "partition_by": ["order_date"],
+        "merge_schema": true,
+        "compression": "snappy"
+      },
+      "issues": []
+    }
+  ]
+}
+```
+
+Cada dataset puede incluir propiedades adicionales (`metrics` en ejecuciones reales) pero el núcleo anterior se mantiene estable para CI y tooling externo.
+
+## Validación en pruebas
+
+`tests/unit/test_engine_plan.py` valida el contrato contra `plan.schema.json`. Cualquier cambio estructural debe acompañarse de una actualización explícita del esquema y de la documentación.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,10 +19,11 @@ La configuración se organiza por entorno (`configs/envs/<env>`), capa (`layers/
 ## Estructura de datasets
 - `source`: puede ser un objeto o una lista de fuentes. Cada fuente define `type`, `uri`/`options`/`read_options`, `format`, `infer_schema`, `record_path`, `flatten`, autenticación (para `endpoint`/`api_rest`) y paginación. Para streaming (`kafka`, `event_hubs`) declara el `payload_format`.
 - `transform`: admite `sql`, `udf`, `ops` (operaciones declarativas aplicadas en orden determinístico) y `add_ingestion_ts` (`true` por defecto).
+- `validation`: define reglas de calidad (`rules`), severidad (`error|warn`), `threshold` y `quarantine_sink`.
 - `merge_strategy`: combina múltiples fuentes usando `keys`, `prefer` (`newest|left|coalesce`) y `order_by`.
-- `sink`: soporta `storage`, `warehouse`, `nosql`, `kafka`, `event_hubs` con opciones específicas (particionado vía `partition_by`, `merge_schema`, `target_file_size_mb`, `compression`, `checkpoint_location`, `batch_size`, etc.).
+- `sink`: soporta `storage`, `warehouse`, `nosql`, `kafka`, `event_hubs` con opciones específicas (particionado vía `partition_by`, `merge_schema`, `target_file_size_mb`, `compression`, `checkpoint_location`, `batch_size`, etc.). `repartition` acepta un entero, una lista de columnas o un objeto `{columns: [...], numPartitions: <int>}`.
 - `incremental`: controla `mode` (`full|append|merge`), `keys`, `order_by`, `watermark` (`{column, delay_threshold}`) y banderas específicas por sink.
-- `streaming`: `enabled`, `trigger` (valor de `processingTime`), `checkpoint_location` y `watermark` (`{column, delay_threshold}`).
+- `streaming`: `enabled`, `trigger` (valor de `processingTime`) y `checkpoint_location`. Si se requiere `watermark`, decláralo en `incremental.watermark`.
 
 ## Ejemplo completo (capa silver)
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,18 +5,96 @@ La configuración se organiza por entorno (`configs/envs/<env>`), capa (`layers/
 ## Archivos principales
 - `project.yml`: describe el proyecto, entorno, plataforma, datasets y parámetros Spark.
 - `layers/<layer>.yml`: complementa con configuraciones específicas de cada capa.
-- `configs/platforms/<cloud>.yml`: define URIs, rutas de checkpoints y parámetros propios del proveedor.
+- `configs/platforms/<cloud>.yml`: define URIs, rutas de checkpoints, secretos y parámetros propios del proveedor.
 
-## Validación
-El comando `prodi validate --config <ruta>` valida el YAML contra `project.schema.json` o `layer.schema.json` según corresponda. Se usa `jsonschema` con soporte para esquemas anidados.
+## Validación y ayudas
+- El comando `prodi validate --config <ruta>` valida el YAML contra `project.schema.json` o `layer.schema.json`.
+- `prodi plan --config <project.yml>` lista los datasets por capa y alerta sobre problemas rápidos (p.ej. `merge` sin claves).
+- `prodi run --layer silver --config <project.yml> --dry-run` imprime el plan JSON de lectura/transformación/escritura.
 
-## Variables soportadas
-- `project`: nombre del proyecto.
-- `environment`: `dev`, `test` o `prod`.
-- `platform`: `azure`, `aws` o `gcp`.
-- `datasets[]`: lista de datasets con origen, transformaciones, validaciones y sink.
-- `incremental`: parámetros `mode`, `keys`, `watermark_column`.
-- `streaming`: flags `enabled` y `trigger`.
+## Variables y secretos
+- Cualquier campo puede hacer referencia a `${ENV_VAR}` o `${SECRET:ALIAS}`. `PlatformBase.resolve_secret` resuelve primero secretos nativos de la nube y hace fallback a variables de entorno o `configs/platforms`.
+- Los parámetros sensibles (tokens, cadenas de conexión) deben declararse usando estas referencias.
 
-## Ejemplo
-Consulta los ejemplos en `configs/envs/dev` y la sección `/examples` para ver pipelines funcionales por plataforma.
+## Estructura de datasets
+- `source`: puede ser un objeto o una lista de fuentes. Cada fuente define `type`, `uri`/`options`, `format`, `infer_schema`, `record_path`, `flatten`, etc.
+- `transform`: admite `sql`, `udf`, `ops` (operaciones declarativas) y `add_ingestion_ts` (`true` por defecto).
+- `merge_strategy`: combina múltiples fuentes usando `keys`, `prefer` (`newest|left|coalesce`) y `order_by`.
+- `sink`: soporta `storage`, `warehouse`, `nosql`, `kafka`, `event_hubs` con opciones específicas (particionado, `mergeSchema`, etc.).
+- `incremental`: controla `mode` (`append|merge`), `keys`, `order_by`, `watermark_column`.
+- `streaming`: `enabled`, `trigger`, `checkpoint`, `watermark_column`.
+
+## Ejemplo completo (capa silver)
+```yaml
+project: retail360
+environment: dev
+platform: azure
+spark:
+  shuffle_partitions: 4
+  extra_conf:
+    spark.sql.adaptive.enabled: true
+datasets:
+  - name: orders_silver
+    layer: silver
+    source:
+      - type: storage
+        format: csv
+        uri: abfs://landing/orders/
+        infer_schema: true
+        options:
+          header: true
+          delimiter: ";"
+      - type: api_rest
+        options:
+          endpoint: https://api.example.com/v1/orders
+          method: GET
+          params:
+            status: completed
+          flatten: true
+    merge_strategy:
+      keys: [order_id]
+      prefer: newest
+      order_by: ["_ingestion_ts DESC"]
+    transform:
+      add_ingestion_ts: true
+      ops:
+        - trim: [customer_name]
+        - uppercase: [country]
+        - rename:
+            country: country_code
+        - cast:
+            total_amount: decimal(18,2)
+        - standardize_dates:
+            cols: [order_date]
+            format_in: "yyyy-MM-dd'T'HH:mm:ss'Z'"
+            format_out: "yyyy-MM-dd"
+            tz: UTC
+        - deduplicate:
+            keys: [order_id]
+            order_by: ["order_date DESC", "_ingestion_ts DESC"]
+    validation:
+      expect_not_null: [order_id, order_date]
+      expect_unique: [order_id]
+      expect_between:
+        col: total_amount
+        min: 0
+        max: 100000
+      expect_email: [customer_email]
+    incremental:
+      mode: merge
+      keys: [order_id]
+      order_by: ["order_date DESC", "_ingestion_ts DESC"]
+      watermark_column: order_date
+    sink:
+      type: warehouse
+      engine: synapse
+      table: analytics.orders_silver
+      partition_by: [order_date]
+      options:
+        batchsize: 10000
+        truncate: false
+        isolationLevel: READ_COMMITTED
+        createTableOptions: "DISTRIBUTION = HASH(order_id)"
+```
+
+Consulta la carpeta `/examples` para ver variantes por plataforma y streaming.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,9 +19,9 @@ La configuración se organiza por entorno (`configs/envs/<env>`), capa (`layers/
 ## Estructura de datasets
 - `source`: puede ser un objeto o una lista de fuentes. Cada fuente define `type`, `uri`/`options`/`read_options`, `format`, `infer_schema`, `record_path`, `flatten`, autenticación (para `endpoint`/`api_rest`) y paginación. Para streaming (`kafka`, `event_hubs`) declara el `payload_format`.
 - `transform`: admite `sql`, `udf`, `ops` (operaciones declarativas aplicadas en orden determinístico) y `add_ingestion_ts` (`true` por defecto).
-- `validation`: define reglas de calidad (`rules`), severidad (`error|warn`), `threshold` y `quarantine_sink`.
+- `validation`: define reglas de calidad (`rules`), severidad (`error|warn`), `threshold` y `quarantine_sink`. **Nota:** las reglas deben declararse aquí; el bloque heredado `transform.validation` fue retirado.
 - `merge_strategy`: combina múltiples fuentes usando `keys`, `prefer` (`newest|left|coalesce`) y `order_by`.
-- `sink`: soporta `storage`, `warehouse`, `nosql`, `kafka`, `event_hubs` con opciones específicas (particionado vía `partition_by`, `merge_schema`, `target_file_size_mb`, `compression`, `checkpoint_location`, `batch_size`, etc.). `repartition` acepta un entero, una lista de columnas o un objeto `{columns: [...], numPartitions: <int>}`.
+- `sink`: soporta `storage`, `warehouse`, `nosql`, `kafka`, `event_hubs` con opciones específicas (particionado vía `partition_by`, `merge_schema`, `target_file_size_mb`, `compression`, `checkpoint_location`, `batch_size`, etc.). `repartition` acepta un entero, una lista de columnas o un objeto estructurado `{columns: [...], numPartitions: <int>}`.
 - `incremental`: controla `mode` (`full|append|merge`), `keys`, `order_by`, `watermark` (`{column, delay_threshold}`) y banderas específicas por sink.
 - `streaming`: `enabled`, `trigger` (valor de `processingTime`) y `checkpoint_location`. Si se requiere `watermark`, decláralo en `incremental.watermark`.
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,6 +1,6 @@
 # Conectores disponibles
 
-Los conectores implementan puertos específicos para cada tipo de fuente o destino y se instancian automáticamente desde `datacore.io` según la configuración.
+Los conectores implementan puertos específicos para cada tipo de fuente o destino y se instancian automáticamente desde `datacore.io` según la configuración del dataset.
 
 ## Storage
 - **S3** (`datacore.connectors.storage.s3`)
@@ -8,14 +8,85 @@ Los conectores implementan puertos específicos para cada tipo de fuente o desti
 - **Google Cloud Storage** (`datacore.connectors.storage.gcs`)
 - **Local/MinIO** (`datacore.connectors.storage.local`)
 
-Todos soportan lectura/escritura batch y streaming. La resolución de rutas se delega en la plataforma (`normalize_uri`).
+Formatos soportados: `csv`, `json` (multiLine), `parquet`, `avro`, `orc`. Las opciones principales incluyen `header`, `inferSchema`, `delimiter`, `compression`, `mergeSchema`, `partitionBy` y `pathGlobFilter`. Todos los conectores exponen `read` y `write` batch/streaming.
+
+```yaml
+source:
+  type: storage
+  format: parquet
+  uri: s3://landing/sales/
+  options:
+    mergeSchema: true
+sink:
+  type: storage
+  format: parquet
+  uri: abfs://silver/sales/
+  partition_by: [year, month]
+  options:
+    compression: snappy
+```
 
 ## APIs
-- **REST** (`datacore.connectors.api.rest`): soporta autenticación Bearer, paginación y backoff exponencial.
-- **GraphQL** (`datacore.connectors.api.graphql`): ejecuta queries parametrizadas con variables dinámicas.
+- **REST** (`datacore.connectors.api.rest`): `fetch_pages` soporta paginación, backoff, cabeceras dinámicas y flatten opcional.
+- **GraphQL** (`datacore.connectors.api.graphql`): `execute_query` permite queries parametrizadas con `variables`.
 
-## Bases de datos
-- **JDBC** (`datacore.connectors.db.jdbc`): Postgres, SQL Server, MySQL, Redshift, Synapse.
-- **NoSQL** (`datacore.connectors.db.nosql`): interfaz genérica con placeholders para DynamoDB/CosmosDB.
+```yaml
+source:
+  type: api_rest
+  options:
+    endpoint: https://api.example.com/orders
+    method: GET
+    params:
+      status: completed
+    flatten: true
+```
 
-Cada conector expone funciones `build_reader_options` y/o `write` para facilitar la integración con Spark.
+## Bases de datos y warehouses
+- **JDBC** (`datacore.connectors.db.jdbc`): Postgres, SQL Server/Synapse, MySQL, Redshift. Soporta `pushdown`, lectura por particiones (`partitionColumn`, `lowerBound`, `upperBound`, `numPartitions`) y upserts en modo `merge`.
+- **Warehouse** (`datacore.io.writers`): escritura JDBC con `batchsize`, `isolationLevel`, `truncate` seguro y `createTableOptions`.
+- **BigQuery** (`datacore.connectors.db.bigquery`): escritura batch con `temporaryGcsBucket` e `intermediateFormat`.
+
+```yaml
+sink:
+  type: warehouse
+  engine: postgres
+  table: analytics.orders
+  options:
+    batchsize: 5000
+    truncate: false
+    isolationLevel: READ_COMMITTED
+```
+
+## NoSQL
+- **CosmosDB** (`sink.engine: cosmosdb`): Spark connector oficial con soporte para `checkpointLocation` y `partitionKey`.
+- **DynamoDB** (`sink.engine: dynamodb`): escritor híbrido (Spark + boto3) con soporte para catálogos Glue.
+
+```yaml
+sink:
+  type: nosql
+  engine: cosmosdb
+  options:
+    endpoint: ${SECRET:COSMOS_URI}
+    masterkey: ${SECRET:COSMOS_KEY}
+    database: sales
+    collection: orders
+```
+
+## Streaming (Kafka / Event Hubs)
+Los lectores y escritores streaming utilizan `readStream`/`writeStream`. El payload puede ser JSON o CSV y se especifica mediante `options.format`. Se soportan `watermark_column`, `trigger`, `checkpointLocation` y `topic` / `eventHubs.connectionString`.
+
+```yaml
+source:
+  type: kafka
+  options:
+    subscribe: orders
+    startingOffsets: earliest
+    format: json
+    watermark_column: event_time
+sink:
+  type: event_hubs
+  options:
+    eventHubs.connectionString: ${SECRET:EH_CONN}
+    topic: orders_enriched
+    checkpointLocation: abfs://checkpoints/orders
+```

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -26,19 +26,25 @@ sink:
     compression: snappy
 ```
 
-## APIs
+## APIs y endpoints HTTP
 - **REST** (`datacore.connectors.api.rest`): `fetch_pages` soporta paginación, backoff, cabeceras dinámicas y flatten opcional.
 - **GraphQL** (`datacore.connectors.api.graphql`): `execute_query` permite queries parametrizadas con `variables`.
+- **Endpoint genérico** (`datacore.connectors.http`): autenticación `bearer`/`basic`, reintentos exponenciales y paginación por página, cursor o cabecera `Link`. El lector normaliza JSON a columnas y permite `flatten_depth` configurable.
 
 ```yaml
 source:
-  type: api_rest
-  options:
-    endpoint: https://api.example.com/orders
-    method: GET
-    params:
-      status: completed
-    flatten: true
+  type: endpoint
+  url: https://api.example.com/v1/orders
+  method: GET
+  auth:
+    type: bearer
+    token: ${API_TOKEN}
+  pagination:
+    strategy: cursor
+    param: cursor
+    cursor_path: $.next
+  record_path: items
+  flatten: true
 ```
 
 ## Bases de datos y warehouses

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -1,15 +1,31 @@
 # Procesamiento incremental
 
-El módulo `datacore.core.incremental` proporciona utilidades para ejecutar cargas incrementales mediante operaciones `append` o `merge`.
+El módulo `datacore.core.incremental` proporciona utilidades para ejecutar cargas incrementales mediante operaciones `append` o `merge`. El modo se define por dataset dentro del bloque `incremental`.
 
 ## Modo append
 - Añade registros nuevos sin deduplicar.
-- Requiere `watermark_column` para streaming.
+- Compatible con cualquier sink soportado.
+- En streaming se recomienda definir `watermark_column` para controlar la retención de estados.
 
 ## Modo merge
-- Realiza un `MERGE` sobre tablas Delta cuando está disponible.
-- Alternativamente, implementa un `merge` genérico escribiendo datos temporales y realizando un reemplazo atómico.
-- Requiere definir claves (`keys`).
+- Requiere claves (`keys`) y opcionalmente `order_by` para priorizar registros (por defecto `_ingestion_ts DESC`).
+- Si el sink es Delta Lake se utiliza `MERGE INTO` nativo.
+- Para otros formatos se ejecuta un merge genérico: se escribe un staging temporal, se deduplica por `keys`+`order_by` y se reemplaza la tabla destino de forma atómica.
+- Para sinks JDBC el motor crea una tabla temporal y ejecuta un merge por etapas dentro de una transacción, respetando `isolationLevel`.
 
-## Watermarks
-El motor calcula un watermark por dataset para evitar reprocesos en modo streaming. El valor se almacena en el directorio de checkpoints proporcionado por la plataforma.
+## Upserts JDBC
+1. Se escribe el DataFrame en una tabla temporal con `batchsize` configurable.
+2. Se ejecuta el `MERGE`/`UPSERT` mediante SQL específico del motor (`postgres`, `mysql`, `sqlserver/synapse`, `redshift`).
+3. Se limpia la tabla temporal y se registran métricas.
+
+## Watermarks y streaming
+- `watermark_column` puede definirse en `source`, `incremental` o `streaming`; el motor la unifica.
+- `streaming.trigger` acepta expresiones `processingTime=5 minutes`.
+- Los checkpoints se almacenan en `platform.checkpoint_dir(layer, dataset, env)`.
+- Para fuentes Kafka/Event Hubs se soporta `readStream` con parseo JSON/CSV y watermark.
+
+## Métricas y rejects
+- Cada ejecución produce métricas `{input_rows, valid_rows, invalid_rows, reglas...}` en `<sink.uri>/_metrics/<timestamp>.json`.
+- Los registros que no superan las reglas de validación se escriben en `<sink.uri>/_rejects/` con columna `_reject_reason`.
+
+Consulta `examples/` para pipelines con `append`, `merge` y streaming.

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -5,7 +5,7 @@ El módulo `datacore.core.incremental` proporciona utilidades para ejecutar carg
 ## Modo append
 - Añade registros nuevos sin deduplicar.
 - Compatible con cualquier sink soportado.
-- En streaming se recomienda definir `watermark_column` para controlar la retención de estados.
+- En streaming se recomienda definir `watermark` (`{column, delay_threshold}`) para controlar la retención de estados.
 
 ## Modo merge
 - Requiere claves (`keys`) y opcionalmente `order_by` para priorizar registros (por defecto `_ingestion_ts DESC`).
@@ -19,13 +19,13 @@ El módulo `datacore.core.incremental` proporciona utilidades para ejecutar carg
 3. Se limpia la tabla temporal y se registran métricas.
 
 ## Watermarks y streaming
-- `watermark_column` puede definirse en `source`, `incremental` o `streaming`; el motor la unifica.
-- `streaming.trigger` acepta expresiones `processingTime=5 minutes`.
-- Los checkpoints se almacenan en `platform.checkpoint_dir(layer, dataset, env)`.
+- `watermark` puede definirse en `source`, `incremental` o `streaming`; el motor la normaliza y aplica `withWatermark`.
+- `streaming.trigger` acepta valores compatibles con `trigger(processingTime=...)`, por ejemplo `"5 minutes"`.
+- Los checkpoints se almacenan en `platform.checkpoint_dir(layer, dataset, env)` o en `streaming.checkpoint_location`/`sink.checkpoint_location`.
 - Para fuentes Kafka/Event Hubs se soporta `readStream` con parseo JSON/CSV y watermark.
 
 ## Métricas y rejects
-- Cada ejecución produce métricas `{input_rows, valid_rows, invalid_rows, reglas...}` en `<sink.uri>/_metrics/<timestamp>.json`.
+- Cada ejecución produce métricas `{input_rows, valid_rows, invalid_rows, by_rule: {...}, run_id...}` en `<sink.uri>/_metrics/<run_id>.json`.
 - Los registros que no superan las reglas de validación se escriben en `<sink.uri>/_rejects/` con columna `_reject_reason`.
 
 Consulta `examples/` para pipelines con `append`, `merge` y streaming.

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -1,6 +1,6 @@
 # Validaciones de datos
 
-Las validaciones se definen dentro de `validation.rules` (o en `transform.validation` para configuraciones heredadas). Cada regla genera métricas, puede marcar registros inválidos y opcionalmente enviarlos a cuarentena.
+Las validaciones se declaran en el bloque `validation` de cada dataset (junto a `source` y `sink`). Cada regla genera métricas, puede marcar registros inválidos y opcionalmente enviarlos a cuarentena.
 
 ## Reglas soportadas
 - `expect_not_null`: asegura que las columnas listadas no contengan nulos.
@@ -35,6 +35,7 @@ validation:
 - Registros inválidos se escriben en `<sink.uri>/_rejects/` con las columnas originales más `_reject_reason`.
 - Las reglas con `on_fail: quarantine` se escriben adicionalmente en `validation.quarantine_sink` (si se configura) con `_reject_reason` y preservando el esquema original.
 - El motor devuelve métricas estructuradas `{input_rows, valid_rows, invalid_rows, by_rule: {...}, quarantine_rows, run_id, ...}` y escribe un JSON por ejecución en `<sink.uri>/_metrics/<run_id>.json`.
+- El bloque histórico `transform.validation` ya no es soportado; migra las reglas al nivel superior `validation`.
 
 ## Buenas prácticas
 - Definir validaciones clave en capas `silver`/`gold` para asegurar contratos aguas arriba.

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -1,13 +1,45 @@
 # Validaciones de datos
 
-Las validaciones se definen en el bloque `transform.validation` de cada dataset.
+Las validaciones se definen dentro de `transform.validation` o en el bloque `validation` del dataset (compatibilidad hacia atrás). Cada regla genera métricas y puede producir registros rechazados.
 
 ## Reglas soportadas
 - `expect_not_null`: asegura que las columnas listadas no contengan nulos.
-- `expect_unique`: valida unicidad (opcional) sobre columnas.
-- `expect_domain`: verifica que los valores pertenezcan a un conjunto permitido.
+- `expect_unique` / `expect_column_values_to_be_unique`: valida unicidad sobre columnas o conjuntos de columnas.
+- `expect_between`: `{col, min, max}` valida que el valor se encuentre en el rango.
+- `expect_regex`: `{col, pattern}` aplica expresiones regulares.
+- `expect_email`: lista de columnas a validar con patrón RFC 5322 simplificado.
+- `expect_length`: `{col, min?, max?}` controla la longitud de cadenas o arrays.
+- `expect_set`: `{col, allowed: [...]}` limita los valores permitidos.
+- `expect_foreign_key`: `{col, ref_table, ref_col}` valida referencias externas si se proporciona el DataFrame de referencia.
+- `expect_domain`: alias legado para `expect_set`.
 
-Durante la ejecución, `datacore.core.validation` aplica las reglas y genera métricas de registros válidos e inválidos. Los registros rechazados se escriben en `_rejects` según configuración.
+## Ejemplo YAML
+```yaml
+validation:
+  expect_not_null: [order_id, order_date]
+  expect_unique:
+    - [order_id, order_date]
+  expect_between:
+    col: total_amount
+    min: 0
+  expect_regex:
+    col: country_code
+    pattern: "^[A-Z]{2}$"
+  expect_email: [customer_email]
+  expect_length:
+    col: customer_name
+    min: 3
+  expect_set:
+    col: status
+    allowed: [pending, shipped, delivered]
+```
 
-## Contratos
-Los contratos se describen en YAML y se validan con `layer.schema.json`. Se pueden combinar múltiples reglas por dataset.
+## Rejects y métricas
+- Registros inválidos se escriben en `<sink.uri>/_rejects/` con las columnas originales más `_reject_reason`.
+- El motor devuelve métricas estructuradas `{input_rows, valid_rows, invalid_rows, reglas...}` y además escribe un JSON por ejecución en `<sink.uri>/_metrics/<timestamp>.json`.
+- Las métricas agregan contadores por cada regla (`expect_not_null`, `expect_regex`, etc.).
+
+## Buenas prácticas
+- Definir validaciones clave en capas `silver`/`gold` para asegurar contratos aguas arriba.
+- Combinar `deduplicate` + `expect_unique` cuando existan merges incrementales.
+- Usar `prodi run --dry-run` para revisar qué reglas aplicarán antes de ejecutar.

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -1,43 +1,40 @@
 # Validaciones de datos
 
-Las validaciones se definen dentro de `transform.validation` o en el bloque `validation` del dataset (compatibilidad hacia atrás). Cada regla genera métricas y puede producir registros rechazados.
+Las validaciones se definen dentro de `validation.rules` (o en `transform.validation` para configuraciones heredadas). Cada regla genera métricas, puede marcar registros inválidos y opcionalmente enviarlos a cuarentena.
 
 ## Reglas soportadas
 - `expect_not_null`: asegura que las columnas listadas no contengan nulos.
 - `expect_unique` / `expect_column_values_to_be_unique`: valida unicidad sobre columnas o conjuntos de columnas.
-- `expect_between`: `{col, min, max}` valida que el valor se encuentre en el rango.
-- `expect_regex`: `{col, pattern}` aplica expresiones regulares.
-- `expect_email`: lista de columnas a validar con patrón RFC 5322 simplificado.
-- `expect_length`: `{col, min?, max?}` controla la longitud de cadenas o arrays.
-- `expect_set`: `{col, allowed: [...]}` limita los valores permitidos.
-- `expect_foreign_key`: `{col, ref_table, ref_col}` valida referencias externas si se proporciona el DataFrame de referencia.
-- `expect_domain`: alias legado para `expect_set`.
+- `range` (`expect_between` legado): `{column|col, min?, max?}` valida que el valor se encuentre en el rango.
+- `regex`: `{column|col, pattern}` aplica expresiones regulares.
+- `values_in_set` (`expect_set`): `{column|col, allowed: [...]}` limita los valores permitidos.
+- `expect_email`, `expect_length`, `expect_foreign_key`: compatibles con versiones anteriores.
 
 ## Ejemplo YAML
 ```yaml
 validation:
-  expect_not_null: [order_id, order_date]
-  expect_unique:
-    - [order_id, order_date]
-  expect_between:
-    col: total_amount
-    min: 0
-  expect_regex:
-    col: country_code
-    pattern: "^[A-Z]{2}$"
-  expect_email: [customer_email]
-  expect_length:
-    col: customer_name
-    min: 3
-  expect_set:
-    col: status
-    allowed: [pending, shipped, delivered]
+  rules:
+    - check: expect_not_null
+      columns: [order_id, order_date]
+      severity: error
+    - check: regex
+      column: country_code
+      pattern: "^[A-Z]{2}$"
+      severity: warn
+      threshold: 0.05   # tolera 5% de incumplimientos
+    - check: values_in_set
+      column: status
+      allowed: [pending, shipped, delivered]
+      on_fail: quarantine
+  quarantine_sink:
+    type: storage
+    uri: abfs://silver/quarantine/orders/
 ```
 
 ## Rejects y métricas
 - Registros inválidos se escriben en `<sink.uri>/_rejects/` con las columnas originales más `_reject_reason`.
-- El motor devuelve métricas estructuradas `{input_rows, valid_rows, invalid_rows, reglas...}` y además escribe un JSON por ejecución en `<sink.uri>/_metrics/<timestamp>.json`.
-- Las métricas agregan contadores por cada regla (`expect_not_null`, `expect_regex`, etc.).
+- Las reglas con `on_fail: quarantine` se escriben adicionalmente en `validation.quarantine_sink` (si se configura) con `_quarantine_reason`.
+- El motor devuelve métricas estructuradas `{input_rows, valid_rows, invalid_rows, rules: {...}}`, añade `quarantine_rows` y un `run_id`, y escribe un JSON por ejecución en `<sink.uri>/_metrics/<timestamp>.json`.
 
 ## Buenas prácticas
 - Definir validaciones clave en capas `silver`/`gold` para asegurar contratos aguas arriba.

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -5,7 +5,7 @@ Las validaciones se definen dentro de `validation.rules` (o en `transform.valida
 ## Reglas soportadas
 - `expect_not_null`: asegura que las columnas listadas no contengan nulos.
 - `expect_unique` / `expect_column_values_to_be_unique`: valida unicidad sobre columnas o conjuntos de columnas.
-- `range` (`expect_between` legado): `{column|col, min?, max?}` valida que el valor se encuentre en el rango.
+- `range`/`expect_range` (`expect_between` legado): `{column|col, min?, max?}` valida que el valor se encuentre en el rango.
 - `regex`: `{column|col, pattern}` aplica expresiones regulares.
 - `values_in_set` (`expect_set`): `{column|col, allowed: [...]}` limita los valores permitidos.
 - `expect_email`, `expect_length`, `expect_foreign_key`: compatibles con versiones anteriores.
@@ -33,8 +33,8 @@ validation:
 
 ## Rejects y métricas
 - Registros inválidos se escriben en `<sink.uri>/_rejects/` con las columnas originales más `_reject_reason`.
-- Las reglas con `on_fail: quarantine` se escriben adicionalmente en `validation.quarantine_sink` (si se configura) con `_quarantine_reason`.
-- El motor devuelve métricas estructuradas `{input_rows, valid_rows, invalid_rows, rules: {...}}`, añade `quarantine_rows` y un `run_id`, y escribe un JSON por ejecución en `<sink.uri>/_metrics/<timestamp>.json`.
+- Las reglas con `on_fail: quarantine` se escriben adicionalmente en `validation.quarantine_sink` (si se configura) con `_reject_reason` y preservando el esquema original.
+- El motor devuelve métricas estructuradas `{input_rows, valid_rows, invalid_rows, by_rule: {...}, quarantine_rows, run_id, ...}` y escribe un JSON por ejecución en `<sink.uri>/_metrics/<run_id>.json`.
 
 ## Buenas prácticas
 - Definir validaciones clave en capas `silver`/`gold` para asegurar contratos aguas arriba.

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -1,6 +1,6 @@
 # Validaciones de datos
 
-Las validaciones se declaran en el bloque `validation` de cada dataset (junto a `source` y `sink`). Cada regla genera métricas, puede marcar registros inválidos y opcionalmente enviarlos a cuarentena.
+Las validaciones se declaran en el bloque `validation` de cada dataset (junto a `source` y `sink`). Cada regla genera métricas, puede marcar registros inválidos y opcionalmente enviarlos a cuarentena. El bloque histórico `transform.validation` quedó obsoleto y ya no es reconocido por el esquema.
 
 ## Reglas soportadas
 - `expect_not_null`: asegura que las columnas listadas no contengan nulos.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,8 @@ Cada carpeta contiene pipelines de referencia raw→gold para Azure, AWS, GCP y 
 - `azure/orders_pipeline.yaml`: ingesta multi-fuente (ABFS + API REST) → parquet silver → Synapse gold.
 - `aws/products_pipeline.yaml`: normalización JSON → parquet bronze → Redshift merge.
 - `gcp/customers_pipeline.yaml`: unión Parquet + GraphQL → parquet silver → BigQuery gold.
+- `endpoint_orders.yaml`: ingesta REST paginada con autenticación bearer hacia almacenamiento S3.
+- `jdbc_partitioned.yaml`: lectura JDBC paralelizada con pushdown hacia parquet raw.
 - `streaming/kafka_cosmos.yaml`: streaming Kafka → CosmosDB con watermark y checkpoint dedicado.
 - `streaming/orders_stream.yaml`: pipeline base para lecturas Kafka particionadas con watermark declarativo.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,21 @@
 # Ejemplos por plataforma
 
-Cada carpeta contiene pipelines de referencia raw→gold para Azure, AWS y GCP.
+Cada carpeta contiene pipelines de referencia raw→gold para Azure, AWS, GCP y escenarios streaming.
 
 ## Datos
 - `data/customers.csv`: dataset base utilizado en los ejemplos dev.
 
+## Pipelines destacados
+- `azure/orders_pipeline.yaml`: ingesta multi-fuente (ABFS + API REST) → parquet silver → Synapse gold.
+- `aws/products_pipeline.yaml`: normalización JSON → parquet bronze → Redshift merge.
+- `gcp/customers_pipeline.yaml`: unión Parquet + GraphQL → parquet silver → BigQuery gold.
+- `streaming/kafka_cosmos.yaml`: streaming Kafka → CosmosDB con watermark y checkpoint dedicado.
+
 ## Ejecución local (Spark standalone)
 ```bash
-prodi run --layer raw --config configs/envs/dev/layers/raw.yml --platform local
-prodi run --layer bronze --config configs/envs/dev/layers/bronze.yml --platform local
-prodi run --layer silver --config configs/envs/dev/layers/silver.yml --platform local
-prodi run --layer gold --config configs/envs/dev/layers/gold.yml --platform local
+prodi validate --config examples/azure/orders_pipeline.yaml
+prodi plan --config examples/aws/products_pipeline.yaml
+prodi run --layer silver --config examples/gcp/customers_pipeline.yaml --dry-run
 ```
+
+Para ejecuciones completas define las plataformas (`configs/platforms/*.yml`) y secretos necesarios (`${SECRET:...}`).

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Cada carpeta contiene pipelines de referencia raw→gold para Azure, AWS, GCP y 
 - `aws/products_pipeline.yaml`: normalización JSON → parquet bronze → Redshift merge.
 - `gcp/customers_pipeline.yaml`: unión Parquet + GraphQL → parquet silver → BigQuery gold.
 - `streaming/kafka_cosmos.yaml`: streaming Kafka → CosmosDB con watermark y checkpoint dedicado.
+- `streaming/orders_stream.yaml`: pipeline base para lecturas Kafka particionadas con watermark declarativo.
 
 ## Ejecución local (Spark standalone)
 ```bash

--- a/examples/aws/products_pipeline.yaml
+++ b/examples/aws/products_pipeline.yaml
@@ -23,20 +23,23 @@ datasets:
         - lowercase: [category]
         - trim: [product_name]
     validation:
-      expect_not_null: [product_id, product_name]
-      expect_set:
-        col: status
-        allowed: [active, discontinued]
+      rules:
+        - check: expect_not_null
+          columns: [product_id, product_name]
+        - check: expect_values_in_set
+          column: status
+          allowed: [active, discontinued]
     incremental:
       mode: append
-      watermark_column: updated_at
+      watermark:
+        column: updated_at
+        delay_threshold: "30 minutes"
     sink:
       type: storage
       format: parquet
       uri: s3://bronze/retail/products/
-      options:
-        mergeSchema: true
-        compression: snappy
+      merge_schema: true
+      compression: snappy
   - name: products_gold
     layer: gold
     source:
@@ -56,11 +59,13 @@ datasets:
             keys: [product_id]
             order_by: ["updated_at DESC", "_ingestion_ts DESC"]
     validation:
-      expect_unique: [product_id]
-      expect_between:
-        col: price
-        min: 0
-        max: 9999
+      rules:
+        - check: expect_unique
+          columns: [product_id]
+        - check: expect_range
+          column: price
+          min: 0
+          max: 9999
     incremental:
       mode: merge
       keys: [product_id]
@@ -69,8 +74,6 @@ datasets:
       type: warehouse
       engine: redshift
       table: analytics.products_gold
-      options:
-        batchsize: 5000
-        truncate: false
-        isolationLevel: SERIALIZABLE
-        createTableOptions: "DISTSTYLE KEY DISTKEY(product_id) SORTKEY(updated_at)"
+      batch_size: 5000
+      isolation_level: SERIALIZABLE
+      create_table_options: "DISTSTYLE KEY DISTKEY(product_id) SORTKEY(updated_at)"

--- a/examples/aws/products_pipeline.yaml
+++ b/examples/aws/products_pipeline.yaml
@@ -1,0 +1,76 @@
+project: retail360
+environment: dev
+platform: aws
+spark:
+  shuffle_partitions: 4
+  extra_conf:
+    spark.sql.files.maxPartitionBytes: 134217728
+datasets:
+  - name: products_bronze
+    layer: bronze
+    source:
+      type: storage
+      format: json
+      uri: s3://landing/retail/products/
+      infer_schema: true
+      options:
+        multiLine: true
+    transform:
+      add_ingestion_ts: true
+      ops:
+        - flatten_json:
+            depth: 2
+        - lowercase: [category]
+        - trim: [product_name]
+    validation:
+      expect_not_null: [product_id, product_name]
+      expect_set:
+        col: status
+        allowed: [active, discontinued]
+    incremental:
+      mode: append
+      watermark_column: updated_at
+    sink:
+      type: storage
+      format: parquet
+      uri: s3://bronze/retail/products/
+      options:
+        mergeSchema: true
+        compression: snappy
+  - name: products_gold
+    layer: gold
+    source:
+      type: storage
+      format: parquet
+      uri: s3://bronze/retail/products/
+      options:
+        mergeSchema: true
+    transform:
+      ops:
+        - rename:
+            product_name: name
+            category: category_code
+        - cast:
+            price: decimal(12,2)
+        - deduplicate:
+            keys: [product_id]
+            order_by: ["updated_at DESC", "_ingestion_ts DESC"]
+    validation:
+      expect_unique: [product_id]
+      expect_between:
+        col: price
+        min: 0
+        max: 9999
+    incremental:
+      mode: merge
+      keys: [product_id]
+      order_by: ["updated_at DESC", "_ingestion_ts DESC"]
+    sink:
+      type: warehouse
+      engine: redshift
+      table: analytics.products_gold
+      options:
+        batchsize: 5000
+        truncate: false
+        isolationLevel: SERIALIZABLE
+        createTableOptions: "DISTSTYLE KEY DISTKEY(product_id) SORTKEY(updated_at)"

--- a/examples/azure/orders_pipeline.yaml
+++ b/examples/azure/orders_pipeline.yaml
@@ -126,7 +126,6 @@ datasets:
       table: analytics.orders_gold
       partition_by: [order_date]
       batch_size: 10000
+      truncate_safe: false
       isolation_level: READ_COMMITTED
-        truncate: false
-        isolationLevel: READ_COMMITTED
-        createTableOptions: "DISTRIBUTION = HASH(order_id)"
+      create_table_options: "DISTRIBUTION = HASH(order_id)"

--- a/examples/azure/orders_pipeline.yaml
+++ b/examples/azure/orders_pipeline.yaml
@@ -14,13 +14,18 @@ datasets:
         options:
           header: true
           delimiter: ";"
-      - type: api_rest
-        options:
-          endpoint: https://api.retail.example.com/v1/orders
-          method: GET
-          params:
-            status: completed
-          flatten: true
+      - type: endpoint
+        url: https://api.retail.example.com/v1/orders
+        method: GET
+        auth:
+          type: bearer
+          token: ${SECRET:RETAIL_API_TOKEN}
+        pagination:
+          strategy: cursor
+          param: cursor
+          cursor_path: $.next
+        record_path: data
+        flatten: true
     merge_strategy:
       keys: [order_id]
       prefer: newest
@@ -44,12 +49,21 @@ datasets:
             keys: [order_id]
             order_by: ["order_date DESC", "_ingestion_ts DESC"]
     validation:
-      expect_not_null: [order_id, order_date]
-      expect_unique: [order_id]
-      expect_between:
-        col: total_amount
-        min: 0
-      expect_email: [customer_email]
+      rules:
+        - check: expect_not_null
+          columns: [order_id, order_date]
+        - check: expect_unique
+          columns: [order_id]
+        - check: range
+          column: total_amount
+          min: 0
+        - check: regex
+          column: customer_email
+          pattern: "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"
+          severity: warn
+      quarantine_sink:
+        type: storage
+        uri: abfs://silver/retail/orders_silver/_quarantine/
     incremental:
       mode: merge
       keys: [order_id]
@@ -63,6 +77,8 @@ datasets:
       options:
         mergeSchema: true
         compression: snappy
+      write_options:
+        maxRecordsPerFile: 134217728
   - name: orders_gold
     layer: gold
     source:

--- a/examples/azure/orders_pipeline.yaml
+++ b/examples/azure/orders_pipeline.yaml
@@ -1,0 +1,107 @@
+project: retail360
+environment: dev
+platform: azure
+spark:
+  shuffle_partitions: 4
+datasets:
+  - name: orders_silver
+    layer: silver
+    source:
+      - type: storage
+        format: csv
+        uri: abfs://landing/retail/orders/
+        infer_schema: true
+        options:
+          header: true
+          delimiter: ";"
+      - type: api_rest
+        options:
+          endpoint: https://api.retail.example.com/v1/orders
+          method: GET
+          params:
+            status: completed
+          flatten: true
+    merge_strategy:
+      keys: [order_id]
+      prefer: newest
+      order_by: ["_ingestion_ts DESC"]
+    transform:
+      add_ingestion_ts: true
+      ops:
+        - trim: [customer_name, country]
+        - uppercase: [country]
+        - rename:
+            country: country_code
+        - cast:
+            total_amount: decimal(18,2)
+        - normalize_whitespace: [customer_name]
+        - standardize_dates:
+            cols: [order_date]
+            format_in: "yyyy-MM-dd'T'HH:mm:ss'Z'"
+            format_out: "yyyy-MM-dd"
+            tz: UTC
+        - deduplicate:
+            keys: [order_id]
+            order_by: ["order_date DESC", "_ingestion_ts DESC"]
+    validation:
+      expect_not_null: [order_id, order_date]
+      expect_unique: [order_id]
+      expect_between:
+        col: total_amount
+        min: 0
+      expect_email: [customer_email]
+    incremental:
+      mode: merge
+      keys: [order_id]
+      order_by: ["order_date DESC", "_ingestion_ts DESC"]
+      watermark_column: order_date
+    sink:
+      type: storage
+      format: parquet
+      uri: abfs://silver/retail/orders_silver/
+      partition_by: [order_date]
+      options:
+        mergeSchema: true
+        compression: snappy
+  - name: orders_gold
+    layer: gold
+    source:
+      type: storage
+      format: parquet
+      uri: abfs://silver/retail/orders_silver/
+      options:
+        mergeSchema: true
+    transform:
+      sql:
+        - |
+          SELECT
+            order_id,
+            customer_name,
+            customer_email,
+            country_code,
+            total_amount,
+            CAST(order_date AS DATE) AS order_date,
+            _ingestion_ts
+          FROM orders_silver
+    validation:
+      expect_not_null: [order_id, order_date, customer_email]
+      expect_regex:
+        col: country_code
+        pattern: "^[A-Z]{2}$"
+      expect_length:
+        col: customer_name
+        min: 3
+    incremental:
+      mode: merge
+      keys: [order_id]
+      order_by: ["order_date DESC", "_ingestion_ts DESC"]
+    sink:
+      type: warehouse
+      engine: synapse
+      table: analytics.orders_gold
+      partition_by: [order_date]
+      options:
+        batchsize: 10000
+        truncate: false
+        isolationLevel: READ_COMMITTED
+        createTableOptions: "DISTRIBUTION = HASH(order_id)"

--- a/examples/azure/orders_pipeline.yaml
+++ b/examples/azure/orders_pipeline.yaml
@@ -52,12 +52,16 @@ datasets:
       rules:
         - check: expect_not_null
           columns: [order_id, order_date]
+          severity: error
         - check: expect_unique
           columns: [order_id]
-        - check: range
+          severity: error
+        - check: expect_range
           column: total_amount
           min: 0
-        - check: regex
+          severity: warn
+          threshold: 0.05
+        - check: expect_regex
           column: customer_email
           pattern: "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"
           severity: warn
@@ -68,17 +72,17 @@ datasets:
       mode: merge
       keys: [order_id]
       order_by: ["order_date DESC", "_ingestion_ts DESC"]
-      watermark_column: order_date
+      watermark:
+        column: order_date
+        delay_threshold: "1 day"
     sink:
       type: storage
       format: parquet
       uri: abfs://silver/retail/orders_silver/
       partition_by: [order_date]
-      options:
-        mergeSchema: true
-        compression: snappy
-      write_options:
-        maxRecordsPerFile: 134217728
+      merge_schema: true
+      compression: snappy
+      target_file_size_mb: 128
   - name: orders_gold
     layer: gold
     source:
@@ -100,13 +104,18 @@ datasets:
             _ingestion_ts
           FROM orders_silver
     validation:
-      expect_not_null: [order_id, order_date, customer_email]
-      expect_regex:
-        col: country_code
-        pattern: "^[A-Z]{2}$"
-      expect_length:
-        col: customer_name
-        min: 3
+      rules:
+        - check: expect_not_null
+          columns: [order_id, order_date, customer_email]
+          severity: error
+        - check: expect_regex
+          column: country_code
+          pattern: "^[A-Z]{2}$"
+          severity: warn
+        - check: expect_length
+          column: customer_name
+          min: 3
+          severity: warn
     incremental:
       mode: merge
       keys: [order_id]
@@ -116,8 +125,8 @@ datasets:
       engine: synapse
       table: analytics.orders_gold
       partition_by: [order_date]
-      options:
-        batchsize: 10000
+      batch_size: 10000
+      isolation_level: READ_COMMITTED
         truncate: false
         isolationLevel: READ_COMMITTED
         createTableOptions: "DISTRIBUTION = HASH(order_id)"

--- a/examples/endpoint_orders.yaml
+++ b/examples/endpoint_orders.yaml
@@ -1,0 +1,32 @@
+project: retail360
+environment: dev
+platform: aws
+datasets:
+  - name: orders_endpoint
+    layer: bronze
+    source:
+      type: endpoint
+      url: https://api.example.com/v1/orders
+      method: GET
+      auth:
+        type: bearer
+        token_env: API_TOKEN
+      pagination:
+        strategy: cursor
+        param: cursor
+        cursor_path: $.next
+      record_path: data.items
+      flatten: true
+      infer_schema: true
+    transform:
+      ops:
+        - rename:
+            orderId: order_id
+        - cast:
+            totalAmount: double
+    sink:
+      type: storage
+      format: parquet
+      uri: s3://raw/orders_endpoint/
+      merge_schema: true
+      compression: snappy

--- a/examples/gcp/customers_pipeline.yaml
+++ b/examples/gcp/customers_pipeline.yaml
@@ -10,22 +10,21 @@ datasets:
       - type: storage
         format: parquet
         uri: gs://landing/retail/customers/
-        options:
-          mergeSchema: true
+        merge_schema: true
       - type: api_graphql
-        options:
-          endpoint: https://api.retail.example.com/graphql
-          query: |
-            query Customers($region: String!) {
-              customers(region: $region) {
-                id
-                email
-                loyaltyTier
-                updatedAt
-              }
+        url: https://api.retail.example.com/graphql
+        query: |
+          query Customers($region: String!) {
+            customers(region: $region) {
+              id
+              email
+              loyaltyTier
+              updatedAt
             }
-          variables:
-            region: EU
+          }
+        variables:
+          region: EU
+        record_path: data.customers
     merge_strategy:
       keys: [customer_id]
       prefer: coalesce
@@ -40,11 +39,14 @@ datasets:
         - trim: [email]
         - normalize_whitespace: [full_name]
     validation:
-      expect_not_null: [customer_id, email]
-      expect_email: [email]
-      expect_length:
-        col: loyalty_tier
-        min: 1
+      rules:
+        - check: expect_not_null
+          columns: [customer_id, email]
+        - check: expect_email
+          columns: [email]
+        - check: expect_length
+          column: loyalty_tier
+          min: 1
     incremental:
       mode: merge
       keys: [customer_id]
@@ -53,9 +55,8 @@ datasets:
       type: storage
       format: parquet
       uri: gs://silver/retail/customers/
-      options:
-        mergeSchema: true
-        compression: snappy
+      merge_schema: true
+      compression: snappy
   - name: customers_gold
     layer: gold
     source:
@@ -76,10 +77,12 @@ datasets:
             _ingestion_ts
           FROM customers_silver
     validation:
-      expect_unique: [customer_id]
-      expect_regex:
-        col: loyalty_tier
-        pattern: "^(platinum|gold|silver|bronze)$"
+      rules:
+        - check: expect_unique
+          columns: [customer_id]
+        - check: expect_regex
+          column: loyalty_tier
+          pattern: "^(platinum|gold|silver|bronze)$"
     incremental:
       mode: merge
       keys: [customer_id]
@@ -88,6 +91,5 @@ datasets:
       type: warehouse
       engine: bigquery
       table: analytics.customers_gold
-      options:
-        temporaryGcsBucket: gs://tmp-retail/datacore/
-        intermediateFormat: parquet
+      temporary_gcs_bucket: gs://tmp-retail/datacore/
+      intermediate_format: parquet

--- a/examples/gcp/customers_pipeline.yaml
+++ b/examples/gcp/customers_pipeline.yaml
@@ -1,0 +1,93 @@
+project: retail360
+environment: dev
+platform: gcp
+spark:
+  shuffle_partitions: 4
+datasets:
+  - name: customers_silver
+    layer: silver
+    source:
+      - type: storage
+        format: parquet
+        uri: gs://landing/retail/customers/
+        options:
+          mergeSchema: true
+      - type: api_graphql
+        options:
+          endpoint: https://api.retail.example.com/graphql
+          query: |
+            query Customers($region: String!) {
+              customers(region: $region) {
+                id
+                email
+                loyaltyTier
+                updatedAt
+              }
+            }
+          variables:
+            region: EU
+    merge_strategy:
+      keys: [customer_id]
+      prefer: coalesce
+      order_by: ["_ingestion_ts DESC"]
+    transform:
+      ops:
+        - rename:
+            id: customer_id
+            loyaltyTier: loyalty_tier
+            updatedAt: updated_at
+        - lowercase: [loyalty_tier]
+        - trim: [email]
+        - normalize_whitespace: [full_name]
+    validation:
+      expect_not_null: [customer_id, email]
+      expect_email: [email]
+      expect_length:
+        col: loyalty_tier
+        min: 1
+    incremental:
+      mode: merge
+      keys: [customer_id]
+      order_by: ["updated_at DESC", "_ingestion_ts DESC"]
+    sink:
+      type: storage
+      format: parquet
+      uri: gs://silver/retail/customers/
+      options:
+        mergeSchema: true
+        compression: snappy
+  - name: customers_gold
+    layer: gold
+    source:
+      type: storage
+      format: parquet
+      uri: gs://silver/retail/customers/
+      options:
+        mergeSchema: true
+    transform:
+      sql:
+        - |
+          SELECT
+            customer_id,
+            full_name,
+            email,
+            loyalty_tier,
+            updated_at,
+            _ingestion_ts
+          FROM customers_silver
+    validation:
+      expect_unique: [customer_id]
+      expect_regex:
+        col: loyalty_tier
+        pattern: "^(platinum|gold|silver|bronze)$"
+    incremental:
+      mode: merge
+      keys: [customer_id]
+      order_by: ["updated_at DESC", "_ingestion_ts DESC"]
+    sink:
+      type: warehouse
+      engine: bigquery
+      table: analytics.customers_gold
+      options:
+        temporaryGcsBucket: gs://tmp-retail/datacore/
+        intermediateFormat: parquet

--- a/examples/jdbc_partitioned.yaml
+++ b/examples/jdbc_partitioned.yaml
@@ -1,0 +1,25 @@
+project: retail360
+environment: dev
+platform: aws
+datasets:
+  - name: orders_jdbc
+    layer: raw
+    source:
+      type: jdbc
+      url: "${JDBC_URL}"
+      table: public.orders
+      options:
+        user: "${DB_USER}"
+        password: "${DB_PASS}"
+      partition_column: id
+      lower_bound: 1
+      upper_bound: 100000000
+      num_partitions: 16
+      fetchsize: 10000
+      pushdown: true
+    sink:
+      type: storage
+      format: parquet
+      uri: s3://raw/orders/
+      merge_schema: true
+      compression: snappy

--- a/examples/streaming/kafka_cosmos.yaml
+++ b/examples/streaming/kafka_cosmos.yaml
@@ -11,10 +11,9 @@ datasets:
       options:
         subscribe: retail-orders
         startingOffsets: earliest
-        format: json
         kafka.bootstrap.servers: kafka:9092
         failOnDataLoss: false
-      watermark_column: event_time
+      payload_format: json
     transform:
       add_ingestion_ts: true
       ops:
@@ -25,15 +24,19 @@ datasets:
             total_amount: decimal(18,2)
         - uppercase: [currency]
     validation:
-      expect_not_null: [order_id, event_time]
-      expect_between:
-        col: total_amount
-        min: 0
+      rules:
+        - check: expect_not_null
+          columns: [order_id, event_time]
+        - check: expect_range
+          column: total_amount
+          min: 0
     streaming:
       enabled: true
-      trigger: processingTime=1 minute
-      checkpoint: abfs://checkpoints/retail/orders_stream/
-      watermark_column: event_time
+      trigger: "1 minute"
+      checkpoint_location: abfs://checkpoints/retail/orders_stream/
+      watermark:
+        column: event_time
+        delay_threshold: "5 minutes"
     sink:
       type: nosql
       engine: cosmosdb
@@ -42,7 +45,7 @@ datasets:
         masterkey: ${SECRET:COSMOS_KEY}
         database: retail
         collection: orders_stream
-        checkpointLocation: abfs://checkpoints/retail/orders_stream/
         writeThroughput: 400
+      checkpoint_location: abfs://checkpoints/retail/orders_stream/
     incremental:
       mode: append

--- a/examples/streaming/kafka_cosmos.yaml
+++ b/examples/streaming/kafka_cosmos.yaml
@@ -1,0 +1,48 @@
+project: retail360
+environment: dev
+platform: azure
+spark:
+  shuffle_partitions: 2
+datasets:
+  - name: orders_stream
+    layer: bronze
+    source:
+      type: kafka
+      options:
+        subscribe: retail-orders
+        startingOffsets: earliest
+        format: json
+        kafka.bootstrap.servers: kafka:9092
+        failOnDataLoss: false
+      watermark_column: event_time
+    transform:
+      add_ingestion_ts: true
+      ops:
+        - flatten_json:
+            depth: 1
+        - cast:
+            event_time: timestamp
+            total_amount: decimal(18,2)
+        - uppercase: [currency]
+    validation:
+      expect_not_null: [order_id, event_time]
+      expect_between:
+        col: total_amount
+        min: 0
+    streaming:
+      enabled: true
+      trigger: processingTime=1 minute
+      checkpoint: abfs://checkpoints/retail/orders_stream/
+      watermark_column: event_time
+    sink:
+      type: nosql
+      engine: cosmosdb
+      options:
+        endpoint: ${SECRET:COSMOS_URI}
+        masterkey: ${SECRET:COSMOS_KEY}
+        database: retail
+        collection: orders_stream
+        checkpointLocation: abfs://checkpoints/retail/orders_stream/
+        writeThroughput: 400
+    incremental:
+      mode: append

--- a/examples/streaming/kafka_cosmos.yaml
+++ b/examples/streaming/kafka_cosmos.yaml
@@ -34,9 +34,6 @@ datasets:
       enabled: true
       trigger: "1 minute"
       checkpoint_location: abfs://checkpoints/retail/orders_stream/
-      watermark:
-        column: event_time
-        delay_threshold: "5 minutes"
     sink:
       type: nosql
       engine: cosmosdb
@@ -49,3 +46,6 @@ datasets:
       checkpoint_location: abfs://checkpoints/retail/orders_stream/
     incremental:
       mode: append
+      watermark:
+        column: event_time
+        delay_threshold: "5 minutes"

--- a/examples/streaming/orders_stream.yaml
+++ b/examples/streaming/orders_stream.yaml
@@ -6,7 +6,7 @@ source:
     bootstrapServers: "${KAFKA_BOOTSTRAP}"
     subscribe: "orders"
     startingOffsets: "latest"
-    format: json
+  payload_format: json
 transform:
   ops:
     - cast:
@@ -20,5 +20,4 @@ incremental:
 sink:
   type: nosql
   engine: cosmosdb
-  options:
-    checkpointLocation: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"
+  checkpoint_location: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"

--- a/examples/streaming/orders_stream.yaml
+++ b/examples/streaming/orders_stream.yaml
@@ -1,0 +1,24 @@
+dataset: orders_stream
+layer: bronze
+source:
+  type: kafka
+  options:
+    bootstrapServers: "${KAFKA_BOOTSTRAP}"
+    subscribe: "orders"
+    startingOffsets: "latest"
+    format: json
+transform:
+  ops:
+    - cast:
+        created_at: timestamp
+        amount: double
+incremental:
+  mode: append
+  watermark:
+    column: created_at
+    delay_threshold: "10 minutes"
+sink:
+  type: nosql
+  engine: cosmosdb
+  options:
+    checkpointLocation: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"

--- a/examples/streaming/orders_stream.yaml
+++ b/examples/streaming/orders_stream.yaml
@@ -1,27 +1,31 @@
-dataset: orders_stream
-layer: bronze
-source:
-  type: kafka
-  options:
-    bootstrapServers: "${KAFKA_BOOTSTRAP}"
-    subscribe: "orders"
-    startingOffsets: "latest"
-  payload_format: json
-transform:
-  ops:
-    - cast:
-        created_at: timestamp
-        amount: double
-streaming:
-  enabled: true
-  trigger: "1 minute"
-  checkpoint_location: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"
-incremental:
-  mode: append
-  watermark:
-    column: created_at
-    delay_threshold: "10 minutes"
-sink:
-  type: nosql
-  engine: cosmosdb
-  checkpoint_location: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"
+project: retail360
+environment: dev
+platform: azure
+datasets:
+  - name: orders_stream
+    layer: bronze
+    source:
+      type: kafka
+      options:
+        bootstrapServers: "${KAFKA_BOOTSTRAP}"
+        subscribe: "orders"
+        startingOffsets: "latest"
+      payload_format: json
+    transform:
+      ops:
+        - cast:
+            created_at: timestamp
+            amount: double
+    streaming:
+      enabled: true
+      trigger: "1 minute"
+      checkpoint_location: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"
+    incremental:
+      mode: append
+      watermark:
+        column: created_at
+        delay_threshold: "10 minutes"
+    sink:
+      type: nosql
+      engine: cosmosdb
+      checkpoint_location: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"

--- a/examples/streaming/orders_stream.yaml
+++ b/examples/streaming/orders_stream.yaml
@@ -12,6 +12,10 @@ transform:
     - cast:
         created_at: timestamp
         amount: double
+streaming:
+  enabled: true
+  trigger: "1 minute"
+  checkpoint_location: "abfss://chk@storage.dfs.core.windows.net/orders_stream/_chk/"
 incremental:
   mode: append
   watermark:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pyyaml>=6.0",
   "jsonschema>=4.20",
   "requests>=2.31",
+  "boto3>=1.34",
 ]
 
 [project.optional-dependencies]

--- a/tests/integration/test_pipeline_local.py
+++ b/tests/integration/test_pipeline_local.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 from datacore.core.engine import run_layer_plan
 
 
@@ -29,4 +34,5 @@ def test_run_layer_plan_local(tmp_path):
         ],
     }
     results = run_layer_plan("raw", config, platform_name="local", environment="dev")
-    assert results[0]["status"] == "completed"
+    assert "run_id" in results
+    assert results["datasets"][0]["status"] == "completed"

--- a/tests/unit/test_api_connectors.py
+++ b/tests/unit/test_api_connectors.py
@@ -1,0 +1,58 @@
+from datacore.connectors.api import graphql, rest
+
+
+class _DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def json(self):  # type: ignore[no-untyped-def]
+        return self._payload
+
+
+def test_rest_fetch_pages(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def fake_get(url, headers=None, params=None, timeout=None):  # type: ignore[no-untyped-def]
+        calls.append({"headers": headers, "params": params})
+        return _DummyResponse({"items": []})
+
+    monkeypatch.setattr(rest.requests, "get", fake_get)
+    monkeypatch.setattr(rest.time, "sleep", lambda *_: None)
+
+    list(
+        rest.fetch_pages(
+            {"url": "https://api.example.com", "bearer_token": "abc", "max_pages": 2}
+        )
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["headers"]["Authorization"] == "Bearer abc"
+    assert calls[0]["params"]["page"] == 1
+    assert calls[1]["params"]["page"] == 2
+
+
+def test_graphql_execute_query(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # type: ignore[no-untyped-def]
+        captured.update({"url": url, "json": json, "headers": headers})
+        return _DummyResponse({"data": {"ok": True}})
+
+    monkeypatch.setattr(graphql.requests, "post", fake_post)
+
+    response = graphql.execute_query(
+        {
+            "url": "https://graphql.example.com",
+            "query": "query($id: ID!){ item(id: $id) { id } }",
+            "variables": {"id": 1},
+            "headers": {"X-Token": "secret"},
+        }
+    )
+
+    assert response["data"]["ok"] is True
+    assert captured["url"] == "https://graphql.example.com"
+    assert captured["json"]["variables"] == {"id": 1}
+    assert captured["headers"]["X-Token"] == "secret"

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from datacore.cli import main as cli_main
+
+
+@pytest.fixture
+def sample_config(tmp_path: Path) -> Path:
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+project: demo
+environment: dev
+platform: local
+datasets:
+  - name: demo
+    layer: bronze
+    source:
+      type: storage
+      uri: file:///tmp/input
+    sink:
+      type: storage
+      uri: file:///tmp/output
+"""
+    )
+    return config
+
+
+def test_cli_validate(monkeypatch, sample_config):
+    called = {}
+
+    def fake_validate(data, schema=None):
+        called["validated"] = (data, schema)
+
+    monkeypatch.setattr(cli_main, "validate_config", fake_validate)
+    cli_main.main(["validate", "--config", str(sample_config)])
+    assert "validated" in called
+
+
+def test_cli_run_dry_run(monkeypatch, sample_config, capsys):
+    monkeypatch.setattr(cli_main, "validate_config", lambda data, schema=None: None)
+    monkeypatch.setattr(
+        cli_main,
+        "run_layer_plan",
+        lambda **kwargs: {"run_id": "run-123", "datasets": [{"name": "demo", "status": "planned"}]},
+    )
+
+    cli_main.main(
+        [
+            "run",
+            "--layer",
+            "bronze",
+            "--config",
+            str(sample_config),
+            "--dry-run",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["run_id"] == "run-123"
+    assert output["layer"] == "bronze"
+    assert output["datasets"][0]["status"] == "planned"
+
+
+def test_cli_plan(monkeypatch, sample_config, capsys):
+    monkeypatch.setattr(cli_main, "validate_config", lambda data, schema=None: None)
+
+    def fake_plan(**kwargs):
+        return {
+            "run_id": f"run-{kwargs['layer']}",
+            "datasets": [{"name": f"{kwargs['layer']}_ds", "status": "planned"}],
+        }
+
+    monkeypatch.setattr(cli_main, "run_layer_plan", fake_plan)
+
+    cli_main.main(["plan", "--config", str(sample_config)])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["layers"][0]["run_id"].startswith("run-")
+    assert payload["layers"][0]["datasets"][0]["status"] == "planned"

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -60,7 +60,7 @@ def test_cli_run_dry_run(monkeypatch, sample_config, capsys):
 
     output = json.loads(capsys.readouterr().out)
     assert output["run_id"] == "run-123"
-    assert output["layer"] == "bronze"
+    assert "layer" not in output
     assert output["datasets"][0]["status"] == "planned"
 
 

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -62,6 +62,7 @@ def test_cli_run_dry_run(monkeypatch, sample_config, capsys):
     assert output["run_id"] == "run-123"
     assert "layer" not in output
     assert output["datasets"][0]["status"] == "planned"
+    assert output["plan"] == output["datasets"]
 
 
 def test_cli_plan(monkeypatch, sample_config, capsys):

--- a/tests/unit/test_core_ops.py
+++ b/tests/unit/test_core_ops.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+from pyspark.sql import Row
+
+from datacore.core import ops
+
+
+def test_apply_ops_transformations(spark):
+    df = spark.createDataFrame([(1, " ada ", "foo"), (2, "bea", "bar")], ["id", "name", "payload"])
+
+    result = ops.apply_ops(
+        df,
+        [
+            {"trim": ["name"]},
+            {"uppercase": ["name"]},
+            {"rename": {"name": "NAME"}},
+            {"drop_columns": ["payload"]},
+        ],
+    )
+
+    assert "payload" not in result.columns
+    assert result.collect()[0]["NAME"] == "ADA"
+
+
+def test_deduplicate_and_flatten(spark):
+    df = spark.createDataFrame(
+        [
+            (1, Row(info=Row(value="A")), datetime(2024, 1, 1, 0, 0, 0)),
+            (1, Row(info=Row(value="B")), datetime(2024, 2, 1, 0, 0, 0)),
+        ],
+        ["id", "data", "_ingestion_ts"],
+    )
+
+    result = ops.apply_ops(
+        df,
+        [
+            {"flatten_json": {"prefix": "flat"}},
+            {"deduplicate": {"keys": ["id"], "order_by": ["_ingestion_ts DESC"]}},
+        ],
+    )
+
+    row = result.collect()[0]
+    assert row.id == 1
+    assert row.flatdata_info_value == "B"

--- a/tests/unit/test_engine_internal.py
+++ b/tests/unit/test_engine_internal.py
@@ -1,0 +1,91 @@
+from pyspark.sql import Row
+
+from datacore.core import engine
+
+
+def test_sanitize_options_masks_sensitive():
+    options = {"Password": "secret", "path": "/tmp/data"}
+    sanitized = engine._sanitize_options(options)
+    assert sanitized["Password"] == "***"
+    assert sanitized["path"] == "/tmp/data"
+
+
+def test_merge_strategy_coalesce(spark):
+    df = spark.createDataFrame(
+        [
+            Row(id=1, value=None, _ingestion_ts="2024-01-01T00:00:00Z", __dc_source_ordinal=0),
+            Row(id=1, value="B", _ingestion_ts="2024-01-02T00:00:00Z", __dc_source_ordinal=1),
+        ]
+    )
+
+    result = engine._merge_strategy(df, {"keys": ["id"], "prefer": "coalesce"})
+    row = result.collect()[0]
+    assert row.id == 1
+    assert row.value == "B"
+
+
+def test_merge_strategy_left_prefers_first(spark):
+    df = spark.createDataFrame(
+        [
+            Row(id=1, value="LEFT", _ingestion_ts="2024-01-01T00:00:00Z", __dc_source_ordinal=0),
+            Row(id=1, value="RIGHT", _ingestion_ts="2024-02-01T00:00:00Z", __dc_source_ordinal=1),
+        ]
+    )
+
+    result = engine._merge_strategy(
+        df,
+        {"keys": ["id"], "prefer": "left", "order_by": ["_ingestion_ts DESC"]},
+    )
+    row = result.collect()[0]
+    assert row.value == "LEFT"
+
+
+def test_detect_dataset_issues_multisource():
+    dataset = {
+        "name": "customers",
+        "source": [{"type": "storage"}, {"type": "storage"}],
+        "sink": {"type": "storage", "format": "txt"},
+        "incremental": {"mode": "merge"},
+    }
+    issues = engine._detect_dataset_issues(dataset)
+    assert any("merge_strategy" in issue for issue in issues)
+    assert any("Formato" in issue for issue in issues)
+
+
+def test_apply_transformations_adds_ingestion_ts(spark):
+    df = spark.createDataFrame([Row(id=1, value=1)])
+    transformed = engine._apply_transformations(
+        df,
+        {
+            "sql": ["SELECT id, value FROM _src_0"],
+            "ops": [{"rename": {"value": "amount"}}],
+            "add_ingestion_ts": True,
+        },
+    )
+    assert "_ingestion_ts" in transformed.columns
+    assert "amount" in transformed.columns
+
+
+def test_build_plan_masks_sink_options():
+    dataset = {
+        "name": "customers",
+        "layer": "silver",
+        "source": {"type": "storage", "uri": "file:///tmp", "options": {"password": "secret"}},
+        "sink": {
+            "type": "warehouse",
+            "format": "delta",
+            "options": {"connectionString": "abc"},
+            "write_options": {"apiKey": "hidden"},
+        },
+        "transform": {"ops": [{"exclude": ["tmp"]}]},
+        "incremental": {"mode": "append"},
+        "streaming": {"enabled": False},
+    }
+
+    plan = engine._build_plan(dataset)
+
+    source_options = plan["source_plan"]["sources"][0]["options"]
+    assert source_options["password"] == "***"
+    sink_options = plan["sink_plan"]["options"]
+    assert sink_options["connectionString"] == "***"
+    assert plan["transform_plan"]["ops"] == [{"exclude": ["tmp"]}]

--- a/tests/unit/test_engine_plan.py
+++ b/tests/unit/test_engine_plan.py
@@ -1,0 +1,30 @@
+from datacore.core.engine import run_layer_plan
+
+
+def test_run_layer_plan_dry_run(tmp_path):
+    config = {
+        "project": "demo",
+        "environment": "dev",
+        "platform": "local",
+        "datasets": [
+            {
+                "name": "customers_raw",
+                "layer": "bronze",
+                "source": {
+                    "type": "storage",
+                    "uri": str(tmp_path / "in"),
+                    "backend": "local",
+                },
+                "sink": {
+                    "type": "storage",
+                    "uri": str(tmp_path / "out"),
+                    "backend": "local",
+                },
+                "incremental": {"mode": "merge"},
+            }
+        ],
+    }
+
+    plan = run_layer_plan("bronze", config, dry_run=True)
+    assert plan[0]["status"] == "planned"
+    assert "incremental.merge requiere keys" in plan[0]["issues"][0]

--- a/tests/unit/test_engine_plan.py
+++ b/tests/unit/test_engine_plan.py
@@ -59,6 +59,9 @@ def test_plan_streaming_contract(tmp_path):
                     "enabled": True,
                     "trigger": "10 minutes",
                     "checkpoint_location": str(tmp_path / "chk"),
+                },
+                "incremental": {
+                    "mode": "append",
                     "watermark": {"column": "created_at", "delay_threshold": "5 minutes"},
                 },
                 "source": {

--- a/tests/unit/test_engine_plan.py
+++ b/tests/unit/test_engine_plan.py
@@ -26,5 +26,7 @@ def test_run_layer_plan_dry_run(tmp_path):
     }
 
     plan = run_layer_plan("bronze", config, dry_run=True)
-    assert plan[0]["status"] == "planned"
-    assert "incremental.merge requiere keys" in plan[0]["issues"][0]
+    assert "run_id" in plan
+    dataset_plan = plan["datasets"][0]
+    assert dataset_plan["status"] == "planned"
+    assert any("incremental.merge requiere keys" in issue for issue in dataset_plan["issues"])

--- a/tests/unit/test_engine_plan.py
+++ b/tests/unit/test_engine_plan.py
@@ -1,4 +1,16 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
 from datacore.core.engine import run_layer_plan
+
+PLAN_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "datacore" / "config" / "schemas" / "plan.schema.json"
+
+with PLAN_SCHEMA_PATH.open("r", encoding="utf-8") as handle:
+    PLAN_SCHEMA = json.load(handle)
+
+PLAN_VALIDATOR = Draft7Validator(PLAN_SCHEMA)
 
 
 def test_run_layer_plan_dry_run(tmp_path):
@@ -27,6 +39,43 @@ def test_run_layer_plan_dry_run(tmp_path):
 
     plan = run_layer_plan("bronze", config, dry_run=True)
     assert "run_id" in plan
+    PLAN_VALIDATOR.validate(plan)
     dataset_plan = plan["datasets"][0]
     assert dataset_plan["status"] == "planned"
+    assert "source_plan" in dataset_plan
     assert any("incremental.merge requiere keys" in issue for issue in dataset_plan["issues"])
+
+
+def test_plan_streaming_contract(tmp_path):
+    config = {
+        "project": "demo",
+        "environment": "dev",
+        "platform": "local",
+        "datasets": [
+            {
+                "name": "orders_stream",
+                "layer": "bronze",
+                "streaming": {
+                    "enabled": True,
+                    "trigger": "10 minutes",
+                    "checkpoint_location": str(tmp_path / "chk"),
+                    "watermark": {"column": "created_at", "delay_threshold": "5 minutes"},
+                },
+                "source": {
+                    "type": "kafka",
+                    "options": {"subscribe": "orders", "kafka.bootstrap.servers": "localhost:9092"},
+                    "payload_format": "json",
+                },
+                "sink": {"type": "nosql", "engine": "cosmosdb", "options": {}},
+            }
+        ],
+    }
+
+    plan = run_layer_plan("bronze", config, dry_run=True)
+    PLAN_VALIDATOR.validate(plan)
+    dataset_plan = plan["datasets"][0]
+    streaming_plan = dataset_plan["streaming_plan"]
+    assert streaming_plan["enabled"] is True
+    assert streaming_plan["trigger"] == "10 minutes"
+    assert streaming_plan["checkpoint_location"] == str(tmp_path / "chk")
+    assert streaming_plan["watermark"]["column"] == "created_at"

--- a/tests/unit/test_engine_plan.py
+++ b/tests/unit/test_engine_plan.py
@@ -109,3 +109,47 @@ def test_streaming_examples_emit_watermark_and_checkpoint(monkeypatch, config_re
     assert watermark
     assert watermark.get("column")
     assert watermark.get("delay_threshold")
+
+
+@pytest.mark.parametrize(
+    "config_rel_path",
+    [
+        "examples/azure/orders_pipeline.yaml",
+        "examples/aws/products_pipeline.yaml",
+        "examples/gcp/customers_pipeline.yaml",
+        "examples/endpoint_orders.yaml",
+        "examples/jdbc_partitioned.yaml",
+        "examples/streaming/orders_stream.yaml",
+        "examples/streaming/kafka_cosmos.yaml",
+    ],
+)
+def test_examples_dry_run_match_plan_contract(monkeypatch, config_rel_path):
+    base_dir = Path(__file__).resolve().parents[2]
+    config_path = base_dir / config_rel_path
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config = dict(config)
+    config["platform"] = "local"
+    monkeypatch.setattr(engine_module, "_prepare_spark", lambda platform, conf: object())
+    layers = {dataset.get("layer") for dataset in config.get("datasets", []) if dataset.get("layer")}
+    assert layers, "El ejemplo no define datasets con capa"
+
+    for layer in layers:
+        plan = engine_module.run_layer_plan(
+            layer,
+            config,
+            platform_name="local",
+            environment=config.get("environment", "dev"),
+            dry_run=True,
+        )
+        PLAN_VALIDATOR.validate(plan)
+        assert plan.get("datasets"), "El plan debe contener datasets"
+        for dataset_plan in plan["datasets"]:
+            assert dataset_plan["layer"] == layer
+            streaming_plan = dataset_plan.get("streaming_plan", {})
+            if streaming_plan.get("enabled"):
+                checkpoint = streaming_plan.get("checkpoint_location")
+                assert checkpoint, f"Falta checkpoint para {dataset_plan['name']}"
+                watermark = streaming_plan.get("watermark")
+                assert watermark, f"Falta watermark para {dataset_plan['name']}"
+                assert watermark.get("column")
+                assert watermark.get("delay_threshold")

--- a/tests/unit/test_engine_plan.py
+++ b/tests/unit/test_engine_plan.py
@@ -1,8 +1,11 @@
 import json
 from pathlib import Path
 
+import pytest
+import yaml
 from jsonschema import Draft7Validator
 
+from datacore.core import engine as engine_module
 from datacore.core.engine import run_layer_plan
 
 PLAN_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "datacore" / "config" / "schemas" / "plan.schema.json"
@@ -82,3 +85,27 @@ def test_plan_streaming_contract(tmp_path):
     assert streaming_plan["trigger"] == "10 minutes"
     assert streaming_plan["checkpoint_location"] == str(tmp_path / "chk")
     assert streaming_plan["watermark"]["column"] == "created_at"
+
+
+@pytest.mark.parametrize(
+    "config_rel_path, layer, dataset_name",
+    [
+        ("examples/streaming/orders_stream.yaml", "bronze", "orders_stream"),
+        ("examples/streaming/kafka_cosmos.yaml", "bronze", "orders_stream"),
+    ],
+)
+def test_streaming_examples_emit_watermark_and_checkpoint(monkeypatch, config_rel_path, layer, dataset_name):
+    base_dir = Path(__file__).resolve().parents[2]
+    config = yaml.safe_load((base_dir / config_rel_path).read_text(encoding="utf-8"))
+    config = dict(config)
+    config["platform"] = "local"
+    monkeypatch.setattr(engine_module, "_prepare_spark", lambda platform, conf: object())
+    plan = engine_module.run_layer_plan(layer, config, platform_name="local", dry_run=True)
+    PLAN_VALIDATOR.validate(plan)
+    dataset_plan = next(ds for ds in plan["datasets"] if ds["name"] == dataset_name)
+    streaming_plan = dataset_plan["streaming_plan"]
+    assert streaming_plan["checkpoint_location"]
+    watermark = streaming_plan.get("watermark")
+    assert watermark
+    assert watermark.get("column")
+    assert watermark.get("delay_threshold")

--- a/tests/unit/test_engine_process.py
+++ b/tests/unit/test_engine_process.py
@@ -1,0 +1,120 @@
+from pyspark.sql import Row
+
+from datacore.core import engine, validation
+from datacore.core.validation import ValidationResult
+from datacore.platforms.base import LocalPlatform
+
+
+def test_process_dataset_batch_flow(monkeypatch, spark, tmp_path):
+    platform = LocalPlatform({"checkpoint_base": str(tmp_path / "chk")})
+    dataset = {
+        "name": "customers",
+        "layer": "silver",
+        "source": {"type": "storage", "uri": "file:///tmp/in", "backend": "local"},
+        "sink": {"type": "storage", "uri": str(tmp_path / "out"), "backend": "local"},
+        "transform": {},
+        "validation": {
+            "quarantine_sink": {
+                "type": "storage",
+                "uri": str(tmp_path / "quarantine"),
+                "backend": "local",
+            }
+        },
+    }
+
+    source_df = spark.createDataFrame([Row(id=1)])
+    valid_df = spark.createDataFrame([Row(id=1, _reject_reason="")])
+    invalid_df = spark.createDataFrame([Row(id=2, _reject_reason="bad")])
+    quarantine_df = invalid_df
+    metrics = {
+        "input_rows": 2,
+        "valid_rows": 1,
+        "invalid_rows": 1,
+        "by_rule": {"expect_not_null:id": {"invalid_rows": 1, "valid_rows": 1}},
+    }
+    result_obj = ValidationResult(
+        valid_df=valid_df,
+        invalid_df=invalid_df,
+        quarantine_df=quarantine_df,
+        metrics=metrics,
+    )
+
+    monkeypatch.setattr(engine.readers, "read_batch", lambda *args, **kwargs: source_df)
+    monkeypatch.setattr(validation, "apply_validation", lambda df, cfg: result_obj)
+    monkeypatch.setattr(engine, "prepare_incremental", lambda df, sink, cfg, platform: (df, sink, False))
+
+    batch_calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(engine.writers, "write_batch", lambda df, plat, sink: batch_calls.append(("batch", sink)))
+    rejects: list[dict] = []
+    monkeypatch.setattr(engine.writers, "write_rejects", lambda df, plat, sink, **kw: rejects.append(sink))
+    metrics_calls: list[dict] = []
+    monkeypatch.setattr(
+        engine.writers,
+        "write_metrics",
+        lambda spark, plat, sink, **kw: metrics_calls.append({"sink": sink, **kw}),
+    )
+    monkeypatch.setattr(engine.observability, "record_dataset", lambda *a, **k: None)
+
+    result = engine._process_dataset(
+        layer="silver",
+        dataset=dataset,
+        platform=platform,
+        environment="dev",
+        spark=spark,
+        run_id="run-1",
+        dry_run=False,
+    )
+
+    assert result["status"] == "completed"
+    assert len(batch_calls) == 2
+    assert rejects and rejects[0]["type"] == "storage"
+    assert metrics_calls and metrics_calls[0]["run_id"] == "run-1"
+    assert metrics_calls[0]["metrics"]["quarantine_rows"] == 1
+
+
+def test_process_dataset_streaming_flow(monkeypatch, spark, tmp_path):
+    platform = LocalPlatform({"checkpoint_base": str(tmp_path / "chk")})
+    dataset = {
+        "name": "orders_stream",
+        "layer": "bronze",
+        "streaming": {
+            "enabled": True,
+            "trigger": "5 minutes",
+            "checkpoint_location": str(tmp_path / "chk"),
+        },
+        "source": {"type": "kafka", "options": {"subscribe": "orders"}},
+        "sink": {"type": "nosql", "engine": "cosmosdb", "options": {}},
+    }
+
+    dummy_df = object()
+    monkeypatch.setattr(engine.readers, "read_stream", lambda *a, **k: dummy_df)
+    monkeypatch.setattr(engine, "_apply_streaming_options", lambda df, cfg: df)
+    monkeypatch.setattr(engine, "_apply_transformations", lambda df, cfg: df)
+
+    writes: list[dict[str, object]] = []
+
+    def fake_write_stream(df, platform, sink, checkpoint, trigger=None):  # type: ignore[no-untyped-def]
+        writes.append({
+            "df": df,
+            "sink": sink,
+            "checkpoint": checkpoint,
+            "trigger": trigger,
+        })
+
+    monkeypatch.setattr(engine.writers, "write_stream", fake_write_stream)
+    monkeypatch.setattr(engine.observability, "record_dataset", lambda *a, **k: None)
+
+    result = engine._process_dataset(
+        layer="bronze",
+        dataset=dataset,
+        platform=platform,
+        environment="dev",
+        spark=spark,
+        run_id="run-2",
+        dry_run=False,
+    )
+
+    assert result["status"] == "streaming"
+    assert writes and writes[0]["df"] is dummy_df
+    assert writes[0]["checkpoint"] == str(tmp_path / "chk")
+    assert writes[0]["trigger"] == "5 minutes"

--- a/tests/unit/test_http_connector.py
+++ b/tests/unit/test_http_connector.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from datacore.connectors import http
+
+
+@dataclass
+class _FakeResponse:
+    payload: dict[str, Any]
+    status_code: int = 200
+    headers: dict[str, str] | None = None
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+    @property
+    def text(self) -> str:
+        return "ok"
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]):
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+        self.auth = None
+
+    def request(self, method: str, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        if not self._responses:
+            raise RuntimeError("no more responses")
+        return self._responses.pop(0)
+
+
+@pytest.mark.parametrize("strategy", ["page", "cursor", "link"])
+def test_fetch_pages_strategies(monkeypatch, strategy: str) -> None:
+    if strategy == "page":
+        responses = [
+            _FakeResponse({"data": [1]}),
+            _FakeResponse({"data": [2]}),
+        ]
+        pagination = {"strategy": "page", "param": "page", "max_pages": 2}
+    elif strategy == "cursor":
+        responses = [
+            _FakeResponse({"items": [1], "next": "cursor-2"}),
+            _FakeResponse({"items": [2], "next": None}),
+        ]
+        pagination = {"strategy": "cursor", "param": "cursor", "cursor_path": "$.next"}
+    else:
+        responses = [
+            _FakeResponse({"items": [1]}, headers={"Link": "<http://example.com?page=2>; rel=\"next\""}),
+            _FakeResponse({"items": [2]}, headers={}),
+        ]
+        pagination = {"strategy": "link", "max_pages": 5}
+
+    fake_session = _FakeSession(responses)
+    monkeypatch.setattr(http.requests, "Session", lambda: fake_session)
+
+    pages = list(
+        http.fetch_pages(
+            {
+                "url": "https://api.example.com/orders",
+                "method": "GET",
+                "auth": {"type": "bearer", "token": "XYZ"},
+                "pagination": pagination,
+                "retry": {"max_attempts": 1},
+            }
+        )
+    )
+
+    assert len(pages) == 2
+    assert fake_session.calls[0]["headers"]["Authorization"] == "Bearer XYZ"
+    if strategy == "page":
+        assert fake_session.calls[0]["params"]["page"] == 1
+        assert fake_session.calls[1]["params"]["page"] == 2
+    elif strategy == "cursor":
+        assert fake_session.calls[1]["params"]["cursor"] == "cursor-2"
+    else:
+        assert fake_session.calls[1]["url"].endswith("page=2")
+
+
+def test_fetch_pages_basic_auth(monkeypatch) -> None:
+    responses = [_FakeResponse({"items": []})]
+    session = _FakeSession(responses)
+    monkeypatch.setattr(http.requests, "Session", lambda: session)
+
+    list(
+        http.fetch_pages(
+            {
+                "url": "https://api.example.com/orders",
+                "method": "GET",
+                "auth": {"type": "basic", "username": "user", "password": "pass"},
+            }
+        )
+    )
+
+    assert session.auth == ("user", "pass")

--- a/tests/unit/test_incremental.py
+++ b/tests/unit/test_incremental.py
@@ -1,8 +1,31 @@
 from datacore.core.incremental import handle_incremental
 
 
-def test_handle_incremental_append(tmp_path, spark):
+def test_handle_incremental_merge_storage(tmp_path, spark):
     path = tmp_path / "dataset"
+    existing = spark.createDataFrame(
+        [(1, "old", "2024-01-01 00:00:00"), (2, "keep", "2024-01-02 00:00:00")],
+        ["id", "value", "_ingestion_ts"],
+    )
+    existing.write.mode("overwrite").parquet(str(path))
+
+    new_df = spark.createDataFrame(
+        [(1, "new", "2024-02-01 00:00:00"), (3, "fresh", "2024-02-02 00:00:00")],
+        ["id", "value", "_ingestion_ts"],
+    )
+
+    handled = handle_incremental(
+        new_df,
+        {"type": "storage", "uri": str(path), "format": "parquet"},
+        {"mode": "merge", "keys": ["id"], "order_by": ["_ingestion_ts DESC"]},
+    )
+
+    assert handled is True
+    result = spark.read.parquet(str(path)).orderBy("id").collect()
+    assert [row.value for row in result] == ["new", "keep", "fresh"]
+
+
+def test_handle_incremental_non_merge_returns_false(spark):
     df = spark.createDataFrame([(1, "A")], ["id", "value"])
-    handle_incremental(df, {"uri": str(path), "format": "parquet"}, "append", [])
-    assert spark.read.parquet(str(path)).count() == 1
+    handled = handle_incremental(df, {"type": "storage", "uri": "/tmp/x"}, {"mode": "append"})
+    assert handled is False

--- a/tests/unit/test_io_readers.py
+++ b/tests/unit/test_io_readers.py
@@ -2,14 +2,80 @@ from datacore.io import readers
 from datacore.platforms.base import LocalPlatform
 
 
-def test_read_batch_local(tmp_path, spark):
-    path = tmp_path / "data.parquet"
+def test_read_batch_storage_infer_schema(tmp_path, spark):
+    path = tmp_path / "data.csv"
     df = spark.createDataFrame([(1, "A")], ["id", "name"])
-    df.write.parquet(str(path))
+    df.write.mode("overwrite").option("header", True).csv(str(path))
     platform = LocalPlatform({"checkpoint_base": str(tmp_path / "chk")})
+
     result = readers.read_batch(
         spark,
         platform,
-        {"type": "storage", "format": "parquet", "uri": str(path), "backend": "local"},
+        {
+            "type": "storage",
+            "format": "csv",
+            "uri": str(path),
+            "backend": "local",
+            "infer_schema": True,
+            "options": {"header": "true"},
+        },
+        layer="bronze",
+        dataset="customers",
+        environment="dev",
     )
+
+    assert result.schema[0].name == "id"
+    cache_path = (tmp_path / "chk" / "bronze" / "customers" / "_schema_cache" / "schema.json")
+    assert cache_path.exists()
+
+
+def test_read_batch_api_rest(monkeypatch, spark, tmp_path):
+    platform = LocalPlatform({"checkpoint_base": str(tmp_path / "chk")})
+
+    monkeypatch.setattr(
+        readers.rest,
+        "fetch_pages",
+        lambda cfg: [{"items": [{"id": 1, "info": {"name": "Ada"}}]}],
+    )
+
+    result = readers.read_batch(
+        spark,
+        platform,
+        {
+            "type": "api_rest",
+            "record_path": "items",
+            "flatten": True,
+        },
+        layer="bronze",
+        dataset="api_customers",
+        environment="dev",
+    )
+
+    assert result.collect()[0]["info.name"] == "Ada"
+
+
+def test_read_batch_api_graphql(monkeypatch, spark, tmp_path):
+    platform = LocalPlatform({"checkpoint_base": str(tmp_path / "chk")})
+
+    monkeypatch.setattr(
+        readers.graphql,
+        "execute_query",
+        lambda cfg: {"data": {"customers": [{"id": 1, "email": "ada@example.com"}]}},
+    )
+
+    result = readers.read_batch(
+        spark,
+        platform,
+        {
+            "type": "api_graphql",
+            "url": "https://example/graphql",
+            "query": "query { customers { id email } }",
+            "record_path": ["data", "customers"],
+        },
+        layer="silver",
+        dataset="graphql_customers",
+        environment="dev",
+    )
+
     assert result.count() == 1
+    assert result.collect()[0]["email"] == "ada@example.com"

--- a/tests/unit/test_io_writers.py
+++ b/tests/unit/test_io_writers.py
@@ -1,0 +1,71 @@
+from unittest import mock
+
+from pyspark.sql import Row
+
+from datacore.io import writers
+from datacore.platforms.base import LocalPlatform
+
+
+def test_write_batch_storage_partition(tmp_path, spark):
+    df = spark.createDataFrame([Row(id=1, country="mx"), Row(id=2, country="mx")])
+    platform = LocalPlatform({})
+    sink = {
+        "type": "storage",
+        "uri": str(tmp_path / "out"),
+        "format": "parquet",
+        "backend": "local",
+        "partition_by": ["country"],
+    }
+    writers.write_batch(df, platform, sink)
+    stored = spark.read.parquet(str(tmp_path / "out"))
+    assert stored.count() == 2
+
+
+def test_write_nosql_dynamodb(monkeypatch, spark):
+    df = spark.createDataFrame([Row(id=1, value="A"), Row(id=2, value="B")])
+
+    mock_batch = mock.MagicMock()
+    mock_table = mock.MagicMock()
+    mock_table.batch_writer.return_value.__enter__.return_value = mock_batch
+    mock_resource = mock.MagicMock()
+    mock_resource.Table.return_value = mock_table
+    monkeypatch.setattr(writers, "boto3", mock.MagicMock(resource=lambda *args, **kwargs: mock_resource))
+
+    sink = {
+        "type": "nosql",
+        "engine": "dynamodb",
+        "table": "tbl",
+        "batch_size": 1,
+        "options": {"region": "us-east-1"},
+    }
+    writers.write_batch(df, LocalPlatform({}), sink)
+
+    assert mock_batch.put_item.call_count == 2
+
+
+def test_write_rejects_and_metrics(tmp_path, spark):
+    df = spark.createDataFrame([Row(id=1, _reject_reason="bad")])
+    platform = LocalPlatform({"checkpoint_base": str(tmp_path / "chk")})
+    sink = {"type": "storage", "uri": str(tmp_path / "target"), "backend": "local"}
+
+    writers.write_rejects(
+        df,
+        platform,
+        sink,
+        layer="silver",
+        dataset="customers",
+        environment="dev",
+    )
+    assert (tmp_path / "target" / "_rejects").exists()
+
+    writers.write_metrics(
+        spark,
+        platform,
+        sink,
+        layer="silver",
+        dataset="customers",
+        environment="dev",
+        metrics={"input_rows": 1},
+    )
+    metrics_dir = tmp_path / "target" / "_metrics"
+    assert any(metrics_dir.iterdir())

--- a/tests/unit/test_io_writers.py
+++ b/tests/unit/test_io_writers.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import mock
 
 from pyspark.sql import Row
@@ -65,7 +66,94 @@ def test_write_rejects_and_metrics(tmp_path, spark):
         layer="silver",
         dataset="customers",
         environment="dev",
+        run_id="run-1",
         metrics={"input_rows": 1},
     )
     metrics_dir = tmp_path / "target" / "_metrics"
-    assert any(metrics_dir.iterdir())
+    assert (metrics_dir / "run-1.json").exists()
+
+
+def test_write_batch_bigquery(monkeypatch, spark):
+    df = spark.createDataFrame([Row(id=1)])
+
+    captured: dict[str, Any] = {"options": {}}
+
+    from pyspark.sql.readwriter import DataFrameWriter
+
+    def fake_format(self, fmt):  # type: ignore[override]
+        captured["format"] = fmt
+        return self
+
+    def fake_mode(self, mode):  # type: ignore[override]
+        captured["mode"] = mode
+        return self
+
+    def fake_option(self, key, value):  # type: ignore[override]
+        captured["options"][key] = value
+        return self
+
+    def fake_save(self, path=None, format=None, mode=None, partitionBy=None, **kwargs):  # type: ignore[override]
+        captured["path"] = path
+        return None
+
+    monkeypatch.setattr(DataFrameWriter, "format", fake_format, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "mode", fake_mode, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "option", fake_option, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "save", fake_save, raising=False)
+
+    writers.write_batch(
+        df,
+        LocalPlatform({}),
+        {
+            "type": "warehouse",
+            "engine": "bigquery",
+            "table": "dataset.table",
+            "mode": "overwrite",
+            "temporary_gcs_bucket": "gs://tmp",
+            "intermediate_format": "parquet",
+            "options": {"writeMethod": "direct"},
+        },
+    )
+
+    assert captured["path"] == "dataset.table"
+    assert captured["format"] == "bigquery"
+    assert captured["mode"] == "overwrite"
+    assert captured["options"]["writeMethod"] == "direct"
+    assert captured["options"]["temporaryGcsBucket"] == "gs://tmp"
+    assert captured["options"]["intermediateFormat"] == "parquet"
+
+
+def test_write_stream_storage(monkeypatch, spark):
+    df = spark.createDataFrame([Row(id=1)])
+
+    captured: dict[str, Any] = {}
+
+    def fake_stream_writer(df, options, fmt, mode, checkpoint, trigger=None):  # type: ignore[no-untyped-def]
+        captured["fmt"] = fmt
+        captured["mode"] = mode
+        captured["options"] = options
+        captured["checkpoint"] = checkpoint
+        captured["trigger"] = trigger
+
+    monkeypatch.setattr(writers, "_stream_writer_common", fake_stream_writer)
+
+    writers.write_stream(
+        df,
+        LocalPlatform({}),
+        {
+            "type": "storage",
+            "format": "parquet",
+            "uri": "file:///tmp/out",
+            "mode": "append",
+            "write_options": {"compression": "snappy"},
+        },
+        checkpoint="/tmp/chk",
+        trigger="5 minutes",
+    )
+
+    assert captured["fmt"] == "parquet"
+    assert captured["mode"] == "append"
+    assert captured["options"]["path"] == "file:///tmp/out"
+    assert captured["options"]["compression"] == "snappy"
+    assert captured["checkpoint"] == "/tmp/chk"
+    assert captured["trigger"] == "5 minutes"

--- a/tests/unit/test_jdbc_connector.py
+++ b/tests/unit/test_jdbc_connector.py
@@ -1,0 +1,78 @@
+from datacore.connectors.db import jdbc
+
+
+class _FakeReader:
+    def __init__(self):
+        self.options: dict[str, object] = {}
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def load(self):
+        return self.options
+
+
+class _FakeSpark:
+    def __init__(self):
+        self._reader = _FakeReader()
+
+    @property
+    def read(self):  # pragma: no cover - accessor pattern
+        return self
+
+    def format(self, fmt):
+        assert fmt == "jdbc"
+        return self._reader
+
+
+def test_jdbc_read_injects_partitioning_and_pushdown():
+    spark = _FakeSpark()
+    result = jdbc.read(
+        spark,
+        {
+            "url": "jdbc:postgresql://host/db",
+            "table": "public.orders",
+            "pushdown": True,
+            "partition_column": "id",
+            "lower_bound": 1,
+            "upper_bound": 100,
+            "num_partitions": 4,
+            "fetchsize": 1_000,
+        },
+    )
+
+    assert result["url"] == "jdbc:postgresql://host/db"
+    assert result["dbtable"] == "public.orders"
+    assert result["partitionColumn"] == "id"
+    assert result["lowerBound"] == 1
+    assert result["upperBound"] == 100
+    assert result["numPartitions"] == 4
+    assert result["fetchsize"] == 1_000
+    assert result["pushDownPredicate"] == "true"
+
+
+def test_jdbc_read_supports_partitioning_block_aliases():
+    spark = _FakeSpark()
+    result = jdbc.read(
+        spark,
+        {
+            "url": "jdbc:postgresql://host/db",
+            "table": "public.orders",
+            "partitioning": {
+                "partitionColumn": "id",
+                "lower_bound": 10,
+                "upperBound": 20,
+                "num_partitions": 2,
+                "fetchsize": 5_000,
+            },
+            "predicate_pushdown": False,
+        },
+    )
+
+    assert result["partitionColumn"] == "id"
+    assert result["lowerBound"] == 10
+    assert result["upperBound"] == 20
+    assert result["numPartitions"] == 2
+    assert result["fetchsize"] == 5_000
+    assert result["pushDownPredicate"] == "false"

--- a/tests/unit/test_jdbc_connector.py
+++ b/tests/unit/test_jdbc_connector.py
@@ -1,33 +1,14 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from datacore.connectors.db import jdbc
 
 
-class _FakeReader:
-    def __init__(self):
-        self.options: dict[str, object] = {}
-
-    def option(self, key, value):
-        self.options[key] = value
-        return self
-
-    def load(self):
-        return self.options
-
-
-class _FakeSpark:
-    def __init__(self):
-        self._reader = _FakeReader()
-
-    @property
-    def read(self):  # pragma: no cover - accessor pattern
-        return self
-
-    def format(self, fmt):
-        assert fmt == "jdbc"
-        return self._reader
-
-
 def test_jdbc_read_injects_partitioning_and_pushdown():
-    spark = _FakeSpark()
+    reader = MagicMock()
+    reader.jdbc.return_value = "df"
+    spark = SimpleNamespace(read=reader)
+
     result = jdbc.read(
         spark,
         {
@@ -39,21 +20,31 @@ def test_jdbc_read_injects_partitioning_and_pushdown():
             "upper_bound": 100,
             "num_partitions": 4,
             "fetchsize": 1_000,
+            "options": {"user": "app", "password": "secret"},
         },
     )
 
-    assert result["url"] == "jdbc:postgresql://host/db"
-    assert result["dbtable"] == "public.orders"
-    assert result["partitionColumn"] == "id"
-    assert result["lowerBound"] == 1
-    assert result["upperBound"] == 100
-    assert result["numPartitions"] == 4
-    assert result["fetchsize"] == 1_000
-    assert result["pushDownPredicate"] == "true"
+    assert result == "df"
+    reader.jdbc.assert_called_once()
+    kwargs = reader.jdbc.call_args.kwargs
+    assert kwargs["url"] == "jdbc:postgresql://host/db"
+    assert kwargs["table"] == "public.orders"
+    assert kwargs["column"] == "id"
+    assert kwargs["lowerBound"] == 1
+    assert kwargs["upperBound"] == 100
+    assert kwargs["numPartitions"] == 4
+    props = kwargs["properties"]
+    assert props["fetchsize"] == "1000"
+    assert props["pushDownPredicate"] == "true"
+    assert props["user"] == "app"
+    assert props["password"] == "secret"
 
 
 def test_jdbc_read_supports_partitioning_block_aliases():
-    spark = _FakeSpark()
+    reader = MagicMock()
+    reader.jdbc.return_value = "df"
+    spark = SimpleNamespace(read=reader)
+
     result = jdbc.read(
         spark,
         {
@@ -70,12 +61,15 @@ def test_jdbc_read_supports_partitioning_block_aliases():
         },
     )
 
-    assert result["partitionColumn"] == "id"
-    assert result["lowerBound"] == 10
-    assert result["upperBound"] == 20
-    assert result["numPartitions"] == 2
-    assert result["fetchsize"] == 5_000
-    assert result["pushDownPredicate"] == "false"
+    assert result == "df"
+    kwargs = reader.jdbc.call_args.kwargs
+    assert kwargs["column"] == "id"
+    assert kwargs["lowerBound"] == 10
+    assert kwargs["upperBound"] == 20
+    assert kwargs["numPartitions"] == 2
+    props = kwargs["properties"]
+    assert props["fetchsize"] == "5000"
+    assert props["pushDownPredicate"] == "false"
 
 
 def test_jdbc_write_honours_snake_case_options():

--- a/tests/unit/test_layer_schema.py
+++ b/tests/unit/test_layer_schema.py
@@ -84,3 +84,32 @@ def test_schema_supports_sink_type_enum():
     }
 
     VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_rejects_invalid_sink_mode():
+    dataset = {
+        "name": "invalid_mode",
+        "layer": "silver",
+        "source": {"type": "storage", "uri": "s3://bucket/path"},
+        "sink": {"type": "storage", "uri": "s3://bucket/out", "mode": "unsupported"},
+    }
+
+    with pytest.raises(ValidationError):
+        VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_accepts_streaming_configuration():
+    dataset = {
+        "name": "orders_stream",
+        "layer": "bronze",
+        "source": {"type": "kafka", "options": {"subscribe": "orders"}},
+        "sink": {"type": "storage", "uri": "s3://bronze/orders/"},
+        "streaming": {
+            "enabled": True,
+            "trigger": "5 minutes",
+            "checkpoint_location": "/tmp/chk",
+            "watermark": {"column": "created_at", "delay_threshold": "10 minutes"},
+        },
+    }
+
+    VALIDATOR.validate(_base_config(dataset))

--- a/tests/unit/test_layer_schema.py
+++ b/tests/unit/test_layer_schema.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator, ValidationError
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "datacore" / "config" / "schemas" / "layer.schema.json"
+
+with SCHEMA_PATH.open("r", encoding="utf-8") as handle:
+    SCHEMA = json.load(handle)
+
+VALIDATOR = Draft7Validator(SCHEMA)
+
+
+def _base_config(dataset: dict) -> dict:
+    return {
+        "project": "demo",
+        "environment": "dev",
+        "platform": "azure",
+        "datasets": [dataset],
+    }
+
+
+def test_schema_accepts_single_source_object():
+    dataset = {
+        "name": "customers",
+        "layer": "silver",
+        "source": {
+            "type": "storage",
+            "format": "parquet",
+            "uri": "abfss://bronze@contoso.dfs.core.windows.net/customers/",
+        },
+        "sink": {
+            "type": "storage",
+            "format": "parquet",
+            "uri": "abfss://silver@contoso.dfs.core.windows.net/customers/",
+        },
+    }
+
+    VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_accepts_multi_source_list():
+    dataset = {
+        "name": "orders",
+        "layer": "bronze",
+        "source": [
+            {"type": "storage", "format": "csv", "uri": "s3://raw/orders/"},
+            {
+                "type": "api_rest",
+                "url": "https://api.example.com/v1/orders",
+                "record_path": "items",
+            },
+        ],
+        "sink": {
+            "type": "warehouse",
+            "engine": "synapse",
+            "table": "analytics.orders_bronze",
+            "mode": "append",
+        },
+    }
+
+    VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_enforces_source_type_enum():
+    dataset = {
+        "name": "bad_dataset",
+        "layer": "raw",
+        "source": {"type": "unsupported"},
+        "sink": {"type": "storage", "uri": "file:///tmp/out"},
+    }
+
+    with pytest.raises(ValidationError):
+        VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_supports_sink_type_enum():
+    dataset = {
+        "name": "events",
+        "layer": "bronze",
+        "source": {"type": "kafka", "options": {"subscribe": "events"}},
+        "sink": {"type": "nosql", "engine": "cosmosdb"},
+    }
+
+    VALIDATOR.validate(_base_config(dataset))

--- a/tests/unit/test_layer_schema.py
+++ b/tests/unit/test_layer_schema.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 from jsonschema import Draft7Validator, ValidationError
 
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "datacore" / "config" / "schemas" / "layer.schema.json"
@@ -12,6 +13,17 @@ with SCHEMA_PATH.open("r", encoding="utf-8") as handle:
 Draft7Validator.check_schema(SCHEMA)
 
 VALIDATOR = Draft7Validator(SCHEMA)
+
+EXAMPLES_BASE = Path(__file__).resolve().parents[2] / "examples"
+EXAMPLE_CONFIGS = [
+    EXAMPLES_BASE / "azure" / "orders_pipeline.yaml",
+    EXAMPLES_BASE / "aws" / "products_pipeline.yaml",
+    EXAMPLES_BASE / "gcp" / "customers_pipeline.yaml",
+    EXAMPLES_BASE / "endpoint_orders.yaml",
+    EXAMPLES_BASE / "jdbc_partitioned.yaml",
+    EXAMPLES_BASE / "streaming" / "kafka_cosmos.yaml",
+    EXAMPLES_BASE / "streaming" / "orders_stream.yaml",
+]
 
 
 def _base_config(dataset: dict) -> dict:
@@ -196,3 +208,9 @@ def test_schema_allows_dataset_validation_block():
     }
 
     VALIDATOR.validate(_base_config(dataset))
+
+
+@pytest.mark.parametrize("example_path", EXAMPLE_CONFIGS)
+def test_examples_conform_to_layer_schema(example_path: Path):
+    data = yaml.safe_load(example_path.read_text(encoding="utf-8"))
+    VALIDATOR.validate(data)

--- a/tests/unit/test_layer_schema.py
+++ b/tests/unit/test_layer_schema.py
@@ -9,6 +9,8 @@ SCHEMA_PATH = Path(__file__).resolve().parents[2] / "datacore" / "config" / "sch
 with SCHEMA_PATH.open("r", encoding="utf-8") as handle:
     SCHEMA = json.load(handle)
 
+Draft7Validator.check_schema(SCHEMA)
+
 VALIDATOR = Draft7Validator(SCHEMA)
 
 
@@ -131,6 +133,44 @@ def test_schema_accepts_repartition_object():
     }
 
     VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_accepts_repartition_integer():
+    dataset = {
+        "name": "customers",
+        "layer": "silver",
+        "source": {"type": "storage", "uri": "abfss://bronze/customers/"},
+        "sink": {"type": "storage", "uri": "abfss://silver/customers/", "repartition": 3},
+    }
+
+    VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_accepts_repartition_list():
+    dataset = {
+        "name": "customers",
+        "layer": "silver",
+        "source": {"type": "storage", "uri": "abfss://bronze/customers/"},
+        "sink": {
+            "type": "storage",
+            "uri": "abfss://silver/customers/",
+            "repartition": ["country", "segment"],
+        },
+    }
+
+    VALIDATOR.validate(_base_config(dataset))
+
+
+def test_schema_rejects_invalid_repartition_shape():
+    dataset = {
+        "name": "customers",
+        "layer": "silver",
+        "source": {"type": "storage", "uri": "abfss://bronze/customers/"},
+        "sink": {"type": "storage", "uri": "abfss://silver/customers/", "repartition": {}},
+    }
+
+    with pytest.raises(ValidationError):
+        VALIDATOR.validate(_base_config(dataset))
 
 
 def test_schema_rejects_transform_validation_block():

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,110 @@
+import logging
+import sys
+import types
+
+from datacore.utils import observability
+
+
+def test_new_run_id_unique():
+    run_a = observability.new_run_id()
+    run_b = observability.new_run_id()
+    assert run_a != run_b
+
+
+def test_record_dataset_logs(monkeypatch, caplog):
+    monkeypatch.setattr(observability, "DATASET_RUNS", None)
+    monkeypatch.setattr(observability, "DATASET_DURATION", None)
+    with caplog.at_level(logging.DEBUG):
+        observability.record_dataset("demo", "completed", 0.5, {"rows": 10})
+    assert "demo" in caplog.text
+
+
+def test_emit_openlineage_skip(caplog):
+    with caplog.at_level(logging.DEBUG):
+        observability.emit_openlineage({}, {"enabled": True})
+    assert "OpenLineage" in caplog.text
+
+
+def test_record_dataset_with_metrics(monkeypatch):
+    class _Metric:
+        def __init__(self):
+            self.calls: list[dict[str, str]] = []
+            self.count = 0
+
+        def labels(self, **labels):  # type: ignore[override]
+            self.calls.append(labels)
+            return self
+
+        def inc(self):
+            self.count += 1
+
+        def observe(self, value):  # type: ignore[override]
+            self.count += 1
+            self.value = value
+
+    counter = _Metric()
+    histogram = _Metric()
+    monkeypatch.setattr(observability, "DATASET_RUNS", counter)
+    monkeypatch.setattr(observability, "DATASET_DURATION", histogram)
+
+    observability.record_dataset("customers", "completed", 1.2, {"rows": 5})
+
+    assert counter.calls[0]["dataset"] == "customers"
+    assert histogram.calls[0]["dataset"] == "customers"
+    assert histogram.value == 1.2
+
+
+def test_emit_openlineage_happy_path(monkeypatch):
+    emitted: dict[str, object] = {}
+
+    class _Client:
+        def __init__(self, url, api_key=None):  # type: ignore[no-untyped-def]
+            self.url = url
+            self.api_key = api_key
+
+        def emit(self, event):  # type: ignore[no-untyped-def]
+            emitted["event"] = event
+
+    class _RunState:
+        COMPLETE = "COMPLETE"
+        FAILED = "FAILED"
+
+        @classmethod
+        def from_string(cls, value):  # type: ignore[no-untyped-def]
+            if value == "FAILED":
+                return cls.FAILED
+            return cls.COMPLETE
+
+    class _Run:
+        def __init__(self, runId):  # type: ignore[no-untyped-def]
+            self.runId = runId
+
+    class _Job:
+        def __init__(self, namespace, name):  # type: ignore[no-untyped-def]
+            self.namespace = namespace
+            self.name = name
+
+    class _RunEvent:
+        def __init__(self, eventType, eventTime, run, job, inputs, outputs):  # type: ignore[no-untyped-def]
+            self.eventType = eventType
+            self.eventTime = eventTime
+            self.run = run
+            self.job = job
+            self.inputs = inputs
+            self.outputs = outputs
+
+    client_mod = types.SimpleNamespace(OpenLineageClient=_Client)
+    run_mod = types.SimpleNamespace(Job=_Job, Run=_Run, RunEvent=_RunEvent, RunState=_RunState)
+    monkeypatch.setitem(sys.modules, "openlineage", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "openlineage.client", client_mod)
+    monkeypatch.setitem(sys.modules, "openlineage.client.run", run_mod)
+
+    observability.emit_openlineage(
+        {"run_id": "abc", "dataset": "customers", "layer": "silver", "status": "failed"},
+        {"enabled": True, "url": "https://ol", "namespace": "demo", "api_key": "token"},
+    )
+
+    event = emitted["event"]
+    assert event.eventType == _RunState.FAILED
+    assert event.job.name == "silver::customers"
+    assert event.run.runId == "abc"

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,0 +1,19 @@
+import pytest
+
+from datacore.utils import secrets
+
+
+def test_get_secret_env(monkeypatch):
+    monkeypatch.setenv("MY_SECRET", "value")
+    assert secrets.get_secret("MY_SECRET") == "value"
+
+
+def test_get_secret_default(monkeypatch):
+    monkeypatch.delenv("MISSING_SECRET", raising=False)
+    assert secrets.get_secret("MISSING_SECRET", default="fallback") == "fallback"
+
+
+def test_get_secret_missing(monkeypatch):
+    monkeypatch.delenv("ABSENT", raising=False)
+    with pytest.raises(secrets.SecretNotFoundError):
+        secrets.get_secret("ABSENT")

--- a/tests/unit/test_storage_connectors.py
+++ b/tests/unit/test_storage_connectors.py
@@ -1,0 +1,88 @@
+import importlib
+
+import pytest
+from pyspark.sql import Row
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "datacore.connectors.storage.abfs",
+        "datacore.connectors.storage.gcs",
+        "datacore.connectors.storage.s3",
+    ],
+)
+def test_storage_connector_write(monkeypatch, spark, module_name):
+    module = importlib.import_module(module_name)
+    df = spark.createDataFrame([Row(id=1, partition="a")])
+
+    captured: dict[str, object] = {"options": {}}
+
+    from pyspark.sql.readwriter import DataFrameWriter
+
+    def fake_mode(self, value):  # type: ignore[override]
+        captured["mode"] = value
+        return self
+
+    def fake_format(self, fmt):  # type: ignore[override]
+        captured["format"] = fmt
+        return self
+
+    def fake_partitionBy(self, *cols):  # type: ignore[override]
+        captured["partition_by"] = cols
+        return self
+
+    def fake_option(self, key, value):  # type: ignore[override]
+        captured["options"][key] = value
+        return self
+
+    def fake_save(self, uri):  # type: ignore[override]
+        captured["uri"] = uri
+        return None
+
+    monkeypatch.setattr(DataFrameWriter, "mode", fake_mode, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "format", fake_format, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "partitionBy", fake_partitionBy, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "option", fake_option, raising=False)
+    monkeypatch.setattr(DataFrameWriter, "save", fake_save, raising=False)
+
+    module.write(
+        df,
+        "file:///tmp/out",
+        "parquet",
+        "append",
+        {"compression": "snappy"},
+        partition_by=["partition"],
+        merge_schema=True,
+    )
+
+    assert captured["mode"] == "append"
+    assert captured["format"] == "parquet"
+    assert captured["partition_by"] == ("partition",)
+    assert captured["options"]["compression"] == "snappy"
+    assert captured["options"]["mergeSchema"] == "true"
+    assert captured["uri"] == "file:///tmp/out"
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "datacore.connectors.storage.abfs",
+        "datacore.connectors.storage.gcs",
+        "datacore.connectors.storage.s3",
+    ],
+)
+def test_storage_connector_read(tmp_path, spark, module_name):
+    module = importlib.import_module(module_name)
+    source_path = tmp_path / "data.parquet"
+    spark.createDataFrame([Row(id=1)]).write.mode("overwrite").parquet(str(source_path))
+
+    df = module.read(
+        spark,
+        str(source_path),
+        "parquet",
+        {"mergeSchema": "true"},
+        schema=None,
+    )
+
+    assert df.count() == 1

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,8 +1,43 @@
-from datacore.core.validation import apply_validation
+from datacore.core.validation import ValidationResult, apply_validation
 
 
-def test_apply_validation_not_null(spark):
-    df = spark.createDataFrame([(1, "a"), (2, None)], ["id", "value"])
-    metrics = apply_validation(df, {"expect_not_null": ["value"]})
-    assert metrics["invalid_rows"] == 1
-    assert metrics["valid_rows"] == 1
+def test_validation_rules_with_metrics(spark):
+    df = spark.createDataFrame(
+        [
+            (1, "ada@example.com", "100", "2024-01-01"),
+            (1, "invalid", "1000", "2024-01-02"),
+            (2, None, "200", "2024-01-03"),
+        ],
+        ["id", "email", "amount", "date"],
+    )
+
+    result = apply_validation(
+        df,
+        {
+            "expect_not_null": ["email"],
+            "expect_unique": ["id"],
+            "expect_regex": [{"col": "email", "pattern": r".+@.+"}],
+            "expect_between": [{"col": "amount", "min": 0, "max": 500}],
+        },
+    )
+
+    assert isinstance(result, ValidationResult)
+    assert result.metrics["input_rows"] == 3
+    assert result.metrics["invalid_rows"] == 3
+    assert "expect_unique:id" in result.metrics["rules"]
+    reasons = [row._reject_reason for row in result.invalid_df.collect() if row._reject_reason]
+    assert reasons
+
+
+def test_validation_alias_and_set_rule(spark):
+    df = spark.createDataFrame([(1, "A"), (2, "C")], ["id", "status"])
+    result = apply_validation(
+        df,
+        {
+            "expect_column_values_to_be_unique": ["id"],
+            "expect_set": [{"col": "status", "allowed": ["A", "B"]}],
+        },
+    )
+
+    assert result.metrics["invalid_rows"] == 1
+    assert "expect_set:status" in result.metrics["rules"]

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -24,8 +24,9 @@ def test_validation_rules_with_metrics(spark):
     assert isinstance(result, ValidationResult)
     assert result.metrics["input_rows"] == 3
     assert result.metrics["invalid_rows"] >= 1
-    unique_rule = result.metrics["rules"]["expect_unique:id"]
+    unique_rule = result.metrics["by_rule"]["expect_unique:id"]
     assert unique_rule["invalid_rows"] >= 1
+    assert unique_rule["valid_rows"] <= result.metrics["input_rows"]
     reasons = [row._reject_reason for row in result.invalid_df.collect() if row._reject_reason]
     assert any("expect_unique" in reason for reason in reasons)
 
@@ -41,7 +42,7 @@ def test_validation_alias_and_set_rule(spark):
     )
 
     assert result.metrics["invalid_rows"] == 1
-    assert "values_in_set:status" in result.metrics["rules"]
+    assert "values_in_set:status" in result.metrics["by_rule"]
 
 
 def test_validation_severity_and_quarantine(spark):
@@ -68,8 +69,68 @@ def test_validation_severity_and_quarantine(spark):
     )
 
     # La severidad warn no genera filas inválidas pero registra métricas
-    warn_rule = result.metrics["rules"]["expect_not_null:email_warn"]
+    warn_rule = result.metrics["by_rule"]["expect_not_null:email_warn"]
     assert warn_rule["invalid_rows"] == 1
     assert result.metrics["invalid_rows"] == 1
     # Cuarentena captura filas fallidas
     assert result.quarantine_df.count() == 1
+    assert "_reject_reason" in result.quarantine_df.columns
+
+
+def test_validation_threshold_prevents_failure(spark):
+    df = spark.createDataFrame([(1, None), (2, "ok")], ["id", "email"])
+
+    result = apply_validation(
+        df,
+        {
+            "rules": [
+                {
+                    "check": "expect_not_null",
+                    "columns": ["email"],
+                    "severity": "error",
+                    "threshold": 0.6,
+                }
+            ]
+        },
+    )
+
+    metrics = result.metrics["by_rule"]["expect_not_null:email"]
+    assert metrics["failed"] is False
+    assert result.metrics["invalid_rows"] == 0
+
+
+def test_validation_email_length_and_foreign_key(spark):
+    df = spark.createDataFrame(
+        [
+            ("ada@example.com", "OK", "A1"),
+            ("invalid", "TOO_LONG", "X9"),
+        ],
+        ["email", "code", "ref"],
+    )
+    reference = spark.createDataFrame([("A1",)], ["ref"])
+    reference.createOrReplaceTempView("dim_refs")
+
+    result = apply_validation(
+        df,
+        {
+            "rules": [
+                {"check": "expect_email", "columns": ["email"]},
+                {"check": "expect_length", "column": "code", "min": 2, "max": 4},
+                {
+                    "check": "expect_foreign_key",
+                    "col": "ref",
+                    "ref_table": "dim_refs",
+                    "ref_col": "ref",
+                    "on_fail": "quarantine",
+                },
+            ]
+        },
+    )
+
+    email_rule = result.metrics["by_rule"]["expect_email:email"]
+    assert email_rule["invalid_rows"] == 1
+    length_rule = result.metrics["by_rule"]["expect_length:code"]
+    assert length_rule["invalid_rows"] == 1
+    fk_rule = result.metrics["by_rule"]["expect_foreign_key:ref"]
+    assert fk_rule["invalid_rows"] == 1
+    assert result.quarantine_df.count() >= 1


### PR DESCRIPTION
## Summary
- Documentar la arquitectura multi-fuente, los conectores ampliados y las guías de incremental/validaciones con ejemplos YAML actualizados.
- Añadir configuraciones de ejemplo para Azure, AWS, GCP y streaming Kafka→Cosmos que ejercitan transformaciones declarativas, validaciones y modos incrementales.
- Actualizar los esquemas JSON y la lógica de validación para reflejar los nuevos campos y registrar correctamente los motivos de rechazo.

## Testing
- `prodi validate --config examples/azure/orders_pipeline.yaml`
- `prodi validate --config examples/aws/products_pipeline.yaml`
- `prodi validate --config examples/gcp/customers_pipeline.yaml`
- `prodi validate --config examples/streaming/kafka_cosmos.yaml`
- `prodi run --layer silver --config examples/azure/orders_pipeline.yaml --dry-run --platform azure --env dev --fail-fast`
- `pytest --maxfail=1 --disable-warnings --cov=datacore --cov=examples --cov=tests --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_6903ee6ab148832089f5eab7a3b0b402