### PR TITLE
feat: add optional Microsoft Fabric provider support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,17 @@ jobs:
       - name: deps
         run: |
           python -m pip install --upgrade pip
+          python -m pip install build
           if [ "${{ matrix.profile }}" = "fabric" ]; then
             pip install -e .[dev,fabric] pytest jsonschema responses
           else
             pip install -e .[dev] pytest jsonschema responses
           fi
+
+      - name: build wheel
+        run: |
+          python -m build
+          pip install --force-reinstall dist/*.whl
 
       - name: spin emulators
         run: docker compose -f ci/docker-compose.emu.yml up -d
@@ -41,6 +47,15 @@ jobs:
 
       - name: plan contract
         run: python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
+
+      - name: mostrar plan
+        run: python -m json.tool plan.json
+
+      - name: subir plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: plan-${{ matrix.profile }}
+          path: plan.json
 
       - name: unit tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: ci
 
 on: [push, pull_request]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -16,46 +20,50 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Purge pip caches (runner)
+        run: |
+          pip cache purge || true
+          rm -rf ~/.cache/pip || true
+
       - name: deps
+        env:
+          PIP_NO_CACHE_DIR: "1"
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build
           if [ "${{ matrix.profile }}" = "fabric" ]; then
-            pip install -e .[dev,fabric] pytest jsonschema responses
+            pip install --no-cache-dir -e .[dev,fabric] pytest jsonschema responses build
           else
-            pip install -e .[dev] pytest jsonschema responses
+            pip install --no-cache-dir -e .[dev] pytest jsonschema responses build
           fi
 
-      - name: build wheel
-        run: |
-          python -m build
-          pip install --force-reinstall dist/*.whl
-
       - name: spin emulators
+        if: ${{ hashFiles('ci/docker-compose.emu.yml') != '' }}
         run: docker compose -f ci/docker-compose.emu.yml up -d
 
       - name: schema check (layer)
         run: python tools/validate_examples_against_layer_schema.py
 
       - name: sanity - CLI import
-        run: >-
-          python -c "import importlib.util as u, sys; ok=bool(u.find_spec('datacore.cli'));
-          print('datacore.cli importable:', ok); sys.exit(0 if ok else 1)"
+        run: python -c "import importlib.util as u, sys; ok=bool(u.find_spec('datacore.cli')); print('datacore.cli importable:', ok); sys.exit(0 if ok else 1)"
 
       - name: plan (module)
         run: python -m datacore.cli plan --config examples/federation/customers_enriched.yaml > plan.json
 
-      - name: plan contract
-        run: python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
+      - name: print plan (debug)
+        run: |
+          python - << 'PY'
+from pathlib import Path; import json
+p=Path("plan.json"); print(json.dumps(json.loads(p.read_text()), indent=2, ensure_ascii=False))
+PY
 
-      - name: mostrar plan
-        run: python -m json.tool plan.json
-
-      - name: subir plan
+      - name: upload plan artifact
         uses: actions/upload-artifact@v4
         with:
-          name: plan-${{ matrix.profile }}
+          name: plan-${{ matrix.profile }}.json
           path: plan.json
+
+      - name: plan contract
+        run: python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
 
       - name: unit tests
         run: |
@@ -64,3 +72,9 @@ jobs:
           else
             pytest -q -k "not fabric"
           fi
+
+      - name: build wheel
+        run: python -m build
+
+      - name: install wheel (smoke)
+        run: pip install --no-cache-dir dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile: [base, fabric]
     steps:
       - uses: actions/checkout@v4
 
@@ -16,7 +19,11 @@ jobs:
       - name: deps
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev] pytest jsonschema
+          if [ "${{ matrix.profile }}" = "fabric" ]; then
+            pip install -e .[dev,fabric] pytest jsonschema responses
+          else
+            pip install -e .[dev] pytest jsonschema responses
+          fi
 
       - name: spin emulators
         run: docker compose -f ci/docker-compose.emu.yml up -d
@@ -35,5 +42,10 @@ jobs:
       - name: plan contract
         run: python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
 
-      - name: tests
-        run: pytest --maxfail=1 --disable-warnings -q
+      - name: unit tests
+        run: |
+          if [ "${{ matrix.profile }}" = "fabric" ]; then
+            pytest -q
+          else
+            pytest -q -k "not fabric"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/datacore/cli/main.py
+++ b/datacore/cli/main.py
@@ -12,6 +12,7 @@ import yaml
 
 from datacore.config.validation import validate_config
 from datacore.core.engine import run_layer_plan
+from datacore.providers import Provider, load_provider
 from datacore.utils import observability
 from datacore.utils.logging import configure_logging
 
@@ -36,6 +37,7 @@ def cmd_run(args: argparse.Namespace) -> None:
     data = _load_config(args.config)
     validate_config(data)
     configure_logging(level=args.log_level)
+    provider = load_provider(data)
     results = run_layer_plan(
         layer=args.layer,
         config=data,
@@ -44,12 +46,16 @@ def cmd_run(args: argparse.Namespace) -> None:
         dry_run=args.dry_run,
         fail_fast=args.fail_fast,
     )
+    fabric_items = _collect_fabric_items(provider, data, force=getattr(args, "provision", False))
+    _attach_fabric_items(results, fabric_items)
     if args.dry_run:
         payload = {
             "run_id": results["run_id"],
             "datasets": results["datasets"],
             "plan": results["datasets"],
         }
+        if fabric_items:
+            _attach_fabric_items(payload, fabric_items)
         print(json.dumps(payload, indent=2, default=str))
     else:
         LOGGER.info("Resultados de ejecución: %s", results)
@@ -58,6 +64,7 @@ def cmd_run(args: argparse.Namespace) -> None:
 def cmd_plan(args: argparse.Namespace) -> None:
     data = _load_config(args.config)
     validate_config(data)
+    provider = load_provider(data)
     layers = sorted({d.get("layer") for d in data.get("datasets", []) if d.get("layer")})
     aggregated_datasets: list[dict[str, Any]] = []
     aggregated_plan_nodes: list[dict[str, Any]] = []
@@ -85,6 +92,8 @@ def cmd_plan(args: argparse.Namespace) -> None:
     payload: dict[str, Any] = {"run_id": run_id, "datasets": aggregated_datasets}
     if aggregated_plan_nodes:
         payload["plan"] = aggregated_plan_nodes
+    fabric_items = _collect_fabric_items(provider, data, force=getattr(args, "provision", False))
+    _attach_fabric_items(payload, fabric_items)
     print(json.dumps(payload, indent=2, default=str))
 
 
@@ -115,6 +124,11 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--log-level", default="INFO", help="Nivel de logging")
     run_parser.add_argument("--dry-run", action="store_true", help="Solo genera el plan")
     run_parser.add_argument("--fail-fast", action="store_true", help="Detener al primer error")
+    run_parser.add_argument(
+        "--provision",
+        action="store_true",
+        help="Provisiona recursos opcionales del provider (Fabric)",
+    )
     run_parser.set_defaults(func=cmd_run)
 
     plan_parser = subparsers.add_parser("plan", help="Muestra el plan de datasets")
@@ -122,6 +136,11 @@ def build_parser() -> argparse.ArgumentParser:
     plan_parser.add_argument("--platform", required=False, help="Plataforma cloud (azure/aws/gcp)")
     plan_parser.add_argument("--env", required=False, help="Entorno (dev/test/prod)")
     plan_parser.add_argument("--fail-fast", action="store_true", help="Detener al primer error")
+    plan_parser.add_argument(
+        "--provision",
+        action="store_true",
+        help="Provisiona recursos opcionales del provider (Fabric)",
+    )
     plan_parser.set_defaults(func=cmd_plan)
 
     return parser
@@ -135,3 +154,114 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
+def _infer_default_fabric_items(dataset_cfg: dict[str, Any]) -> list[str]:
+    inferred: list[str] = []
+    source = dataset_cfg.get("source")
+    if isinstance(source, dict) and source.get("type") == "shortcut":
+        inferred.append("shortcut")
+    sink = dataset_cfg.get("sink", {})
+    if isinstance(sink, dict) and sink.get("backend") == "delta":
+        inferred.append("lakehouse")
+    fabric_cfg = dataset_cfg.get("orchestration", {}).get("fabric", {})
+    if fabric_cfg.get("spark_job"):
+        inferred.append("spark_job")
+    if fabric_cfg.get("pipeline"):
+        inferred.append("pipeline")
+    return inferred
+
+
+def _ensure_fabric_items(
+    provider: Provider,
+    dataset_cfg: dict[str, Any],
+    *,
+    force: bool,
+) -> list[dict[str, Any]]:
+    fabric_cfg = dataset_cfg.get("orchestration", {}).get("fabric", {})
+    create_items: list[str] = list(fabric_cfg.get("create_items", []))
+    if not create_items and force:
+        create_items = _infer_default_fabric_items(dataset_cfg)
+    if not create_items:
+        return []
+
+    # Evitamos duplicados manteniendo orden
+    ordered_unique: list[str] = []
+    for item in create_items:
+        if item not in ordered_unique:
+            ordered_unique.append(item)
+
+    created: list[dict[str, Any]] = []
+    source_cfg = dataset_cfg.get("source")
+    sink_cfg = dataset_cfg.get("sink") or {}
+
+    for item in ordered_unique:
+        if item == "shortcut" and provider.supports("shortcuts"):
+            if isinstance(source_cfg, dict) and source_cfg.get("type") == "shortcut":
+                provider.ensure_shortcut(source_cfg)
+                from datacore.providers.fabric.shortcuts import fingerprint
+
+                created.append(
+                    {
+                        "type": "shortcut",
+                        "name": source_cfg.get("name"),
+                        "fingerprint": fingerprint(source_cfg),
+                    }
+                )
+        elif item == "spark_job" and provider.supports("orchestration"):
+            job_cfg: dict[str, Any] = {
+                "name": f"{dataset_cfg.get('name', 'dataset')}-spark-job",
+                **fabric_cfg.get("spark_job", {}),
+            }
+            metadata = provider.ensure_spark_job(job_cfg)
+            metadata = {k: v for k, v in (metadata or {}).items() if v is not None}
+            metadata.setdefault("name", job_cfg.get("name"))
+            metadata["type"] = "spark_job"
+            created.append(metadata)
+        elif item == "pipeline" and provider.supports("orchestration"):
+            pipeline_cfg: dict[str, Any] = {
+                "name": f"{dataset_cfg.get('name', 'dataset')}-pipeline",
+                **fabric_cfg.get("pipeline", {}),
+            }
+            metadata = provider.ensure_pipeline(pipeline_cfg)
+            metadata = {k: v for k, v in (metadata or {}).items() if v is not None}
+            metadata.setdefault("name", pipeline_cfg.get("name"))
+            metadata["type"] = "pipeline"
+            created.append(metadata)
+        elif item == "lakehouse" and provider.supports("lakehouse"):
+            if isinstance(sink_cfg, dict):
+                created.append(
+                    {
+                        "type": "lakehouse",
+                        "name": sink_cfg.get("uri"),
+                        "backend": sink_cfg.get("backend"),
+                    }
+                )
+    return created
+
+
+def _collect_fabric_items(
+    provider: Provider | None,
+    config: dict[str, Any],
+    *,
+    force: bool,
+) -> list[dict[str, Any]]:
+    if not provider:
+        return []
+    dataset_map = {
+        dataset.get("name"): dataset
+        for dataset in config.get("datasets", [])
+        if isinstance(dataset, dict) and dataset.get("name")
+    }
+    collected: list[dict[str, Any]] = []
+    for dataset_cfg in dataset_map.values():
+        items = _ensure_fabric_items(provider, dataset_cfg, force=force)
+        if items:
+            collected.extend(items)
+    return collected
+
+
+def _attach_fabric_items(payload: dict[str, Any], items: list[dict[str, Any]]) -> None:
+    if not items:
+        return
+    fabric_section = payload.setdefault("fabric", {})
+    fabric_items: list[dict[str, Any]] = fabric_section.setdefault("items", [])
+    fabric_items.extend(items)

--- a/datacore/cli/main.py
+++ b/datacore/cli/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -48,9 +49,20 @@ def cmd_run(args: argparse.Namespace) -> None:
     )
     fabric_items = _collect_fabric_items(provider, data, force=getattr(args, "provision", False))
     _attach_fabric_items(results, fabric_items)
+    summary = observability.summarize_run(results.get("datasets", []))
+    LOGGER.info(
+        "Resumen de ejecución",
+        extra={
+            **summary,
+            "run_id": results.get("run_id"),
+            "created_at": results.get("created_at"),
+            "provider": getattr(provider, "name", "none"),
+        },
+    )
     if args.dry_run:
         payload = {
             "run_id": results["run_id"],
+            "created_at": results.get("created_at"),
             "datasets": results["datasets"],
             "plan": results["datasets"],
         }
@@ -58,7 +70,14 @@ def cmd_run(args: argparse.Namespace) -> None:
             _attach_fabric_items(payload, fabric_items)
         print(json.dumps(payload, indent=2, default=str))
     else:
-        LOGGER.info("Resultados de ejecución: %s", results)
+        LOGGER.info(
+            "Resultados de ejecución",
+            extra={
+                "run_id": results.get("run_id"),
+                "created_at": results.get("created_at"),
+                "datasets": len(results.get("datasets", [])),
+            },
+        )
 
 
 def cmd_plan(args: argparse.Namespace) -> None:
@@ -69,6 +88,7 @@ def cmd_plan(args: argparse.Namespace) -> None:
     aggregated_datasets: list[dict[str, Any]] = []
     aggregated_plan_nodes: list[dict[str, Any]] = []
     run_id: str | None = None
+    created_at: str | None = None
     for layer in layers:
         plan_result = run_layer_plan(
             layer=layer,
@@ -79,6 +99,7 @@ def cmd_plan(args: argparse.Namespace) -> None:
             fail_fast=args.fail_fast,
         )
         run_id = run_id or plan_result.get("run_id")
+        created_at = created_at or plan_result.get("created_at")
         datasets = plan_result.get("datasets", [])
         aggregated_datasets.extend(datasets)
         for dataset_plan in datasets:
@@ -89,7 +110,11 @@ def cmd_plan(args: argparse.Namespace) -> None:
                 )
     if run_id is None:
         run_id = observability.new_run_id()
-    payload: dict[str, Any] = {"run_id": run_id, "datasets": aggregated_datasets}
+    payload: dict[str, Any] = {
+        "run_id": run_id,
+        "created_at": created_at or datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "datasets": aggregated_datasets,
+    }
     if aggregated_plan_nodes:
         payload["plan"] = aggregated_plan_nodes
     fabric_items = _collect_fabric_items(provider, data, force=getattr(args, "provision", False))

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -18,6 +18,24 @@
         }
       }
     },
+    "providers": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "fabric": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "workspace_id": {"type": "string"},
+            "environment_id": {"type": "string"},
+            "lakehouse_id": {"type": "string"},
+            "warehouse_id": {"type": "string"},
+            "eventhouse_id": {"type": "string"},
+            "tenant_id": {"type": "string"}
+          }
+        }
+      }
+    },
     "datasets": {
       "type": "array",
       "items": {"$ref": "#/definitions/dataset"}

--- a/datacore/config/schemas/layer.schema.json
+++ b/datacore/config/schemas/layer.schema.json
@@ -26,12 +26,30 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "workspace_id": {"type": "string"},
-            "environment_id": {"type": "string"},
-            "lakehouse_id": {"type": "string"},
-            "warehouse_id": {"type": "string"},
-            "eventhouse_id": {"type": "string"},
-            "tenant_id": {"type": "string"}
+            "workspace_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "environment_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "lakehouse_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "warehouse_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "eventhouse_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "tenant_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            }
           }
         }
       }

--- a/datacore/config/schemas/plan.schema.json
+++ b/datacore/config/schemas/plan.schema.json
@@ -22,6 +22,34 @@
           }
         }
       }
+    },
+    "fabric": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "lakehouse",
+                  "warehouse",
+                  "pipeline",
+                  "spark_job",
+                  "shortcut"
+                ]
+              },
+              "id": {"type": "string"},
+              "url": {"type": "string"},
+              "name": {"type": "string"}
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/datacore/config/schemas/plan.schema.json
+++ b/datacore/config/schemas/plan.schema.json
@@ -2,9 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": ["run_id", "datasets"],
+  "required": ["run_id", "created_at", "datasets"],
   "properties": {
     "run_id": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"},
     "datasets": {
       "type": "array",
       "items": {"$ref": "#/definitions/dataset_plan"}

--- a/datacore/config/schemas/project.schema.json
+++ b/datacore/config/schemas/project.schema.json
@@ -18,6 +18,42 @@
         }
       }
     },
+    "providers": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "fabric": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "workspace_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "environment_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "lakehouse_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "warehouse_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "eventhouse_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            },
+            "tenant_id": {
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9-]+|\\$\\{[A-Z0-9_]+\\})$"
+            }
+          }
+        }
+      }
+    },
     "datasets": {
       "type": "array",
       "items": {"$ref": "#/definitions/dataset"}
@@ -162,13 +198,11 @@
         {
           "type": "object",
           "required": ["type", "name"],
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "id": {"type": "string"},
             "type": {"const": "shortcut"},
             "name": {"type": "string"},
-            "provider": {"type": "string"},
-            "target_uri": {"type": "string"},
             "read_options": {"$ref": "#/definitions/string_map"}
           }
         },

--- a/datacore/core/engine.py
+++ b/datacore/core/engine.py
@@ -530,7 +530,14 @@ def _process_dataset(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     dataset_cfg = _resolve_references(dataset, platform)
-    LOGGER.info("Procesando dataset %s (run_id=%s)", dataset_cfg["name"], run_id)
+    LOGGER.info(
+        "Procesando dataset",
+        extra={
+            "dataset": dataset_cfg["name"],
+            "run_id": run_id,
+            "layer": layer,
+        },
+    )
     if dry_run:
         plan = _build_plan(dataset_cfg)
         plan["status"] = "planned"
@@ -613,5 +620,9 @@ def run_layer_plan(
                     "duration_seconds": None,
                 }
             )
-    LOGGER.info("Ejecución de capa %s completada", layer)
-    return {"run_id": run_id, "datasets": results}
+    created_at = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    LOGGER.info(
+        "Ejecución de capa completada",
+        extra={"layer": layer, "run_id": run_id, "datasets": len(results)},
+    )
+    return {"run_id": run_id, "created_at": created_at, "datasets": results}

--- a/datacore/core/providers/__init__.py
+++ b/datacore/core/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Abstracciones de providers opcionales."""
+
+from .base import Provider
+
+__all__ = ["Provider"]

--- a/datacore/core/providers/base.py
+++ b/datacore/core/providers/base.py
@@ -1,0 +1,38 @@
+"""Interfaces base para providers opcionales."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class Provider:
+    """Interfaz base para providers externos."""
+
+    name: str = "base"
+
+    def supports(self, feature: str) -> bool:
+        """Indica si el provider implementa una capacidad concreta."""
+        return False
+
+    # ---- Shortcuts / Virtualización ----
+    def ensure_shortcut(self, cfg: Dict[str, Any]) -> None:
+        """Crea o actualiza un shortcut de forma idempotente."""
+        raise NotImplementedError
+
+    # ---- Lakehouse / Delta ----
+    def write_table(self, df, table_uri: str, options: Dict[str, Any]) -> None:
+        """Escribe un DataFrame en una tabla nativa del provider."""
+        raise NotImplementedError
+
+    def optimize(self, table_uri: str, options: Dict[str, Any]) -> None:
+        """Ejecuta tareas de optimización sobre una tabla."""
+        raise NotImplementedError
+
+    # ---- Orchestration ----
+    def ensure_spark_job(self, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        """Crea o actualiza una Spark Job Definition y devuelve metadatos."""
+        raise NotImplementedError
+
+    def ensure_pipeline(self, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        """Crea o actualiza una Data Pipeline y devuelve metadatos."""
+        raise NotImplementedError

--- a/datacore/providers/__init__.py
+++ b/datacore/providers/__init__.py
@@ -1,0 +1,25 @@
+"""Gestión de providers opcionales."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from datacore.core.providers import Provider
+
+
+def load_provider(global_cfg: Optional[Dict[str, Any]]) -> Optional[Provider]:
+    """Carga condicional de providers en función de la configuración global."""
+    providers_cfg = (global_cfg or {}).get("providers", {})
+    if "fabric" in providers_cfg:
+        try:
+            from datacore.providers.fabric.provider import FabricProvider
+        except ImportError as ex:  # pragma: no cover - mensaje claro para el usuario
+            raise RuntimeError(
+                "Provider 'fabric' requerido pero no instalado. "
+                "Instala con: pip install .[fabric]"
+            ) from ex
+        return FabricProvider(providers_cfg["fabric"])
+    return None
+
+
+__all__ = ["Provider", "load_provider"]

--- a/datacore/providers/fabric/__init__.py
+++ b/datacore/providers/fabric/__init__.py
@@ -1,0 +1,5 @@
+"""Provider opcional para Microsoft Fabric."""
+
+from .provider import FabricProvider
+
+__all__ = ["FabricProvider"]

--- a/datacore/providers/fabric/env.py
+++ b/datacore/providers/fabric/env.py
@@ -1,0 +1,58 @@
+"""Gestión de entorno y autenticación para Microsoft Fabric."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class FabricEnv:
+    """Contexto de ejecución y utilidades HTTP para Microsoft Fabric."""
+
+    workspace_id: Optional[str] = None
+    environment_id: Optional[str] = None
+    lakehouse_id: Optional[str] = None
+    warehouse_id: Optional[str] = None
+    eventhouse_id: Optional[str] = None
+    tenant_id: Optional[str] = None
+    _raw_cfg: Dict[str, Any] | None = None
+
+    def __init__(self, cfg: Dict[str, Any]):
+        object.__setattr__(self, "_raw_cfg", dict(cfg or {}))
+        for key, value in (cfg or {}).items():
+            object.__setattr__(self, key, value)
+
+    # Métodos auxiliares -------------------------------------------------
+    def get_token(self) -> str:
+        """Obtiene un token AAD utilizando DefaultAzureCredential."""
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ImportError as exc:  # pragma: no cover - depende del extra opcional
+            raise RuntimeError(
+                "Falta azure-identity. Instala con: pip install .[fabric]"
+            ) from exc
+        credential = DefaultAzureCredential()
+        token = credential.get_token("https://analysis.windows.net/powerbi/api/.default")
+        return token.token
+
+    def http(self, method: str, url: str, **kwargs):
+        """Ejecuta una petición HTTP autenticada contra Fabric."""
+        import requests
+
+        headers = dict(kwargs.pop("headers", {}))
+        headers.setdefault("Authorization", f"Bearer {self.get_token()}")
+        headers.setdefault("Content-Type", "application/json")
+        return requests.request(method, url, headers=headers, **kwargs)
+
+    # Utilidades ---------------------------------------------------------
+    def describe(self) -> Dict[str, Any]:
+        """Devuelve información útil para logs y depuración."""
+        return {k: getattr(self, k) for k in [
+            "workspace_id",
+            "environment_id",
+            "lakehouse_id",
+            "warehouse_id",
+            "eventhouse_id",
+            "tenant_id",
+        ] if getattr(self, k) is not None}

--- a/datacore/providers/fabric/env.py
+++ b/datacore/providers/fabric/env.py
@@ -2,8 +2,23 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+PLACEHOLDER_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)\}")
+ALLOWED_PLACEHOLDERS = {
+    "FABRIC_WORKSPACE_ID",
+    "FABRIC_ENVIRONMENT_ID",
+    "FABRIC_LAKEHOUSE_ID",
+    "FABRIC_WAREHOUSE_ID",
+    "FABRIC_EVENTHOUSE_ID",
+    "FABRIC_TENANT_ID",
+}
 
 
 @dataclass
@@ -21,6 +36,8 @@ class FabricEnv:
     def __init__(self, cfg: Dict[str, Any]):
         object.__setattr__(self, "_raw_cfg", dict(cfg or {}))
         for key, value in (cfg or {}).items():
+            if isinstance(value, str):
+                value = self._resolve_placeholders(key, value)
             object.__setattr__(self, key, value)
 
     # Métodos auxiliares -------------------------------------------------
@@ -38,12 +55,33 @@ class FabricEnv:
 
     def http(self, method: str, url: str, **kwargs):
         """Ejecuta una petición HTTP autenticada contra Fabric."""
+        if os.getenv("FABRIC_HTTP_OFFLINE") == "1":  # pragma: no cover - solo para entornos locales
+            payload = kwargs.get("json") or {"value": []}
+
+            class _OfflineResponse:
+                status_code = 200
+
+                def __init__(self, data):
+                    import json as _json
+
+                    self._data = data
+                    self.content = _json.dumps(data).encode("utf-8")
+
+                def json(self):
+                    return self._data
+
+                def raise_for_status(self):
+                    return None
+
+            return _OfflineResponse(payload)
+
         import requests
 
         headers = dict(kwargs.pop("headers", {}))
         headers.setdefault("Authorization", f"Bearer {self.get_token()}")
         headers.setdefault("Content-Type", "application/json")
-        return requests.request(method, url, headers=headers, **kwargs)
+        response = requests.request(method, url, headers=headers, **kwargs)
+        return response
 
     # Utilidades ---------------------------------------------------------
     def describe(self) -> Dict[str, Any]:
@@ -56,3 +94,30 @@ class FabricEnv:
             "eventhouse_id",
             "tenant_id",
         ] if getattr(self, k) is not None}
+
+    # Internos -----------------------------------------------------------
+    def _resolve_placeholders(self, field: str, value: str) -> str:
+        matches = PLACEHOLDER_PATTERN.findall(value)
+        if not matches:
+            return value
+        resolved = value
+        for placeholder in matches:
+            if placeholder not in ALLOWED_PLACEHOLDERS:
+                raise RuntimeError(
+                    f"Placeholder {placeholder} no permitido en providers.fabric.{field}"
+                )
+            env_value = os.getenv(placeholder)
+            if env_value is None:
+                raise RuntimeError(
+                    f"Variable de entorno {placeholder} requerida para providers.fabric.{field}"
+                )
+            LOGGER.info(
+                "Resolviendo placeholder Fabric",
+                extra={
+                    "field": field,
+                    "placeholder": placeholder,
+                    "workspace_id": getattr(self, "workspace_id", None),
+                },
+            )
+            resolved = resolved.replace(f"${{{placeholder}}}", env_value)
+        return resolved

--- a/datacore/providers/fabric/kql.py
+++ b/datacore/providers/fabric/kql.py
@@ -1,9 +1,73 @@
-"""Placeholders para integraciones KQL/Eventhouse en Fabric."""
+"""Integraciones KQL/Eventhouse para Microsoft Fabric."""
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict
 
+from .env import FabricEnv
 
-def query(env, statement: str, options: Dict[str, Any] | None = None):  # pragma: no cover - stub
-    raise NotImplementedError("KQL/Eventhouse aún no implementado")
+LOGGER = logging.getLogger(__name__)
+
+
+def kql_read(env: FabricEnv, statement: str, options: Dict[str, Any] | None = None):
+    """Ejecuta una consulta KQL contra Eventhouse/Kusto."""
+
+    options = options or {}
+    cluster = options.get("cluster") or getattr(env, "eventhouse_id", None)
+    database = options.get("database")
+    if not cluster or not database:
+        raise ValueError("cluster y database son obligatorios para kql_read")
+    try:
+        from azure.kusto.data import KustoClient, KustoConnectionStringBuilder  # type: ignore
+    except ImportError as exc:  # pragma: no cover - dependencias opcionales
+        raise RuntimeError(
+            "Faltan dependencias azure-kusto-data. Instala con: pip install .[fabric]"
+        ) from exc
+    builder = KustoConnectionStringBuilder.with_aad_token_provider(
+        cluster,
+        lambda: env.get_token(),
+    )
+    client = KustoClient(builder)
+    LOGGER.info(
+        "Ejecutando kql_read",
+        extra={"cluster": cluster, "database": database, "workspace_id": env.workspace_id},
+    )
+    return client.execute(database, statement)
+
+
+def kql_ingest(env: FabricEnv, table: str, df, options: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Ingesta un DataFrame en Eventhouse mediante cola."""
+
+    options = options or {}
+    cluster = options.get("cluster") or getattr(env, "eventhouse_id", None)
+    database = options.get("database")
+    if not cluster or not database:
+        raise ValueError("cluster y database son obligatorios para kql_ingest")
+    try:
+        from azure.kusto.ingest import (  # type: ignore
+            IngestionProperties,
+            QueuedIngestClient,
+        )
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "Faltan dependencias azure-kusto-ingest. Instala con: pip install .[fabric]"
+        ) from exc
+    try:
+        from azure.kusto.data import KustoConnectionStringBuilder  # type: ignore
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "Faltan dependencias azure-kusto-data. Instala con: pip install .[fabric]"
+        ) from exc
+    builder = KustoConnectionStringBuilder.with_aad_token_provider(
+        cluster,
+        lambda: env.get_token(),
+    )
+    ingest_client = QueuedIngestClient(builder)
+    properties = IngestionProperties(database=database, table=table)
+    LOGGER.info(
+        "Ejecutando kql_ingest",
+        extra={"cluster": cluster, "database": database, "table": table},
+    )
+    ingest_client.ingest_from_dataframe(df, ingestion_properties=properties)
+    return {"table": table, "database": database}

--- a/datacore/providers/fabric/kql.py
+++ b/datacore/providers/fabric/kql.py
@@ -1,0 +1,9 @@
+"""Placeholders para integraciones KQL/Eventhouse en Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def query(env, statement: str, options: Dict[str, Any] | None = None):  # pragma: no cover - stub
+    raise NotImplementedError("KQL/Eventhouse aún no implementado")

--- a/datacore/providers/fabric/lakehouse.py
+++ b/datacore/providers/fabric/lakehouse.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+from time import perf_counter
 from typing import Any, Dict
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _spark():
@@ -12,22 +17,70 @@ def _spark():
 
 
 def write_delta(env, df, table_uri: str, options: Dict[str, Any]) -> None:
-    """Escribe un DataFrame en un destino Delta compatible con Fabric."""
+    """Escribe un DataFrame en Delta y ejecuta mantenimiento opcional."""
 
-    _spark()
+    spark = _spark()
+    start = perf_counter()
     writer = df.write.format("delta").mode(options.get("mode", "append"))
-    extra = {k: str(v) for k, v in (options or {}).items() if k != "mode"}
+    extra = {
+        k: str(v)
+        for k, v in (options or {}).items()
+        if k not in {"mode", "optimize", "vacuum_hours", "zorder"}
+    }
     if extra:
         writer = writer.options(**extra)
     writer.save(table_uri)
+    duration = perf_counter() - start
+    LOGGER.info(
+        "Escritura Delta completada",
+        extra={
+            "action": "write",
+            "table_uri": table_uri,
+            "duration_seconds": round(duration, 3),
+            "workspace_id": getattr(env, "workspace_id", None),
+        },
+    )
+
+    if options.get("optimize") or options.get("zorder"):
+        optimize_delta(
+            env,
+            table_uri,
+            {"optimize": bool(options.get("optimize")), "zorder": options.get("zorder")},
+        )
+    if options.get("vacuum_hours"):
+        optimize_delta(env, table_uri, {"vacuum_hours": options.get("vacuum_hours")})
+
+
+def _run_sql(statement: str) -> None:
+    spark = _spark()
+    spark.sql(statement)
 
 
 def optimize_delta(env, table_uri: str, options: Dict[str, Any]) -> None:
-    """Ejecuta operaciones de optimización Delta (noop si no aplica)."""
+    """Ejecuta operaciones OPTIMIZE/VACUUM/ZORDER según corresponda."""
 
-    spark = _spark()
-    if options.get("optimize"):
-        spark.sql(f"OPTIMIZE delta.`{table_uri}`")
-    if "vacuum_hours" in options:
-        hours = options["vacuum_hours"]
-        spark.sql(f"VACUUM delta.`{table_uri}` RETAIN {hours} HOURS")
+    statements: list[str] = []
+    zorder_cols = options.get("zorder")
+    if zorder_cols:
+        cols = ", ".join(zorder_cols)
+        statements.append(f"OPTIMIZE delta.`{table_uri}` ZORDER BY ({cols})")
+    elif options.get("optimize"):
+        statements.append(f"OPTIMIZE delta.`{table_uri}`")
+    if options.get("vacuum_hours"):
+        hours = int(options["vacuum_hours"])
+        statements.append(f"VACUUM delta.`{table_uri}` RETAIN {hours} HOURS")
+    if not statements:
+        return
+    for stmt in statements:
+        start = perf_counter()
+        _run_sql(stmt)
+        LOGGER.info(
+            "Delta maintenance ejecutado",
+            extra={
+                "action": "maintenance",
+                "statement": stmt.split(" ")[0].lower(),
+                "table_uri": table_uri,
+                "duration_seconds": round(perf_counter() - start, 3),
+                "workspace_id": getattr(env, "workspace_id", None),
+            },
+        )

--- a/datacore/providers/fabric/lakehouse.py
+++ b/datacore/providers/fabric/lakehouse.py
@@ -1,0 +1,33 @@
+"""Operaciones Delta Lakehouse para Microsoft Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def _spark():
+    from pyspark.sql import SparkSession
+
+    return SparkSession.builder.getOrCreate()
+
+
+def write_delta(env, df, table_uri: str, options: Dict[str, Any]) -> None:
+    """Escribe un DataFrame en un destino Delta compatible con Fabric."""
+
+    _spark()
+    writer = df.write.format("delta").mode(options.get("mode", "append"))
+    extra = {k: str(v) for k, v in (options or {}).items() if k != "mode"}
+    if extra:
+        writer = writer.options(**extra)
+    writer.save(table_uri)
+
+
+def optimize_delta(env, table_uri: str, options: Dict[str, Any]) -> None:
+    """Ejecuta operaciones de optimización Delta (noop si no aplica)."""
+
+    spark = _spark()
+    if options.get("optimize"):
+        spark.sql(f"OPTIMIZE delta.`{table_uri}`")
+    if "vacuum_hours" in options:
+        hours = options["vacuum_hours"]
+        spark.sql(f"VACUUM delta.`{table_uri}` RETAIN {hours} HOURS")

--- a/datacore/providers/fabric/mirroring.py
+++ b/datacore/providers/fabric/mirroring.py
@@ -1,0 +1,9 @@
+"""Placeholders para fuentes mirroring en Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def list_sources(env, options: Dict[str, Any] | None = None):  # pragma: no cover - stub
+    raise NotImplementedError("Mirroring aún no implementado")

--- a/datacore/providers/fabric/orchestrator.py
+++ b/datacore/providers/fabric/orchestrator.py
@@ -1,0 +1,66 @@
+"""Orquestación de Spark Job Definitions y Data Pipelines en Fabric."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .env import FabricEnv
+from .security import build_auth_headers
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _items_base(env: FabricEnv) -> str:
+    if not env.workspace_id:
+        raise ValueError("workspace_id es obligatorio para orquestación en Fabric")
+    return f"https://api.fabric.microsoft.com/v1/workspaces/{env.workspace_id}/items"
+
+
+def ensure_spark_job(env: FabricEnv, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Crea o actualiza una definición de Spark Job."""
+
+    name = cfg.get("name")
+    if not name:
+        raise ValueError("Spark Job requiere 'name'")
+    headers = build_auth_headers()
+    payload = {
+        "name": name,
+        "type": "sparkJobDefinition",
+        "properties": {
+            "entryPoint": cfg.get("entrypoint"),
+            "parameters": cfg.get("parameters", {}),
+        },
+    }
+    LOGGER.info(
+        "Asegurando Spark Job Definition %s en workspace %s",
+        name,
+        env.workspace_id,
+    )
+    response = env.http("POST", _items_base(env), json=payload, headers=headers)
+    response.raise_for_status()
+    body = response.json() if response.content else {}
+    return {"id": body.get("id"), "url": body.get("webUrl"), "name": body.get("name", name)}
+
+
+def ensure_pipeline(env: FabricEnv, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Crea o actualiza una Data Pipeline de Fabric."""
+
+    name = cfg.get("name")
+    if not name:
+        raise ValueError("Pipeline requiere 'name'")
+    headers = build_auth_headers()
+    payload = {
+        "name": name,
+        "type": "dataPipeline",
+        "properties": cfg.get("properties", {}),
+    }
+    LOGGER.info(
+        "Asegurando Data Pipeline %s en workspace %s",
+        name,
+        env.workspace_id,
+    )
+    response = env.http("POST", _items_base(env), json=payload, headers=headers)
+    response.raise_for_status()
+    body = response.json() if response.content else {}
+    return {"id": body.get("id"), "url": body.get("webUrl"), "name": body.get("name", name)}

--- a/datacore/providers/fabric/orchestrator.py
+++ b/datacore/providers/fabric/orchestrator.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Dict
 
 from .env import FabricEnv
-from .security import build_auth_headers
+from .shortcuts import fingerprint
 
 LOGGER = logging.getLogger(__name__)
+
+
+RETRYABLE = {429, 500, 502, 503, 504}
 
 
 def _items_base(env: FabricEnv) -> str:
@@ -17,28 +21,95 @@ def _items_base(env: FabricEnv) -> str:
     return f"https://api.fabric.microsoft.com/v1/workspaces/{env.workspace_id}/items"
 
 
+def _request(env: FabricEnv, method: str, url: str, *, retries: int = 3, **kwargs):
+    attempt = 0
+    wait = 1.0
+    while True:
+        response = env.http(method, url, **kwargs)
+        if response.status_code in RETRYABLE and attempt < retries:
+            LOGGER.warning(
+                "Reintento orquestación Fabric",
+                extra={
+                    "action": "retry",
+                    "attempt": attempt + 1,
+                    "status": response.status_code,
+                    "workspace_id": env.workspace_id,
+                },
+            )
+            time.sleep(wait)
+            wait *= 2
+            attempt += 1
+            continue
+        response.raise_for_status()
+        return response
+
+
+def _find_item(env: FabricEnv, name: str, item_type: str) -> Dict[str, Any] | None:
+    response = _request(
+        env,
+        "GET",
+        _items_base(env),
+        params={"$filter": f"name eq '{name}' and type eq '{item_type}'"},
+    )
+    body = response.json() if response.content else {}
+    items = body.get("value", []) if isinstance(body, dict) else []
+    return items[0] if items else None
+
+
 def ensure_spark_job(env: FabricEnv, cfg: Dict[str, Any]) -> Dict[str, Any]:
     """Crea o actualiza una definición de Spark Job."""
 
     name = cfg.get("name")
     if not name:
         raise ValueError("Spark Job requiere 'name'")
-    headers = build_auth_headers()
     payload = {
         "name": name,
         "type": "sparkJobDefinition",
         "properties": {
             "entryPoint": cfg.get("entrypoint"),
             "parameters": cfg.get("parameters", {}),
+            "fingerprint": fingerprint(cfg),
         },
     }
     LOGGER.info(
-        "Asegurando Spark Job Definition %s en workspace %s",
-        name,
-        env.workspace_id,
+        "Asegurando Spark Job Definition",
+        extra={
+            "action": "ensure_spark_job",
+            "name": name,
+            "workspace_id": env.workspace_id,
+        },
     )
-    response = env.http("POST", _items_base(env), json=payload, headers=headers)
-    response.raise_for_status()
+    existing = _find_item(env, name, "sparkJobDefinition")
+    desired_fp = payload["properties"]["fingerprint"]
+    if existing:
+        current_fp = (existing.get("properties") or {}).get("fingerprint")
+        if current_fp == desired_fp:
+            LOGGER.debug(
+                "Spark Job ya actualizado",
+                extra={
+                    "action": "noop",
+                    "name": name,
+                    "workspace_id": env.workspace_id,
+                },
+            )
+            return {
+                "id": existing.get("id"),
+                "url": existing.get("webUrl"),
+                "name": existing.get("name", name),
+            }
+        response = _request(
+            env,
+            "PATCH",
+            f"{_items_base(env)}/{existing.get('id')}",
+            json=payload,
+        )
+        body = response.json() if response.content else {}
+        return {
+            "id": body.get("id", existing.get("id")),
+            "url": body.get("webUrl", existing.get("webUrl")),
+            "name": body.get("name", name),
+        }
+    response = _request(env, "POST", _items_base(env), json=payload)
     body = response.json() if response.content else {}
     return {"id": body.get("id"), "url": body.get("webUrl"), "name": body.get("name", name)}
 
@@ -49,18 +120,53 @@ def ensure_pipeline(env: FabricEnv, cfg: Dict[str, Any]) -> Dict[str, Any]:
     name = cfg.get("name")
     if not name:
         raise ValueError("Pipeline requiere 'name'")
-    headers = build_auth_headers()
+    properties = cfg.get("properties", {})
     payload = {
         "name": name,
         "type": "dataPipeline",
-        "properties": cfg.get("properties", {}),
+        "properties": {
+            **properties,
+            "fingerprint": fingerprint(cfg),
+        },
     }
     LOGGER.info(
-        "Asegurando Data Pipeline %s en workspace %s",
-        name,
-        env.workspace_id,
+        "Asegurando Data Pipeline",
+        extra={
+            "action": "ensure_pipeline",
+            "name": name,
+            "workspace_id": env.workspace_id,
+        },
     )
-    response = env.http("POST", _items_base(env), json=payload, headers=headers)
-    response.raise_for_status()
+    existing = _find_item(env, name, "dataPipeline")
+    desired_fp = payload["properties"]["fingerprint"]
+    if existing:
+        current_fp = (existing.get("properties") or {}).get("fingerprint")
+        if current_fp == desired_fp:
+            LOGGER.debug(
+                "Pipeline ya actualizada",
+                extra={
+                    "action": "noop",
+                    "name": name,
+                    "workspace_id": env.workspace_id,
+                },
+            )
+            return {
+                "id": existing.get("id"),
+                "url": existing.get("webUrl"),
+                "name": existing.get("name", name),
+            }
+        response = _request(
+            env,
+            "PATCH",
+            f"{_items_base(env)}/{existing.get('id')}",
+            json=payload,
+        )
+        body = response.json() if response.content else {}
+        return {
+            "id": body.get("id", existing.get("id")),
+            "url": body.get("webUrl", existing.get("webUrl")),
+            "name": body.get("name", name),
+        }
+    response = _request(env, "POST", _items_base(env), json=payload)
     body = response.json() if response.content else {}
     return {"id": body.get("id"), "url": body.get("webUrl"), "name": body.get("name", name)}

--- a/datacore/providers/fabric/provider.py
+++ b/datacore/providers/fabric/provider.py
@@ -1,0 +1,57 @@
+"""Implementación del provider opcional para Microsoft Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from datacore.core.providers.base import Provider
+
+
+class FabricProvider(Provider):
+    """Fachada de capacidades Microsoft Fabric."""
+
+    name = "fabric"
+
+    def __init__(self, cfg: Dict[str, Any]):
+        self.cfg = cfg or {}
+        from .env import FabricEnv
+
+        self.env = FabricEnv(self.cfg)
+
+    def supports(self, feature: str) -> bool:
+        return feature in {
+            "shortcuts",
+            "lakehouse",
+            "warehouse",
+            "kql",
+            "mirroring",
+            "orchestration",
+        }
+
+    # ---- Shortcuts ----
+    def ensure_shortcut(self, cfg: Dict[str, Any]) -> None:
+        from .shortcuts import ensure_shortcut
+
+        ensure_shortcut(self.env, cfg)
+
+    # ---- Lakehouse ----
+    def write_table(self, df, table_uri: str, options: Dict[str, Any]) -> None:
+        from .lakehouse import write_delta
+
+        write_delta(self.env, df, table_uri, options)
+
+    def optimize(self, table_uri: str, options: Dict[str, Any]) -> None:
+        from .lakehouse import optimize_delta
+
+        optimize_delta(self.env, table_uri, options)
+
+    # ---- Orchestration ----
+    def ensure_spark_job(self, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        from .orchestrator import ensure_spark_job
+
+        return ensure_spark_job(self.env, cfg)
+
+    def ensure_pipeline(self, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        from .orchestrator import ensure_pipeline
+
+        return ensure_pipeline(self.env, cfg)

--- a/datacore/providers/fabric/provider.py
+++ b/datacore/providers/fabric/provider.py
@@ -17,16 +17,14 @@ class FabricProvider(Provider):
         from .env import FabricEnv
 
         self.env = FabricEnv(self.cfg)
+        self._capabilities = {"shortcuts", "lakehouse", "orchestration"}
+        if getattr(self.env, "warehouse_id", None):
+            self._capabilities.add("warehouse")
+        if getattr(self.env, "eventhouse_id", None):
+            self._capabilities.add("kql")
 
     def supports(self, feature: str) -> bool:
-        return feature in {
-            "shortcuts",
-            "lakehouse",
-            "warehouse",
-            "kql",
-            "mirroring",
-            "orchestration",
-        }
+        return feature in self._capabilities
 
     # ---- Shortcuts ----
     def ensure_shortcut(self, cfg: Dict[str, Any]) -> None:

--- a/datacore/providers/fabric/security.py
+++ b/datacore/providers/fabric/security.py
@@ -1,0 +1,13 @@
+"""Utilidades de seguridad y manejo de secretos para Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def build_auth_headers(extra: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Compone cabeceras adicionales para peticiones Fabric."""
+    headers = {"User-Agent": "datacore-fabric/1.0"}
+    if extra:
+        headers.update(extra)
+    return headers

--- a/datacore/providers/fabric/security.py
+++ b/datacore/providers/fabric/security.py
@@ -4,10 +4,25 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from datacore.utils.secrets import resolve_secret
+
+
+def resolve_sensitive_values(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Resuelve URIs secret://* apoyándose en la capa de secretos."""
+
+    resolved: Dict[str, Any] = {}
+    for key, value in (payload or {}).items():
+        if isinstance(value, str) and value.startswith("secret://"):
+            resolved[key] = resolve_secret(value)
+        else:
+            resolved[key] = value
+    return resolved
+
 
 def build_auth_headers(extra: Dict[str, Any] | None = None) -> Dict[str, Any]:
     """Compone cabeceras adicionales para peticiones Fabric."""
+
     headers = {"User-Agent": "datacore-fabric/1.0"}
     if extra:
-        headers.update(extra)
+        headers.update(resolve_sensitive_values(extra))
     return headers

--- a/datacore/providers/fabric/shortcuts.py
+++ b/datacore/providers/fabric/shortcuts.py
@@ -1,0 +1,105 @@
+"""Gestión de OneLake Shortcuts mediante la API REST de Fabric."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Dict, Iterable
+
+from .env import FabricEnv
+from .security import build_auth_headers
+
+LOGGER = logging.getLogger(__name__)
+
+
+def fingerprint(cfg: Dict[str, Any]) -> str:
+    payload = json.dumps(cfg, sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _base_url(env: FabricEnv) -> str:
+    if not env.workspace_id:
+        raise ValueError("workspace_id es obligatorio para gestionar shortcuts en Fabric")
+    return f"https://api.fabric.microsoft.com/v1/workspaces/{env.workspace_id}/shortcuts"
+
+
+def _list_shortcuts(env: FabricEnv) -> Iterable[Dict[str, Any]]:
+    response = env.http("GET", _base_url(env))
+    response.raise_for_status()
+    body = response.json() if response.content else {}
+    items = body.get("value", []) if isinstance(body, dict) else []
+    return items
+
+
+def _build_payload(sc_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": sc_cfg["name"],
+        "type": sc_cfg.get("type"),
+        "properties": {
+            "target": sc_cfg.get("target"),
+            "subpath": sc_cfg.get("subpath"),
+            "labels": sc_cfg.get("labels", []),
+            "fingerprint": fingerprint(sc_cfg),
+        },
+    }
+
+
+def ensure_shortcut(env: FabricEnv, sc_cfg: Dict[str, Any]) -> None:
+    """Crea o actualiza un shortcut en OneLake de forma idempotente."""
+
+    if "name" not in sc_cfg:
+        raise ValueError("La configuración de shortcut requiere 'name'")
+
+    desired_fp = fingerprint(sc_cfg)
+    payload = _build_payload(sc_cfg)
+    headers = build_auth_headers()
+    try:
+        existing = next(
+            (
+                item
+                for item in _list_shortcuts(env)
+                if item.get("name") == sc_cfg["name"]
+            ),
+            None,
+        )
+    except Exception as exc:  # pragma: no cover - logging adicional
+        LOGGER.error(
+            "No se pudo listar shortcuts en Fabric (workspace=%s): %s",
+            env.workspace_id,
+            exc,
+        )
+        raise
+
+    if not existing:
+        LOGGER.info(
+            "Creando shortcut %s en workspace %s",
+            sc_cfg["name"],
+            env.workspace_id,
+        )
+        response = env.http("POST", _base_url(env), json=payload, headers=headers)
+        response.raise_for_status()
+        return
+
+    current_fp = (existing.get("properties") or {}).get("fingerprint")
+    shortcut_id = existing.get("id")
+    if current_fp == desired_fp:
+        LOGGER.debug(
+            "Shortcut %s ya está actualizado (fingerprint %s)",
+            sc_cfg["name"],
+            desired_fp,
+        )
+        return
+
+    LOGGER.info(
+        "Actualizando shortcut %s en workspace %s",
+        sc_cfg["name"],
+        env.workspace_id,
+    )
+    response = env.http(
+        "PATCH",
+        f"{_base_url(env)}/{shortcut_id}",
+        json=payload,
+        headers=headers,
+    )
+    response.raise_for_status()

--- a/datacore/providers/fabric/shortcuts.py
+++ b/datacore/providers/fabric/shortcuts.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from typing import Any, Dict, Iterable
+import time
+from typing import Any, Dict, Iterable, List, Optional
 
 from .env import FabricEnv
 from .security import build_auth_headers
@@ -24,11 +25,45 @@ def _base_url(env: FabricEnv) -> str:
     return f"https://api.fabric.microsoft.com/v1/workspaces/{env.workspace_id}/shortcuts"
 
 
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def _request_with_retry(env: FabricEnv, method: str, url: str, *, retries: int = 3, **kwargs):
+    backoff = 1.0
+    attempt = 0
+    while True:
+        response = env.http(method, url, **kwargs)
+        if response.status_code in RETRYABLE_STATUS and attempt < retries:
+            LOGGER.warning(
+                "Reintento HTTP Fabric",
+                extra={
+                    "action": "retry",
+                    "attempt": attempt + 1,
+                    "status": response.status_code,
+                    "workspace_id": env.workspace_id,
+                },
+            )
+            time.sleep(backoff)
+            attempt += 1
+            backoff *= 2
+            continue
+        response.raise_for_status()
+        return response
+
+
 def _list_shortcuts(env: FabricEnv) -> Iterable[Dict[str, Any]]:
-    response = env.http("GET", _base_url(env))
-    response.raise_for_status()
-    body = response.json() if response.content else {}
-    items = body.get("value", []) if isinstance(body, dict) else []
+    url = _base_url(env)
+    items: List[Dict[str, Any]] = []
+    continuation: Optional[str] = None
+    while True:
+        params = {"continuationToken": continuation} if continuation else None
+        response = _request_with_retry(env, "GET", url, params=params)
+        body = response.json() if response.content else {}
+        batch = body.get("value", []) if isinstance(body, dict) else []
+        items.extend(batch)
+        continuation = body.get("continuationToken") if isinstance(body, dict) else None
+        if not continuation:
+            break
     return items
 
 
@@ -73,33 +108,41 @@ def ensure_shortcut(env: FabricEnv, sc_cfg: Dict[str, Any]) -> None:
 
     if not existing:
         LOGGER.info(
-            "Creando shortcut %s en workspace %s",
-            sc_cfg["name"],
-            env.workspace_id,
+            "Creando shortcut Fabric",
+            extra={
+                "action": "create", "name": sc_cfg["name"], "workspace_id": env.workspace_id
+            },
         )
-        response = env.http("POST", _base_url(env), json=payload, headers=headers)
-        response.raise_for_status()
+        _request_with_retry(env, "POST", _base_url(env), json=payload, headers=headers)
         return
 
     current_fp = (existing.get("properties") or {}).get("fingerprint")
     shortcut_id = existing.get("id")
     if current_fp == desired_fp:
         LOGGER.debug(
-            "Shortcut %s ya está actualizado (fingerprint %s)",
-            sc_cfg["name"],
-            desired_fp,
+            "Shortcut Fabric ya actualizado",
+            extra={
+                "action": "noop",
+                "name": sc_cfg["name"],
+                "workspace_id": env.workspace_id,
+                "fingerprint": desired_fp,
+            },
         )
         return
 
     LOGGER.info(
-        "Actualizando shortcut %s en workspace %s",
-        sc_cfg["name"],
-        env.workspace_id,
+        "Actualizando shortcut Fabric",
+        extra={
+            "action": "update",
+            "name": sc_cfg["name"],
+            "workspace_id": env.workspace_id,
+            "fingerprint": desired_fp,
+        },
     )
-    response = env.http(
+    _request_with_retry(
+        env,
         "PATCH",
         f"{_base_url(env)}/{shortcut_id}",
         json=payload,
         headers=headers,
     )
-    response.raise_for_status()

--- a/datacore/providers/fabric/warehouse.py
+++ b/datacore/providers/fabric/warehouse.py
@@ -1,0 +1,10 @@
+"""Placeholders para operaciones de Warehouse en Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def ensure_view(env, cfg: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - stub inicial
+    """Stub para creación de vistas en Warehouse."""
+    raise NotImplementedError("Warehouse aún no implementado")

--- a/datacore/providers/fabric/warehouse.py
+++ b/datacore/providers/fabric/warehouse.py
@@ -1,10 +1,78 @@
-"""Placeholders para operaciones de Warehouse en Fabric."""
+"""Operaciones de Warehouse para Microsoft Fabric."""
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import logging
+from typing import Any, Dict, Iterable
+
+from .env import FabricEnv
+
+LOGGER = logging.getLogger(__name__)
 
 
-def ensure_view(env, cfg: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - stub inicial
-    """Stub para creación de vistas en Warehouse."""
-    raise NotImplementedError("Warehouse aún no implementado")
+def _sql_endpoint(env: FabricEnv) -> str:
+    if not env.workspace_id or not env.warehouse_id:
+        raise ValueError("workspace_id y warehouse_id son obligatorios para warehouse")
+    return (
+        "https://api.fabric.microsoft.com/v1/workspaces/"
+        f"{env.workspace_id}/warehouses/{env.warehouse_id}/sql/statements"
+    )
+
+
+def _execute_sql(env: FabricEnv, statement: str) -> Dict[str, Any]:
+    LOGGER.info(
+        "Ejecutando SQL en Warehouse",
+        extra={
+            "action": "warehouse_sql",
+            "workspace_id": env.workspace_id,
+            "warehouse_id": env.warehouse_id,
+        },
+    )
+    response = env.http("POST", _sql_endpoint(env), json={"statement": statement})
+    response.raise_for_status()
+    return response.json() if response.content else {"statement": statement}
+
+
+def create_or_update_view(env: FabricEnv, delta_table: str, view_name: str, columns: Iterable[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """Crea o actualiza una vista en el Warehouse apuntando a una tabla Delta."""
+
+    if not delta_table or not view_name:
+        raise ValueError("delta_table y view_name son obligatorios")
+    select_expr = "*"
+    if columns:
+        casts = []
+        for column in columns:
+            name = column.get("name")
+            dtype = column.get("type")
+            if not name or not dtype:
+                raise ValueError("Cada columna requiere 'name' y 'type'")
+            casts.append(f"CAST([{name}] AS {dtype}) AS [{name}]")
+        select_expr = ", ".join(casts)
+    statement = (
+        f"CREATE OR ALTER VIEW [{view_name}] AS SELECT {select_expr} FROM delta.`{delta_table}`"
+    )
+    result = _execute_sql(env, statement)
+    result.update({"view": view_name, "statement": statement})
+    return result
+
+
+def copy_into(env: FabricEnv, table_name: str, source: str, *, file_format: str = "DELTA", options: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Ejecuta una operación COPY INTO con soporte de opciones comunes."""
+
+    if not table_name or not source:
+        raise ValueError("table_name y source son obligatorios")
+    options = options or {}
+    clauses = []
+    if partition_by := options.get("partition"):  # pragma: no cover - depende del uso
+        clauses.append(f"PARTITION = '{partition_by}'")
+    if max_errors := options.get("max_errors"):
+        clauses.append(f"MAXERRORS {int(max_errors)}")
+    if pattern := options.get("pattern"):
+        clauses.append(f"PATTERN = '{pattern}'")
+    statement = f"COPY INTO [{table_name}] FROM '{source}' WITH (FILE_TYPE = '{file_format}'"
+    if clauses:
+        statement += ", " + ", ".join(clauses)
+    statement += ")"
+    result = _execute_sql(env, statement)
+    result.update({"table": table_name, "statement": statement})
+    return result

--- a/datacore/utils/logging.py
+++ b/datacore/utils/logging.py
@@ -1,16 +1,73 @@
-"""Configuración de logging."""
+"""Configuración de logging estructurado en JSON."""
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import datetime
+from typing import Any, Dict
+
+
+class _JsonFormatter(logging.Formatter):
+    """Formatter sencillo que serializa los registros como JSON."""
+
+    _RESERVED = {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        payload: Dict[str, Any] = {
+            "timestamp": datetime.utcfromtimestamp(record.created).isoformat() + "Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        for key, value in record.__dict__.items():
+            if key in self._RESERVED:
+                continue
+            payload[key] = value
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, ensure_ascii=False)
 
 
 def configure_logging(level: str = "INFO") -> None:
-    logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
-    )
+    """Configura logging global con formato JSON."""
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(_JsonFormatter())
+
+    root.addHandler(handler)
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
 
 
 def get_logger(name: str | None = None) -> logging.Logger:
+    """Devuelve un logger de módulo."""
+
     return logging.getLogger(name or "datacore")

--- a/datacore/utils/observability.py
+++ b/datacore/utils/observability.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Iterable
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,11 +47,14 @@ def record_dataset(dataset: str, status: str, duration: float, metrics: dict[str
     if DATASET_DURATION is not None:
         DATASET_DURATION.labels(dataset=dataset).observe(duration)
     LOGGER.debug(
-        "Observabilidad dataset=%s status=%s duration=%.3fs métricas=%s",
+        "Observabilidad dataset %s",
         dataset,
-        status,
-        duration,
-        sorted(metrics.keys()) if metrics else [],
+        extra={
+            "dataset": dataset,
+            "status": status,
+            "duration_seconds": round(duration, 3),
+            "metrics": sorted(metrics.keys()) if metrics else [],
+        },
     )
 
 
@@ -90,3 +93,32 @@ def emit_openlineage(payload: dict[str, Any], config: dict[str, Any]) -> None:
         outputs=[],
     )
     client.emit(event)
+
+
+def summarize_run(datasets: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Construye un resumen agregando métricas relevantes."""
+
+    summary = {
+        "datasets_total": 0,
+        "datasets_completed": 0,
+        "datasets_failed": 0,
+        "rows_in": 0,
+        "rows_out": 0,
+        "bytes_written": 0,
+        "duration_seconds": 0.0,
+    }
+    for dataset in datasets:
+        summary["datasets_total"] += 1
+        status = (dataset or {}).get("status") or ""
+        if status.lower() in {"completed", "success", "succeeded"}:
+            summary["datasets_completed"] += 1
+        elif status.lower() in {"failed", "error"}:
+            summary["datasets_failed"] += 1
+        metrics = dataset.get("metrics") or {}
+        summary["rows_in"] += int(metrics.get("input_rows", metrics.get("rows_in", 0)) or 0)
+        summary["rows_out"] += int(metrics.get("valid_rows", metrics.get("rows_out", 0)) or 0)
+        summary["bytes_written"] += int(metrics.get("bytes_written", metrics.get("output_bytes", 0)) or 0)
+        duration = dataset.get("duration_seconds")
+        if duration:
+            summary["duration_seconds"] += float(duration)
+    return summary

--- a/datacore/utils/secrets.py
+++ b/datacore/utils/secrets.py
@@ -1,8 +1,11 @@
-"""Gestión básica de secretos."""
+"""Gestión de secretos multi-cloud."""
 
 from __future__ import annotations
 
+import base64
 import os
+from typing import Optional
+from urllib.parse import urlparse
 
 
 class SecretNotFoundError(RuntimeError):
@@ -14,3 +17,74 @@ def get_secret(name: str, default: str | None = None) -> str:
     if value is None:
         raise SecretNotFoundError(f"No se encontró el secreto {name}")
     return value
+
+
+def resolve_secret(uri: str) -> str:
+    """Resuelve URIs secret:// utilizando el backend apropiado."""
+
+    parsed = urlparse(uri)
+    if parsed.scheme != "secret":
+        raise ValueError(f"URI de secreto inválida: {uri}")
+    backend = parsed.netloc
+    path = parsed.path.lstrip("/")
+    if backend == "kv":
+        return _resolve_azure_kv(path)
+    if backend == "sm":
+        return _resolve_aws_sm(path)
+    if backend == "gcp":
+        return _resolve_gcp_secret(path)
+    raise RuntimeError(f"Backend de secretos desconocido: {backend}")
+
+
+def _resolve_azure_kv(path: str) -> str:
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 2:
+        raise ValueError("Se requiere vault/secret en secret://kv/<vault>/<secret>")
+    vault_name, secret_name, *rest = parts
+    version: Optional[str] = rest[0] if rest else None
+    try:
+        from azure.identity import DefaultAzureCredential  # type: ignore
+        from azure.keyvault.secrets import SecretClient  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depende de extras
+        raise RuntimeError(
+            "Faltan dependencias de Azure Key Vault. Instala con: pip install .[fabric]"
+        ) from exc
+    credential = DefaultAzureCredential()
+    client = SecretClient(vault_url=f"https://{vault_name}.vault.azure.net", credential=credential)
+    secret = client.get_secret(secret_name, version=version)
+    return secret.value
+
+
+def _resolve_aws_sm(path: str) -> str:
+    secret_id = path
+    try:
+        import boto3  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depende del entorno
+        raise RuntimeError(
+            "Falta boto3 para resolver secret://sm/. Instala boto3 o configure el backend"
+        ) from exc
+    client = boto3.client("secretsmanager")
+    response = client.get_secret_value(SecretId=secret_id)
+    if "SecretString" in response:
+        return response["SecretString"]
+    if "SecretBinary" in response:
+        return base64.b64decode(response["SecretBinary"]).decode("utf-8")
+    raise SecretNotFoundError(f"Secret {secret_id} vacío en AWS Secrets Manager")
+
+
+def _resolve_gcp_secret(path: str) -> str:
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 2:
+        raise ValueError("Se requiere project/secret en secret://gcp/<project>/<secret>")
+    project_id, secret_id, *rest = parts
+    version = rest[0] if rest else "latest"
+    try:
+        from google.cloud import secretmanager  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depende de extras
+        raise RuntimeError(
+            "Falta google-cloud-secret-manager para secret://gcp/. Instálalo antes de usarlo"
+        ) from exc
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/{version}"
+    response = client.access_secret_version(name=name)
+    return response.payload.data.decode("utf-8")

--- a/docs/fabric.md
+++ b/docs/fabric.md
@@ -1,0 +1,69 @@
+# Provider opcional Microsoft Fabric
+
+El soporte para Microsoft Fabric es un plugin opcional del proyecto. El núcleo multicloud continúa funcionando sin dependencias de Azure, y solo es necesario instalar los extras cuando se desee operar sobre Fabric.
+
+## Instalación
+
+```bash
+pip install .[fabric]
+```
+
+Este extra instala las bibliotecas necesarias (`azure-identity`, `delta-spark`, `azure-kusto-*`, `pyodbc`, entre otras) para interactuar con los servicios de Fabric.
+
+## Autenticación
+
+El provider utiliza `DefaultAzureCredential`. En entornos de Microsoft Fabric, se recomienda configurar una identidad administrada o un Service Principal con permisos sobre el workspace. Las variables habituales son:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_SECRET`
+
+Si se ejecuta dentro de un entorno gestionado (por ejemplo, un Environment de Fabric), basta con asignar la identidad adecuada.
+
+## Configuración YAML
+
+La sección `providers.fabric` es opcional y no modifica las claves existentes. Un ejemplo mínimo:
+
+```yaml
+providers:
+  fabric:
+    workspace_id: "00000000-0000-0000-0000-000000000000"
+    environment_id: "env-01"
+    lakehouse_id: "lk-01"
+```
+
+Para datasets que utilicen shortcuts:
+
+```yaml
+source:
+  type: shortcut
+  name: ventas_onelake
+  target: "abfss://contoso@onelake.dfs.fabric.microsoft.com/fabric"
+  subpath: "/Ventas/"
+  labels: ["bronze", "externo"]
+```
+
+## Uso de la CLI
+
+El CLI mantiene la compatibilidad con todos los providers. Para habilitar la provisión de recursos Fabric durante un `plan` o un `run`, utilice `--provision` o defina `orchestration.fabric.create_items` dentro del dataset.
+
+```bash
+python -m datacore.cli plan --config examples/fabric/bronze_shortcut.yaml --provision
+```
+
+Cuando se ejecuta con un provider Fabric disponible, el plan incluirá un bloque `fabric.items` con los artefactos creados o asegurados (shortcuts, Spark Job Definitions, Data Pipelines, etc.).
+
+## Lakehouse Delta
+
+El módulo `datacore.providers.fabric.lakehouse` utiliza `delta-spark` para leer y escribir tablas Delta en OneLake. Puede emplearse en pipelines existentes sin cambios en AWS, GCP o Databricks; en esos entornos el provider simplemente no se carga.
+
+## Limitaciones actuales
+
+- Las operaciones de Warehouse, KQL/Eventhouse y Mirroring se exponen como stubs para iteraciones futuras.
+- Las pruebas e2e dependen de credenciales reales y están marcadas como opcionales (`pytest -m fabric_e2e`).
+
+## Roadmap
+
+- Implementar vistas y cargas incrementales sobre Fabric Warehouse.
+- Integración con Eventhouse/KQL para escenarios de streaming.
+- Orquestación avanzada (Data Activator, pipelines compuestas) y gestión de mirroring como CDC.

--- a/docs/fabric.md
+++ b/docs/fabric.md
@@ -8,7 +8,7 @@ El soporte para Microsoft Fabric es un plugin opcional del proyecto. El núcleo 
 pip install .[fabric]
 ```
 
-Este extra instala las bibliotecas necesarias (`azure-identity`, `delta-spark`, `azure-kusto-*`, `pyodbc`, entre otras) para interactuar con los servicios de Fabric.
+El extra instala las bibliotecas necesarias (`azure-identity`, `azure-keyvault-secrets`, `delta-spark`, `azure-kusto-*`, `pyodbc`, entre otras) para interactuar con los servicios de Fabric. El resto del proyecto continúa funcionando sin Fabric instalado.
 
 ## Autenticación
 
@@ -22,14 +22,16 @@ Si se ejecuta dentro de un entorno gestionado (por ejemplo, un Environment de Fa
 
 ## Configuración YAML
 
-La sección `providers.fabric` es opcional y no modifica las claves existentes. Un ejemplo mínimo:
+La sección `providers.fabric` es opcional y no modifica las claves existentes. Puede resolverse dinámicamente con variables de entorno permitidas (`${FABRIC_WORKSPACE_ID}`, `${FABRIC_LAKEHOUSE_ID}`, etc.). Un ejemplo mínimo:
 
 ```yaml
 providers:
   fabric:
     workspace_id: "00000000-0000-0000-0000-000000000000"
     environment_id: "env-01"
-    lakehouse_id: "lk-01"
+    lakehouse_id: "${FABRIC_LAKEHOUSE_ID}"
+
+Los placeholders están restringidos a una lista blanca y deben estar definidos como variables de entorno antes de ejecutar la CLI. Los valores se registran sin exponer el secreto.
 ```
 
 Para datasets que utilicen shortcuts:
@@ -53,17 +55,29 @@ python -m datacore.cli plan --config examples/fabric/bronze_shortcut.yaml --prov
 
 Cuando se ejecuta con un provider Fabric disponible, el plan incluirá un bloque `fabric.items` con los artefactos creados o asegurados (shortcuts, Spark Job Definitions, Data Pipelines, etc.).
 
+Al final de cada `run`, la CLI emite un resumen JSON con métricas agregadas (datasets procesados, filas de entrada/salida, bytes escritos y duración total) junto con el `run_id` y `created_at`. Estos datos también se incluyen en el plan generado.
+
+> Nota: para pruebas locales sin credenciales de Azure puede habilitarse el modo offline exportando `FABRIC_HTTP_OFFLINE=1`; en ese caso las llamadas HTTP se simulan y no se envían a Fabric.
+
 ## Lakehouse Delta
 
-El módulo `datacore.providers.fabric.lakehouse` utiliza `delta-spark` para leer y escribir tablas Delta en OneLake. Puede emplearse en pipelines existentes sin cambios en AWS, GCP o Databricks; en esos entornos el provider simplemente no se carga.
+El módulo `datacore.providers.fabric.lakehouse` utiliza `delta-spark` para leer y escribir tablas Delta en OneLake. Ofrece idempotencia y mantenimiento opcional (`OPTIMIZE`, `Z-ORDER`, `VACUUM`) mediante `options` en los sinks. Puede emplearse en pipelines existentes sin cambios en AWS, GCP o Databricks; en esos entornos el provider simplemente no se carga.
+
+Los secretos referenciados como `secret://kv/<vault>/<secret>` se resuelven automáticamente mediante Azure Key Vault (`DefaultAzureCredential`). Para otros backends (`secret://sm/`, `secret://gcp/`) se delega en AWS Secrets Manager o Google Secret Manager respectivamente, devolviendo errores claros si las dependencias no están instaladas.
+
+## Warehouse y SQL Endpoint
+
+El módulo `datacore.providers.fabric.warehouse` incluye utilidades para crear o actualizar vistas (`CREATE OR ALTER VIEW` apuntando a tablas Delta) y ejecutar operaciones `COPY INTO` con opciones de tolerancia (`MAXERRORS`, patrones de archivos, particiones). Las peticiones se envían al endpoint REST del Warehouse y registran acción y destino en los logs.
+
+## KQL/Eventhouse
+
+`datacore.providers.fabric.kql` expone `kql_read` y `kql_ingest`, que encapsulan `azure-kusto-data` y `azure-kusto-ingest` con autenticación AAD basada en `DefaultAzureCredential`. Ambos métodos son seguros para entornos sin las dependencias: generan errores guiados que recuerdan instalar el extra `fabric`.
+
+## Observabilidad y CI
+
+Los logs se emiten en formato JSON con contexto (`run_id`, dataset, layer, provider). Las métricas de observabilidad se agregan y se imprimen como resumen al finalizar un `run`. El pipeline de CI genera un wheel (`python -m build`), lo instala y publica el plan resultante de los ejemplos como artefacto por cada perfil (`base` y `fabric`).
 
 ## Limitaciones actuales
 
-- Las operaciones de Warehouse, KQL/Eventhouse y Mirroring se exponen como stubs para iteraciones futuras.
+- El soporte de Mirroring continúa como stub; su implementación se planificará en iteraciones posteriores.
 - Las pruebas e2e dependen de credenciales reales y están marcadas como opcionales (`pytest -m fabric_e2e`).
-
-## Roadmap
-
-- Implementar vistas y cargas incrementales sobre Fabric Warehouse.
-- Integración con Eventhouse/KQL para escenarios de streaming.
-- Orquestación avanzada (Data Activator, pipelines compuestas) y gestión de mirroring como CDC.

--- a/examples/fabric/bronze_shortcut.yaml
+++ b/examples/fabric/bronze_shortcut.yaml
@@ -1,0 +1,34 @@
+project: fabric-demo
+environment: dev
+platform: azure
+providers:
+  fabric:
+    workspace_id: "abc"
+    environment_id: "env-1"
+    lakehouse_id: "lk-1"
+
+datasets:
+  - name: sales_shortcut
+    layer: bronze
+    source:
+      type: shortcut
+      name: sales_onelake
+      target: "https://onelake.dfs.fabric.microsoft.com/contoso"
+      subpath: "/sales/"
+      labels: ["bronze", "external"]
+    sink:
+      type: storage
+      backend: delta
+      uri: "lakehouse://tables/bronze/sales_shortcut"
+    incremental:
+      mode: append
+    orchestration:
+      fabric:
+        create_items: [lakehouse, spark_job, pipeline, shortcut]
+        spark_job:
+          name: "sales_shortcut-job"
+          entrypoint: "python -m datacore.cli run --layer bronze --config examples/fabric/bronze_shortcut.yaml"
+        pipeline:
+          name: "sales_shortcut-pipeline"
+          properties:
+            activities: []

--- a/examples/fabric/bronze_shortcut.yaml
+++ b/examples/fabric/bronze_shortcut.yaml
@@ -3,9 +3,9 @@ environment: dev
 platform: azure
 providers:
   fabric:
-    workspace_id: "abc"
-    environment_id: "env-1"
-    lakehouse_id: "lk-1"
+    workspace_id: "${FABRIC_WORKSPACE_ID}"
+    environment_id: "${FABRIC_ENVIRONMENT_ID}"
+    lakehouse_id: "${FABRIC_LAKEHOUSE_ID}"
 
 datasets:
   - name: sales_shortcut

--- a/examples/fabric/multicloud_passthrough.yaml
+++ b/examples/fabric/multicloud_passthrough.yaml
@@ -1,0 +1,18 @@
+project: multicloud-demo
+environment: dev
+platform: aws
+
+datasets:
+  - name: sales_csv
+    layer: bronze
+    source:
+      type: storage
+      backend: s3
+      uri: "s3://acme/sales/*.csv"
+    sink:
+      type: storage
+      backend: s3
+      format: parquet
+      uri: "s3://acme-bronze/sales/"
+    incremental:
+      mode: append

--- a/examples/fabric/silver_federation.yaml
+++ b/examples/fabric/silver_federation.yaml
@@ -3,9 +3,9 @@ environment: dev
 platform: azure
 providers:
   fabric:
-    workspace_id: "abc"
-    environment_id: "env-1"
-    lakehouse_id: "lk-1"
+    workspace_id: "${FABRIC_WORKSPACE_ID}"
+    environment_id: "${FABRIC_ENVIRONMENT_ID}"
+    lakehouse_id: "${FABRIC_LAKEHOUSE_ID}"
 
 datasets:
   - name: customers_enriched

--- a/examples/fabric/silver_federation.yaml
+++ b/examples/fabric/silver_federation.yaml
@@ -1,0 +1,45 @@
+project: fabric-demo
+environment: dev
+platform: azure
+providers:
+  fabric:
+    workspace_id: "abc"
+    environment_id: "env-1"
+    lakehouse_id: "lk-1"
+
+datasets:
+  - name: customers_enriched
+    layer: silver
+    source:
+      - id: api
+        type: endpoint
+        url: "https://api.example.com/customers"
+        format: json
+      - id: crm
+        type: jdbc
+        url: "${JDBC_URL}"
+        table: "public.crm_customers"
+    transform:
+      federate:
+        strategy: join
+        join:
+          left: api
+          right: crm
+          'on':
+            - left: "email"
+              right: "email"
+          join_type: left
+    sink:
+      type: storage
+      backend: delta
+      uri: "lakehouse://tables/silver/customers_enriched"
+    incremental:
+      mode: merge
+      keys: ["email"]
+    orchestration:
+      fabric:
+        create_items: [lakehouse, spark_job]
+        spark_job:
+          name: "customers_enriched-job"
+          parameters:
+            layer: "silver"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ dev = [
   "ruff>=0.4",
   "black>=24.3",
 ]
+fabric = [
+  "azure-identity>=1.17",
+  "requests>=2.31",
+  "delta-spark>=3.0; python_version >= '3.9'",
+  "azure-kusto-data>=4.5; python_version >= '3.9'",
+  "azure-kusto-ingest>=4.5; python_version >= '3.9'",
+  "pyodbc>=5.0; platform_system=='Windows' or platform_system=='Linux'",
+]
 
 [project.scripts]
 prodi = "datacore.cli.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 ]
 fabric = [
   "azure-identity>=1.17",
+  "azure-keyvault-secrets>=4.7",
   "requests>=2.31",
   "delta-spark>=3.0; python_version >= '3.9'",
   "azure-kusto-data>=4.5; python_version >= '3.9'",

--- a/tests/unit/providers/fabric/test_env.py
+++ b/tests/unit/providers/fabric/test_env.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from datacore.providers.fabric.env import FabricEnv
+
+
+def test_env_resolves_placeholders(monkeypatch):
+    monkeypatch.setenv("FABRIC_WORKSPACE_ID", "wk-1")
+    env = FabricEnv({"workspace_id": "${FABRIC_WORKSPACE_ID}"})
+    assert env.workspace_id == "wk-1"
+
+
+def test_env_rejects_unknown_placeholder(monkeypatch):
+    with pytest.raises(RuntimeError):
+        FabricEnv({"workspace_id": "${NOT_ALLOWED}"})

--- a/tests/unit/providers/fabric/test_fabric_shortcuts.py
+++ b/tests/unit/providers/fabric/test_fabric_shortcuts.py
@@ -1,0 +1,96 @@
+"""Pruebas unitarias para la gestión de shortcuts en Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from datacore.providers.fabric.shortcuts import ensure_shortcut, fingerprint
+
+
+class DummyResponse:
+    def __init__(self, payload: Dict[str, Any] | None, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.content = b"{}" if payload is not None else b""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class DummyEnv:
+    def __init__(self, workspace_id: str, responses: List[Tuple[str, DummyResponse]]):
+        self.workspace_id = workspace_id
+        self._responses = responses
+        self.calls: List[Tuple[str, str, Dict[str, Any] | None]] = []
+
+    def http(self, method: str, url: str, **kwargs):
+        payload = kwargs.get("json")
+        self.calls.append((method, url, payload))
+        expected_method, response = self._responses.pop(0)
+        assert expected_method == method
+        return response
+
+
+def _base_url(workspace: str) -> str:
+    return f"https://api.fabric.microsoft.com/v1/workspaces/{workspace}/shortcuts"
+
+
+@pytest.mark.parametrize("existing_fp", [None, "different"])
+def test_ensure_shortcut_creates_or_updates(existing_fp):
+    workspace = "wk-1"
+    shortcut_cfg = {
+        "name": "sales_onelake",
+        "type": "adls",
+        "target": "https://storage",
+        "labels": ["bronze"],
+    }
+    desired_fp = fingerprint(shortcut_cfg)
+    existing = {
+        "id": "shortcut-1",
+        "name": "sales_onelake",
+        "properties": {"fingerprint": existing_fp},
+    }
+    responses = [
+        ("GET", DummyResponse({"value": [] if existing_fp is None else [existing]})),
+    ]
+    if existing_fp is None:
+        responses.append(("POST", DummyResponse({"id": "shortcut-1"})))
+    else:
+        responses.append(("PATCH", DummyResponse({"id": "shortcut-1"})))
+    env = DummyEnv(workspace, responses)
+    ensure_shortcut(env, shortcut_cfg)
+    assert env.calls[0][0] == "GET"
+    if existing_fp is None:
+        method, url, payload = env.calls[1]
+        assert method == "POST"
+        assert url == _base_url(workspace)
+        assert payload["name"] == "sales_onelake"
+        assert payload["properties"]["fingerprint"] == desired_fp
+    else:
+        method, url, payload = env.calls[1]
+        assert method == "PATCH"
+        assert payload["properties"]["fingerprint"] == desired_fp
+
+
+def test_ensure_shortcut_noop_when_same_fingerprint():
+    workspace = "wk-1"
+    shortcut_cfg = {
+        "name": "sales_onelake",
+        "type": "adls",
+        "target": "https://storage",
+    }
+    desired_fp = fingerprint(shortcut_cfg)
+    existing = {
+        "id": "shortcut-1",
+        "name": "sales_onelake",
+        "properties": {"fingerprint": desired_fp},
+    }
+    env = DummyEnv("wk-1", [("GET", DummyResponse({"value": [existing]}))])
+    ensure_shortcut(env, shortcut_cfg)
+    assert len(env.calls) == 1

--- a/tests/unit/providers/fabric/test_fabric_shortcuts.py
+++ b/tests/unit/providers/fabric/test_fabric_shortcuts.py
@@ -27,13 +27,12 @@ class DummyEnv:
     def __init__(self, workspace_id: str, responses: List[Tuple[str, DummyResponse]]):
         self.workspace_id = workspace_id
         self._responses = responses
-        self.calls: List[Tuple[str, str, Dict[str, Any] | None]] = []
+        self.calls: List[Tuple[str, str, Dict[str, Any]]] = []
 
     def http(self, method: str, url: str, **kwargs):
-        payload = kwargs.get("json")
-        self.calls.append((method, url, payload))
         expected_method, response = self._responses.pop(0)
         assert expected_method == method
+        self.calls.append((method, url, kwargs))
         return response
 
 
@@ -67,14 +66,16 @@ def test_ensure_shortcut_creates_or_updates(existing_fp):
     ensure_shortcut(env, shortcut_cfg)
     assert env.calls[0][0] == "GET"
     if existing_fp is None:
-        method, url, payload = env.calls[1]
+        method, url, kwargs = env.calls[1]
         assert method == "POST"
         assert url == _base_url(workspace)
+        payload = kwargs.get("json")
         assert payload["name"] == "sales_onelake"
         assert payload["properties"]["fingerprint"] == desired_fp
     else:
-        method, url, payload = env.calls[1]
+        method, url, kwargs = env.calls[1]
         assert method == "PATCH"
+        payload = kwargs.get("json")
         assert payload["properties"]["fingerprint"] == desired_fp
 
 

--- a/tests/unit/providers/fabric/test_kql.py
+++ b/tests/unit/providers/fabric/test_kql.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from datacore.providers.fabric import kql
+
+
+class DummyEnv:
+    def __init__(self):
+        self.workspace_id = "wk-1"
+        self.eventhouse_id = "https://cluster"
+
+    def get_token(self):
+        return "token"
+
+
+@pytest.fixture
+def azure_modules(monkeypatch):
+    data_module = types.SimpleNamespace()
+    ingest_module = types.SimpleNamespace()
+
+    class DummyClient:
+        def __init__(self, builder):
+            self.builder = builder
+            self.executed = None
+
+        def execute(self, database, statement):
+            self.executed = (database, statement)
+            return {"database": database, "statement": statement}
+
+    dummy_client = DummyClient("builder")
+
+    def with_provider(cluster, provider):
+        assert provider() == "token"
+        return "builder"
+
+    data_module.KustoClient = lambda builder: dummy_client
+    data_module.KustoConnectionStringBuilder = types.SimpleNamespace(
+        with_aad_token_provider=with_provider
+    )
+
+    class DummyIngestClient:
+        def __init__(self, builder):
+            self.builder = builder
+            self.calls = []
+
+        def ingest_from_dataframe(self, df, ingestion_properties):
+            self.calls.append((df, ingestion_properties))
+
+    ingest_client = DummyIngestClient("builder")
+
+    ingest_module.IngestionProperties = lambda **kwargs: kwargs
+    ingest_module.QueuedIngestClient = lambda builder: ingest_client
+
+    monkeypatch.setitem(
+        sys.modules,
+        "azure",
+        types.SimpleNamespace(kusto=types.SimpleNamespace(data=data_module, ingest=ingest_module)),
+    )
+    monkeypatch.setitem(sys.modules, "azure.kusto", types.SimpleNamespace(data=data_module, ingest=ingest_module))
+    monkeypatch.setitem(sys.modules, "azure.kusto.data", data_module)
+    monkeypatch.setitem(sys.modules, "azure.kusto.ingest", ingest_module)
+    yield dummy_client, ingest_client
+    for name in ["azure.kusto.ingest", "azure.kusto.data", "azure.kusto", "azure"]:
+        sys.modules.pop(name, None)
+
+
+def test_kql_read_uses_client(monkeypatch, azure_modules):
+    dummy_client, _ = azure_modules
+    env = DummyEnv()
+    result = kql.kql_read(env, "KQL", {"database": "db"})
+    assert result == {"database": "db", "statement": "KQL"}
+    assert dummy_client.executed == ("db", "KQL")
+
+
+def test_kql_ingest(monkeypatch, azure_modules):
+    _, ingest_client = azure_modules
+    env = DummyEnv()
+    df = object()
+    kql.kql_ingest(env, "table", df, {"database": "db"})
+    assert ingest_client.calls

--- a/tests/unit/providers/fabric/test_lakehouse.py
+++ b/tests/unit/providers/fabric/test_lakehouse.py
@@ -67,3 +67,15 @@ def test_optimize_delta_generates_sql(dummy_spark):
         "OPTIMIZE delta.`lakehouse://tables/bronze/demo`",
         "VACUUM delta.`lakehouse://tables/bronze/demo` RETAIN 168 HOURS",
     ]
+
+
+def test_optimize_delta_with_zorder(dummy_spark):
+    dummy_spark.sql_calls.clear()
+    lakehouse.optimize_delta(
+        None,
+        "lakehouse://tables/silver/demo",
+        {"zorder": ["col_a", "col_b"]},
+    )
+    assert dummy_spark.sql_calls == [
+        "OPTIMIZE delta.`lakehouse://tables/silver/demo` ZORDER BY (col_a, col_b)",
+    ]

--- a/tests/unit/providers/fabric/test_lakehouse.py
+++ b/tests/unit/providers/fabric/test_lakehouse.py
@@ -1,0 +1,69 @@
+"""Pruebas para operaciones de Lakehouse en Fabric."""
+
+from __future__ import annotations
+
+import pytest
+
+from datacore.providers.fabric import lakehouse
+
+
+class DummyWriter:
+    def __init__(self):
+        self.format_value = None
+        self.mode_value = None
+        self.options_value = {}
+        self.saved_path = None
+
+    def format(self, value):
+        self.format_value = value
+        return self
+
+    def mode(self, value):
+        self.mode_value = value
+        return self
+
+    def options(self, **kwargs):
+        self.options_value.update(kwargs)
+        return self
+
+    def save(self, path):
+        self.saved_path = path
+
+
+class DummyDataFrame:
+    def __init__(self):
+        self.write = DummyWriter()
+
+
+class DummySpark:
+    def __init__(self):
+        self.sql_calls: list[str] = []
+
+    def sql(self, statement: str):
+        self.sql_calls.append(statement)
+
+
+@pytest.fixture
+def dummy_spark(monkeypatch):
+    spark = DummySpark()
+    monkeypatch.setattr(lakehouse, "_spark", lambda: spark)
+    return spark
+
+
+def test_write_delta_invokes_writer(dummy_spark):
+    df = DummyDataFrame()
+    options = {"mode": "overwrite", "mergeSchema": True, "maxRecordsPerFile": 1000}
+    lakehouse.write_delta(None, df, "lakehouse://tables/bronze/demo", options)
+    writer = df.write
+    assert writer.format_value == "delta"
+    assert writer.mode_value == "overwrite"
+    assert writer.options_value == {"mergeSchema": "True", "maxRecordsPerFile": "1000"}
+    assert writer.saved_path == "lakehouse://tables/bronze/demo"
+
+
+def test_optimize_delta_generates_sql(dummy_spark):
+    lakehouse.optimize_delta(None, "lakehouse://tables/bronze/demo", {"optimize": True, "vacuum_hours": 168})
+    assert dummy_spark.sql_calls == [
+        "OPTIMIZE delta.`lakehouse://tables/bronze/demo`",
+        "VACUUM delta.`lakehouse://tables/bronze/demo` RETAIN 168 HOURS",
+    ]

--- a/tests/unit/providers/fabric/test_orchestrator.py
+++ b/tests/unit/providers/fabric/test_orchestrator.py
@@ -8,28 +8,29 @@ from datacore.providers.fabric import orchestrator
 
 
 class DummyResponse:
-    def __init__(self, payload: Dict[str, Any]):
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200):
         self._payload = payload
         self.content = b"{}"
+        self.status_code = status_code
 
     def json(self):
         return self._payload
 
     def raise_for_status(self):
-        return None
+        if self.status_code >= 400:
+            raise RuntimeError("error")
 
 
 class DummyEnv:
     def __init__(self, workspace_id: str, responses: List[Tuple[str, DummyResponse]]):
         self.workspace_id = workspace_id
         self._responses = responses
-        self.calls: List[Tuple[str, str, Dict[str, Any] | None]] = []
+        self.calls: List[Tuple[str, str, Dict[str, Any]]] = []
 
     def http(self, method: str, url: str, **kwargs):
-        payload = kwargs.get("json")
-        self.calls.append((method, url, payload))
         expected_method, response = self._responses.pop(0)
         assert expected_method == method
+        self.calls.append((method, url, kwargs))
         return response
 
 
@@ -37,31 +38,54 @@ def test_ensure_spark_job(monkeypatch):
     env = DummyEnv(
         "wk-1",
         [
+            ("GET", DummyResponse({"value": []})),
             (
                 "POST",
                 DummyResponse({"id": "item-1", "webUrl": "https://fabric/jobs/1", "name": "job"}),
-            )
+            ),
         ],
     )
     result = orchestrator.ensure_spark_job(env, {"name": "job", "entrypoint": "python foo"})
     assert result == {"id": "item-1", "url": "https://fabric/jobs/1", "name": "job"}
-    method, url, payload = env.calls[0]
+    assert env.calls[0][0] == "GET"
+    method, url, kwargs = env.calls[1]
     assert method == "POST"
-    assert payload["type"] == "sparkJobDefinition"
+    assert kwargs["json"]["type"] == "sparkJobDefinition"
 
 
 def test_ensure_pipeline(monkeypatch):
     env = DummyEnv(
         "wk-1",
         [
+            ("GET", DummyResponse({"value": []})),
             (
                 "POST",
                 DummyResponse({"id": "pipeline-1", "webUrl": "https://fabric/pipeline/1", "name": "pipeline"}),
-            )
+            ),
         ],
     )
     result = orchestrator.ensure_pipeline(env, {"name": "pipeline"})
     assert result == {"id": "pipeline-1", "url": "https://fabric/pipeline/1", "name": "pipeline"}
-    method, url, payload = env.calls[0]
+    assert env.calls[0][0] == "GET"
+    method, url, kwargs = env.calls[1]
     assert method == "POST"
-    assert payload["type"] == "dataPipeline"
+    assert kwargs["json"]["type"] == "dataPipeline"
+
+
+def test_orchestrator_idempotent_update():
+    existing = {
+        "id": "item-1",
+        "name": "job",
+        "type": "sparkJobDefinition",
+        "webUrl": "https://fabric/jobs/1",
+        "properties": {"fingerprint": "abc"},
+    }
+    env = DummyEnv(
+        "wk-1",
+        [
+            ("GET", DummyResponse({"value": [existing]})),
+            ("PATCH", DummyResponse({"id": "item-1", "webUrl": "https://fabric/jobs/1"})),
+        ],
+    )
+    orchestrator.ensure_spark_job(env, {"name": "job", "entrypoint": "python foo", "parameters": {"x": 1}})
+    assert env.calls[1][0] == "PATCH"

--- a/tests/unit/providers/fabric/test_orchestrator.py
+++ b/tests/unit/providers/fabric/test_orchestrator.py
@@ -1,0 +1,67 @@
+"""Pruebas para el orquestador de Fabric."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from datacore.providers.fabric import orchestrator
+
+
+class DummyResponse:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+        self.content = b"{}"
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class DummyEnv:
+    def __init__(self, workspace_id: str, responses: List[Tuple[str, DummyResponse]]):
+        self.workspace_id = workspace_id
+        self._responses = responses
+        self.calls: List[Tuple[str, str, Dict[str, Any] | None]] = []
+
+    def http(self, method: str, url: str, **kwargs):
+        payload = kwargs.get("json")
+        self.calls.append((method, url, payload))
+        expected_method, response = self._responses.pop(0)
+        assert expected_method == method
+        return response
+
+
+def test_ensure_spark_job(monkeypatch):
+    env = DummyEnv(
+        "wk-1",
+        [
+            (
+                "POST",
+                DummyResponse({"id": "item-1", "webUrl": "https://fabric/jobs/1", "name": "job"}),
+            )
+        ],
+    )
+    result = orchestrator.ensure_spark_job(env, {"name": "job", "entrypoint": "python foo"})
+    assert result == {"id": "item-1", "url": "https://fabric/jobs/1", "name": "job"}
+    method, url, payload = env.calls[0]
+    assert method == "POST"
+    assert payload["type"] == "sparkJobDefinition"
+
+
+def test_ensure_pipeline(monkeypatch):
+    env = DummyEnv(
+        "wk-1",
+        [
+            (
+                "POST",
+                DummyResponse({"id": "pipeline-1", "webUrl": "https://fabric/pipeline/1", "name": "pipeline"}),
+            )
+        ],
+    )
+    result = orchestrator.ensure_pipeline(env, {"name": "pipeline"})
+    assert result == {"id": "pipeline-1", "url": "https://fabric/pipeline/1", "name": "pipeline"}
+    method, url, payload = env.calls[0]
+    assert method == "POST"
+    assert payload["type"] == "dataPipeline"

--- a/tests/unit/providers/fabric/test_warehouse.py
+++ b/tests/unit/providers/fabric/test_warehouse.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from datacore.providers.fabric import warehouse
+
+
+class DummyResponse:
+    def __init__(self, payload: Dict[str, Any] | None = None, status_code: int = 200):
+        self._payload = payload or {}
+        self.status_code = status_code
+        self.content = b"{}"
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError("error")
+
+
+class DummyEnv:
+    def __init__(self, workspace_id: str, warehouse_id: str, responses: List[Tuple[str, DummyResponse]]):
+        self.workspace_id = workspace_id
+        self.warehouse_id = warehouse_id
+        self._responses = responses
+        self.calls: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    def http(self, method: str, url: str, **kwargs):
+        expected_method, response = self._responses.pop(0)
+        assert expected_method == method
+        self.calls.append((method, url, kwargs))
+        return response
+
+
+def test_create_or_update_view_builds_statement():
+    env = DummyEnv(
+        "wk-1",
+        "wh-1",
+        [("POST", DummyResponse({"operationId": "op-1"}))],
+    )
+    result = warehouse.create_or_update_view(
+        env,
+        "lakehouse://tables/bronze/demo",
+        "vw_demo",
+        columns=[{"name": "amount", "type": "DECIMAL(18,2)"}],
+    )
+    assert result["view"] == "vw_demo"
+    method, url, kwargs = env.calls[0]
+    assert method == "POST"
+    statement = kwargs["json"]["statement"]
+    assert "CREATE OR ALTER VIEW [vw_demo]" in statement
+    assert "CAST([amount] AS DECIMAL(18,2)) AS [amount]" in statement
+
+
+def test_copy_into_composes_options():
+    env = DummyEnv(
+        "wk-1",
+        "wh-1",
+        [("POST", DummyResponse({"status": "Queued"}))],
+    )
+    warehouse.copy_into(
+        env,
+        "fact_sales",
+        "https://contoso.dfs.core.windows.net/raw/sales",
+        options={"max_errors": 5, "pattern": "*.parquet"},
+    )
+    statement = env.calls[0][2]["json"]["statement"]
+    assert "COPY INTO [fact_sales]" in statement
+    assert "MAXERRORS 5" in statement
+    assert "PATTERN = '*.parquet'" in statement

--- a/tests/unit/providers/test_loader.py
+++ b/tests/unit/providers/test_loader.py
@@ -1,0 +1,62 @@
+"""Pruebas para el cargador dinámico de providers."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from datacore.providers import load_provider
+
+
+class DummyFabric(ModuleType):
+    def __init__(self):
+        super().__init__("datacore.providers.fabric.provider")
+
+        class _Provider:
+            def __init__(self, cfg):
+                self.cfg = cfg
+
+        self.FabricProvider = _Provider
+
+
+@pytest.fixture(autouse=True)
+def cleanup_modules():
+    yield
+    for key in list(sys.modules):
+        if key.startswith("datacore.providers.fabric"):
+            sys.modules.pop(key)
+
+
+def test_load_provider_without_fabric_section():
+    assert load_provider({}) is None
+
+
+def test_load_provider_missing_extra(monkeypatch):
+    real_import = __import__
+
+    def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "datacore.providers.fabric.provider" or (
+            name == "datacore.providers.fabric" and "provider" in fromlist
+        ):
+            raise ImportError("missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(sys.modules["builtins"], "__import__", _fake_import)
+    cfg = {"providers": {"fabric": {"workspace_id": "1"}}}
+    with pytest.raises(RuntimeError) as exc:
+        load_provider(cfg)
+    assert "pip install .[fabric]" in str(exc.value)
+
+
+def test_load_provider_success(monkeypatch):
+    module = DummyFabric()
+    sys.modules[module.__name__] = module
+    package = ModuleType("datacore.providers.fabric")
+    package.provider = module
+    sys.modules["datacore.providers.fabric"] = package
+    cfg = {"providers": {"fabric": {"workspace_id": "1"}}}
+    provider = load_provider(cfg)
+    assert provider.__class__.__name__ == "_Provider"
+    assert provider.cfg == {"workspace_id": "1"}

--- a/tests/unit/utils/test_secret_resolver.py
+++ b/tests/unit/utils/test_secret_resolver.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from datacore.utils import secrets
+
+
+def test_resolve_secret_azure(monkeypatch):
+    class DummyCredential:
+        def __init__(self):
+            self.tokens = []
+
+        def get_token(self, scope):
+            self.tokens.append(scope)
+            return types.SimpleNamespace(token="token")
+
+    class DummySecretClient:
+        def __init__(self, vault_url, credential):
+            self.vault_url = vault_url
+            self.credential = credential
+
+        def get_secret(self, name, version=None):
+            return types.SimpleNamespace(value=f"secret-{name}-{version or 'latest'}")
+
+    identity_module = types.SimpleNamespace(DefaultAzureCredential=DummyCredential)
+    secrets_module = types.SimpleNamespace(SecretClient=DummySecretClient)
+    monkeypatch.setitem(sys.modules, "azure", types.SimpleNamespace(identity=identity_module, keyvault=types.SimpleNamespace(secrets=secrets_module)))
+    monkeypatch.setitem(sys.modules, "azure.identity", identity_module)
+    monkeypatch.setitem(sys.modules, "azure.keyvault", types.SimpleNamespace(secrets=secrets_module))
+    monkeypatch.setitem(sys.modules, "azure.keyvault.secrets", secrets_module)
+    value = secrets.resolve_secret("secret://kv/myvault/mysecret")
+    assert value == "secret-mysecret-latest"
+    for name in ["azure.keyvault.secrets", "azure.keyvault", "azure.identity", "azure"]:
+        sys.modules.pop(name, None)
+
+
+def test_resolve_secret_aws(monkeypatch):
+    class DummyClient:
+        def get_secret_value(self, SecretId):
+            return {"SecretString": "value"}
+
+    boto3_module = types.SimpleNamespace(client=lambda name: DummyClient())
+    monkeypatch.setitem(sys.modules, "boto3", boto3_module)
+    assert secrets.resolve_secret("secret://sm/mysecret") == "value"
+    sys.modules.pop("boto3", None)
+
+
+def test_resolve_secret_gcp(monkeypatch):
+    class DummyPayload:
+        def __init__(self, data):
+            self.data = data
+
+    class DummyResponse:
+        def __init__(self, data):
+            self.payload = DummyPayload(data)
+
+    class DummyClient:
+        def access_secret_version(self, name):
+            return DummyResponse(b"gcp-value")
+
+    secretmanager_module = types.SimpleNamespace(SecretManagerServiceClient=DummyClient)
+    monkeypatch.setitem(sys.modules, "google", types.SimpleNamespace(cloud=types.SimpleNamespace(secretmanager=secretmanager_module)))
+    monkeypatch.setitem(sys.modules, "google.cloud", types.SimpleNamespace(secretmanager=secretmanager_module))
+    monkeypatch.setitem(sys.modules, "google.cloud.secretmanager", secretmanager_module)
+    assert secrets.resolve_secret("secret://gcp/project/secret/1") == "gcp-value"
+    for name in ["google.cloud.secretmanager", "google.cloud", "google"]:
+        sys.modules.pop(name, None)
+
+
+def test_resolve_secret_invalid_scheme():
+    with pytest.raises(ValueError):
+        secrets.resolve_secret("http://example")


### PR DESCRIPTION
## Summary
- introduce provider abstractions and the optional Microsoft Fabric implementation (shortcuts, lakehouse and orchestration)
- expose Fabric provisioning through the CLI, schemas, documentation and sample configurations
- add Fabric-focused unit tests and extend CI with base and fabric profiles

## Testing
- pytest -q -k "not fabric"
- pytest -q
- python tools/validate_examples_against_layer_schema.py

------
https://chatgpt.com/codex/tasks/task_e_690b6653a9248320886ae92ec6d22dac