### PR TITLE
Add Fabric platform and reuse active Spark sessions

### DIFF
--- a/datacore/cli/main.py
+++ b/datacore/cli/main.py
@@ -144,7 +144,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Capa a ejecutar",
     )
     run_parser.add_argument("--config", required=True, help="Archivo YAML de configuración")
-    run_parser.add_argument("--platform", required=False, help="Plataforma cloud (azure/aws/gcp)")
+    run_parser.add_argument(
+        "--platform",
+        required=False,
+        help="Plataforma cloud (azure/aws/gcp/fabric)",
+    )
     run_parser.add_argument("--env", required=False, help="Entorno (dev/test/prod)")
     run_parser.add_argument("--log-level", default="INFO", help="Nivel de logging")
     run_parser.add_argument("--dry-run", action="store_true", help="Solo genera el plan")
@@ -158,7 +162,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     plan_parser = subparsers.add_parser("plan", help="Muestra el plan de datasets")
     plan_parser.add_argument("--config", required=True, help="Archivo YAML del proyecto")
-    plan_parser.add_argument("--platform", required=False, help="Plataforma cloud (azure/aws/gcp)")
+    plan_parser.add_argument(
+        "--platform",
+        required=False,
+        help="Plataforma cloud (azure/aws/gcp/fabric)",
+    )
     plan_parser.add_argument("--env", required=False, help="Entorno (dev/test/prod)")
     plan_parser.add_argument("--fail-fast", action="store_true", help="Detener al primer error")
     plan_parser.add_argument(

--- a/datacore/core/engine.py
+++ b/datacore/core/engine.py
@@ -10,6 +10,7 @@ from time import perf_counter
 from typing import Any
 
 from pyspark.sql import DataFrame
+from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 
@@ -20,6 +21,7 @@ from datacore.io import readers, writers
 from datacore.platforms.aws_glue import AwsGluePlatform
 from datacore.platforms.azure_databricks import AzureDatabricksPlatform
 from datacore.platforms.base import LocalPlatform, PlatformBase
+from datacore.platforms.fabric import FabricPlatform
 from datacore.platforms.gcp_dataproc import GcpDataprocPlatform
 from datacore.utils.logging import get_logger
 from datacore.utils import observability
@@ -30,6 +32,7 @@ PLATFORM_MAP = {
     "azure": AzureDatabricksPlatform,
     "aws": AwsGluePlatform,
     "gcp": GcpDataprocPlatform,
+    "fabric": FabricPlatform,
     "local": LocalPlatform,
 }
 
@@ -50,7 +53,20 @@ def _prepare_spark(platform: PlatformBase, config: dict[str, Any]):
         spark_conf["spark.sql.shuffle.partitions"] = spark_section["shuffle_partitions"]
     if "extra_conf" in spark_section:
         spark_conf.update(spark_section["extra_conf"])
-    return platform.build_spark_session(spark_conf)
+    active = SparkSession.getActiveSession()
+    if active is not None and getattr(platform, "reuse_active_session", True):
+        LOGGER.info(
+            "Reusing active SparkSession before building platform session",
+            extra={"platform": platform.name, "event": "spark_session_reuse"},
+        )
+        return active
+
+    session = platform.build_spark_session(spark_conf)
+    LOGGER.info(
+        "SparkSession prepared",
+        extra={"platform": platform.name, "event": "spark_session_ready"},
+    )
+    return session
 
 
 def _resolve_references(value: Any, platform: PlatformBase):

--- a/datacore/platforms/azure_databricks.py
+++ b/datacore/platforms/azure_databricks.py
@@ -7,19 +7,36 @@ from typing import Any
 from pyspark.sql import SparkSession
 
 from datacore.platforms.base import PlatformBase
+from datacore.utils.logging import get_logger
+
+
+LOGGER = get_logger(__name__)
 
 
 class AzureDatabricksPlatform(PlatformBase):
     name = "azure"
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
+        active = SparkSession.getActiveSession()
+        if active is not None:
+            LOGGER.info(
+                "Reusing active SparkSession",
+                extra={"platform": self.name, "event": "spark_session_reuse"},
+            )
+            return active
+
         builder = SparkSession.builder.appName(self.config.get("app_name", "datacore-azure"))
         builder = builder.config("spark.sql.sources.partitionOverwriteMode", "dynamic")
         for key, value in (opts or {}).items():
             builder = builder.config(key, value)
         for key, value in self.config.get("extra_conf", {}).items():
             builder = builder.config(key, value)
-        return builder.getOrCreate()
+        session = builder.getOrCreate()
+        LOGGER.info(
+            "Creating new SparkSession",
+            extra={"platform": self.name, "event": "spark_session_create"},
+        )
+        return session
 
     def _resolve_platform_secret(self, name: str) -> str:
         secrets = self.config.get("secrets", {})

--- a/datacore/platforms/base.py
+++ b/datacore/platforms/base.py
@@ -9,12 +9,17 @@ from typing import Any
 from pyspark.sql import SparkSession
 
 from datacore.utils.paths import normalize_uri
+from datacore.utils.logging import get_logger
+
+
+LOGGER = get_logger(__name__)
 
 
 class PlatformBase(abc.ABC):
     """Interfaz común para plataformas cloud."""
 
     name: str
+    reuse_active_session: bool = True
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         self.config = config or {}
@@ -86,10 +91,23 @@ class LocalPlatform(PlatformBase):
     name = "local"
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
+        active = SparkSession.getActiveSession()
+        if active is not None:
+            LOGGER.info(
+                "Reusing active SparkSession",
+                extra={"platform": self.name, "event": "spark_session_reuse"},
+            )
+            return active
+
         builder = SparkSession.builder.appName(self.config.get("app_name", "datacore-local"))
         for key, value in (opts or {}).items():
             builder = builder.config(key, value)
-        return builder.getOrCreate()
+        session = builder.getOrCreate()
+        LOGGER.info(
+            "Creating new SparkSession",
+            extra={"platform": self.name, "event": "spark_session_create"},
+        )
+        return session
 
     def _resolve_platform_secret(self, name: str) -> str:
         return self.config.get("secrets", {}).get(name, "")

--- a/datacore/platforms/fabric.py
+++ b/datacore/platforms/fabric.py
@@ -1,4 +1,4 @@
-"""Plataforma AWS Glue."""
+"""Plataforma para Microsoft Fabric."""
 
 from __future__ import annotations
 
@@ -13,8 +13,8 @@ from datacore.utils.logging import get_logger
 LOGGER = get_logger(__name__)
 
 
-class AwsGluePlatform(PlatformBase):
-    name = "aws"
+class FabricPlatform(PlatformBase):
+    name = "fabric"
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
         active = SparkSession.getActiveSession()
@@ -25,16 +25,14 @@ class AwsGluePlatform(PlatformBase):
             )
             return active
 
-        builder = SparkSession.builder.appName(self.config.get("app_name", "datacore-aws"))
-        builder = builder.config("spark.sql.sources.partitionOverwriteMode", "dynamic")
-        builder = builder.config(
-            "spark.hadoop.fs.s3a.impl",
-            "org.apache.hadoop.fs.s3a.S3AFileSystem",
+        builder = SparkSession.builder.appName(
+            self.config.get("app_name", "datacore-fabric")
         )
         for key, value in (opts or {}).items():
             builder = builder.config(key, value)
         for key, value in self.config.get("extra_conf", {}).items():
             builder = builder.config(key, value)
+
         session = builder.getOrCreate()
         LOGGER.info(
             "Creating new SparkSession",

--- a/datacore/platforms/gcp_dataproc.py
+++ b/datacore/platforms/gcp_dataproc.py
@@ -7,19 +7,36 @@ from typing import Any
 from pyspark.sql import SparkSession
 
 from datacore.platforms.base import PlatformBase
+from datacore.utils.logging import get_logger
+
+
+LOGGER = get_logger(__name__)
 
 
 class GcpDataprocPlatform(PlatformBase):
     name = "gcp"
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
+        active = SparkSession.getActiveSession()
+        if active is not None:
+            LOGGER.info(
+                "Reusing active SparkSession",
+                extra={"platform": self.name, "event": "spark_session_reuse"},
+            )
+            return active
+
         builder = SparkSession.builder.appName(self.config.get("app_name", "datacore-gcp"))
         builder = builder.config("spark.sql.sources.partitionOverwriteMode", "dynamic")
         for key, value in (opts or {}).items():
             builder = builder.config(key, value)
         for key, value in self.config.get("extra_conf", {}).items():
             builder = builder.config(key, value)
-        return builder.getOrCreate()
+        session = builder.getOrCreate()
+        LOGGER.info(
+            "Creating new SparkSession",
+            extra={"platform": self.name, "event": "spark_session_create"},
+        )
+        return session
 
     def _resolve_platform_secret(self, name: str) -> str:
         secrets = self.config.get("secrets", {})

--- a/tests/unit/test_platform_sessions.py
+++ b/tests/unit/test_platform_sessions.py
@@ -1,0 +1,53 @@
+"""Tests for SparkSession management across platforms."""
+
+from __future__ import annotations
+
+import pytest
+
+from datacore.core.engine import _prepare_spark
+from datacore.platforms.azure_databricks import AzureDatabricksPlatform
+from datacore.platforms.fabric import FabricPlatform
+
+
+@pytest.fixture
+def active_session():
+    return object()
+
+
+def test_azure_platform_reuses_active_session(monkeypatch, active_session):
+    class DummySpark:
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return active_session
+
+    monkeypatch.setattr("datacore.platforms.azure_databricks.SparkSession", DummySpark)
+
+    platform = AzureDatabricksPlatform(config={})
+
+    assert platform.build_spark_session({}) is active_session
+
+
+def test_fabric_platform_reuses_active_session(monkeypatch, active_session):
+    class DummySpark:
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return active_session
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+
+    platform = FabricPlatform(config={})
+
+    assert platform.build_spark_session({}) is active_session
+
+
+def test_prepare_spark_reuses_global_active_session(monkeypatch, active_session):
+    class DummySpark:
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return active_session
+
+    monkeypatch.setattr("datacore.core.engine.SparkSession", DummySpark)
+
+    platform = FabricPlatform(config={})
+
+    assert _prepare_spark(platform, {"spark": {"extra_conf": {"foo": "bar"}}}) is active_session


### PR DESCRIPTION
## Summary
- add a Fabric platform provider and register it in the engine factory
- reuse active SparkSession instances across all Spark platforms and log reuse/creation events
- update CLI help text and add tests covering the new SparkSession reuse paths

## Testing
- python tools/validate_examples_against_layer_schema.py
- python -m datacore.cli plan --config examples/federation/customers_enriched.yaml
- python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e52c3eb5c83209b530b51c79f27cc)