### PR TITLE
Guard Fabric SparkSession creation against duplicate contexts

### DIFF
--- a/datacore/platforms/fabric.py
+++ b/datacore/platforms/fabric.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from pyspark import SparkContext
 from pyspark.sql import SparkSession
 
 from datacore.platforms.base import PlatformBase
@@ -15,27 +16,76 @@ LOGGER = get_logger(__name__)
 
 class FabricPlatform(PlatformBase):
     name = "fabric"
+    reuse_active_session = True
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
         active = SparkSession.getActiveSession()
         if active is not None:
             LOGGER.info(
-                "Reusing active SparkSession",
-                extra={"platform": self.name, "event": "spark_session_reuse"},
+                "Reusing active SparkSession for Fabric",
+                extra={"platform": self.name, "event": "spark_session_reuse_active"},
             )
             return active
+
+        default = SparkSession.getDefaultSession()
+        if default is not None:
+            LOGGER.info(
+                "Reusing default SparkSession for Fabric",
+                extra={"platform": self.name, "event": "spark_session_reuse_default"},
+            )
+            return default
+
+        instantiated = getattr(SparkSession, "_instantiatedSession", None)
+        if instantiated is not None:
+            LOGGER.info(
+                "Reusing instantiated SparkSession for Fabric",
+                extra={
+                    "platform": self.name,
+                    "event": "spark_session_reuse_instantiated",
+                },
+            )
+            return instantiated
+
+        active_sc = getattr(SparkContext, "_active_spark_context", None)
+        if active_sc is not None:
+            try:
+                session = SparkSession(active_sc)
+                LOGGER.info(
+                    "Attached to existing active SparkContext for Fabric",
+                    extra={
+                        "platform": self.name,
+                        "event": "spark_session_attach_active_sparkcontext",
+                    },
+                )
+                return session
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.error(
+                    "Unable to attach to existing SparkContext in Fabric",
+                    extra={
+                        "platform": self.name,
+                        "event": "spark_session_attach_failed",
+                        "error": str(exc),
+                    },
+                )
+                raise RuntimeError(
+                    "FabricPlatform detected an existing SparkContext but could not "
+                    "attach a SparkSession. Do not create a new SparkContext in Fabric; "
+                    "ensure you are running inside a managed Fabric Spark environment."
+                ) from exc
 
         builder = SparkSession.builder.appName(
             self.config.get("app_name", "datacore-fabric")
         )
+
         for key, value in (opts or {}).items():
             builder = builder.config(key, value)
+
         for key, value in self.config.get("extra_conf", {}).items():
             builder = builder.config(key, value)
 
         session = builder.getOrCreate()
         LOGGER.info(
-            "Creating new SparkSession",
+            "Creating new SparkSession for Fabric (no active context found)",
             extra={"platform": self.name, "event": "spark_session_create"},
         )
         return session

--- a/tests/unit/test_platform_sessions.py
+++ b/tests/unit/test_platform_sessions.py
@@ -28,16 +28,170 @@ def test_azure_platform_reuses_active_session(monkeypatch, active_session):
 
 
 def test_fabric_platform_reuses_active_session(monkeypatch, active_session):
+    class DummyBuilder:
+        def appName(self, _):  # pragma: no cover - should not be called
+            raise AssertionError("builder.appName should not be invoked")
+
     class DummySpark:
+        builder = DummyBuilder()
+
         @staticmethod
         def getActiveSession():  # noqa: N802 - keep pyspark naming
             return active_session
 
+        @staticmethod
+        def getDefaultSession():  # noqa: N802
+            raise AssertionError("getDefaultSession should not be called")
+
     monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", object())
 
     platform = FabricPlatform(config={})
 
     assert platform.build_spark_session({}) is active_session
+
+
+def test_fabric_platform_reuses_default_session(monkeypatch):
+    default_session = object()
+
+    class DummyBuilder:
+        def appName(self, _):  # pragma: no cover - should not be called
+            raise AssertionError("builder.appName should not be invoked")
+
+    class DummySpark:
+        builder = DummyBuilder()
+        _instantiatedSession = None
+
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+        @staticmethod
+        def getDefaultSession():  # noqa: N802 - keep pyspark naming
+            return default_session
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", object())
+
+    platform = FabricPlatform(config={})
+
+    assert platform.build_spark_session({}) is default_session
+
+
+def test_fabric_platform_reuses_instantiated_session(monkeypatch):
+    instantiated_session = object()
+
+    class DummyBuilder:
+        def appName(self, _):  # pragma: no cover - should not be called
+            raise AssertionError("builder.appName should not be invoked")
+
+    class DummySpark:
+        builder = DummyBuilder()
+        _instantiatedSession = instantiated_session
+
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+        @staticmethod
+        def getDefaultSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", object())
+
+    platform = FabricPlatform(config={})
+
+    assert platform.build_spark_session({}) is instantiated_session
+
+
+def test_fabric_platform_attaches_active_spark_context(monkeypatch):
+    active_sc = object()
+
+    class DummyBuilder:
+        def appName(self, _):  # pragma: no cover - should not be called
+            raise AssertionError("builder.appName should not be invoked")
+
+    class DummySpark:
+        builder = DummyBuilder()
+        _instantiatedSession = None
+
+        def __init__(self, sc):
+            self.sc = sc
+
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+        @staticmethod
+        def getDefaultSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+    class DummySparkContext:
+        _active_spark_context = active_sc
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", DummySparkContext)
+
+    platform = FabricPlatform(config={})
+
+    session = platform.build_spark_session({})
+
+    assert isinstance(session, DummySpark)
+    assert session.sc is active_sc
+
+
+def test_fabric_platform_creates_new_session_when_no_context(monkeypatch):
+    created = object()
+
+    class RecordingBuilder:
+        def __init__(self):
+            self.app_name = None
+            self.configs = []
+
+        def appName(self, name):
+            self.app_name = name
+            return self
+
+        def config(self, key, value):
+            self.configs.append((key, value))
+            return self
+
+        def getOrCreate(self):  # noqa: N802 - keep pyspark naming
+            return created
+
+    class DummySpark:
+        builder = RecordingBuilder()
+        _instantiatedSession = None
+
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+        @staticmethod
+        def getDefaultSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+    class DummySparkContext:
+        _active_spark_context = None
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", DummySparkContext)
+
+    platform = FabricPlatform(
+        config={
+            "app_name": "custom-app",
+            "extra_conf": {"spark.sql.shuffle.partitions": "4"},
+        }
+    )
+
+    session = platform.build_spark_session({"spark.executor.instances": "2"})
+
+    assert session is created
+    builder = DummySpark.builder
+    assert builder.app_name == "custom-app"
+    assert ("spark.executor.instances", "2") in builder.configs
+    assert ("spark.sql.shuffle.partitions", "4") in builder.configs
 
 
 def test_prepare_spark_reuses_global_active_session(monkeypatch, active_session):


### PR DESCRIPTION
## Summary
- ensure FabricPlatform reuses or attaches to existing Spark sessions and SparkContexts before attempting to create new ones so managed Fabric runtimes avoid duplicate SparkContext errors
- add unit tests that cover Fabric session reuse, context attachment, and new session creation paths

## Testing
- python tools/validate_examples_against_layer_schema.py
- python -m datacore.cli plan --config examples/federation/customers_enriched.yaml > plan.json
- python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8548ce3083208352c9cb4bfe7db8)