### PR TITLE
Harden Fabric Spark session reuse logic

### DIFF
--- a/datacore/platforms/fabric.py
+++ b/datacore/platforms/fabric.py
@@ -19,21 +19,31 @@ class FabricPlatform(PlatformBase):
     reuse_active_session = True
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
-        active = SparkSession.getActiveSession()
-        if active is not None:
-            LOGGER.info(
-                "Reusing active SparkSession for Fabric",
-                extra={"platform": self.name, "event": "spark_session_reuse_active"},
-            )
-            return active
+        get_active = getattr(SparkSession, "getActiveSession", None)
+        if callable(get_active):
+            active = get_active()
+            if active is not None:
+                LOGGER.info(
+                    "Reusing active SparkSession for Fabric",
+                    extra={
+                        "platform": self.name,
+                        "event": "spark_session_reuse_active",
+                    },
+                )
+                return active
 
-        default = SparkSession.getDefaultSession()
-        if default is not None:
-            LOGGER.info(
-                "Reusing default SparkSession for Fabric",
-                extra={"platform": self.name, "event": "spark_session_reuse_default"},
-            )
-            return default
+        get_default = getattr(SparkSession, "getDefaultSession", None)
+        if callable(get_default):
+            default = get_default()
+            if default is not None:
+                LOGGER.info(
+                    "Reusing default SparkSession for Fabric",
+                    extra={
+                        "platform": self.name,
+                        "event": "spark_session_reuse_default",
+                    },
+                )
+                return default
 
         instantiated = getattr(SparkSession, "_instantiatedSession", None)
         if instantiated is not None:
@@ -49,7 +59,7 @@ class FabricPlatform(PlatformBase):
         active_sc = getattr(SparkContext, "_active_spark_context", None)
         if active_sc is not None:
             try:
-                session = SparkSession(active_sc)
+                session = SparkSession.builder.getOrCreate()
                 LOGGER.info(
                     "Attached to existing active SparkContext for Fabric",
                     extra={
@@ -58,7 +68,7 @@ class FabricPlatform(PlatformBase):
                     },
                 )
                 return session
-            except Exception as exc:  # pragma: no cover - defensive
+            except Exception as exc:  # pragma: no cover
                 LOGGER.error(
                     "Unable to attach to existing SparkContext in Fabric",
                     extra={
@@ -69,8 +79,8 @@ class FabricPlatform(PlatformBase):
                 )
                 raise RuntimeError(
                     "FabricPlatform detected an existing SparkContext but could not "
-                    "attach a SparkSession. Do not create a new SparkContext in Fabric; "
-                    "ensure you are running inside a managed Fabric Spark environment."
+                    "attach a SparkSession. Avoid creating a new SparkContext in "
+                    "Microsoft Fabric managed environments."
                 ) from exc
 
         builder = SparkSession.builder.appName(

--- a/tests/unit/test_platform_sessions.py
+++ b/tests/unit/test_platform_sessions.py
@@ -106,18 +106,25 @@ def test_fabric_platform_reuses_instantiated_session(monkeypatch):
 
 
 def test_fabric_platform_attaches_active_spark_context(monkeypatch):
-    active_sc = object()
+    attached_session = object()
 
-    class DummyBuilder:
+    class RecordingBuilder:
+        def __init__(self):
+            self.get_or_create_calls = 0
+
+        def getOrCreate(self):  # noqa: N802 - keep pyspark naming
+            self.get_or_create_calls += 1
+            return attached_session
+
         def appName(self, _):  # pragma: no cover - should not be called
-            raise AssertionError("builder.appName should not be invoked")
+            raise AssertionError("appName should not be used when attaching")
+
+        def config(self, *_args, **_kwargs):  # pragma: no cover - defensive
+            raise AssertionError("config should not be used when attaching")
 
     class DummySpark:
-        builder = DummyBuilder()
+        builder = RecordingBuilder()
         _instantiatedSession = None
-
-        def __init__(self, sc):
-            self.sc = sc
 
         @staticmethod
         def getActiveSession():  # noqa: N802 - keep pyspark naming
@@ -128,7 +135,7 @@ def test_fabric_platform_attaches_active_spark_context(monkeypatch):
             return None
 
     class DummySparkContext:
-        _active_spark_context = active_sc
+        _active_spark_context = object()
 
     monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
     monkeypatch.setattr("datacore.platforms.fabric.SparkContext", DummySparkContext)
@@ -137,8 +144,8 @@ def test_fabric_platform_attaches_active_spark_context(monkeypatch):
 
     session = platform.build_spark_session({})
 
-    assert isinstance(session, DummySpark)
-    assert session.sc is active_sc
+    assert session is attached_session
+    assert DummySpark.builder.get_or_create_calls == 1
 
 
 def test_fabric_platform_creates_new_session_when_no_context(monkeypatch):
@@ -192,6 +199,52 @@ def test_fabric_platform_creates_new_session_when_no_context(monkeypatch):
     assert builder.app_name == "custom-app"
     assert ("spark.executor.instances", "2") in builder.configs
     assert ("spark.sql.shuffle.partitions", "4") in builder.configs
+
+
+def test_fabric_platform_handles_missing_getactive(monkeypatch):
+    default_session = object()
+
+    class DummyBuilder:
+        def appName(self, _):  # pragma: no cover - should not be called
+            raise AssertionError("builder.appName should not be invoked")
+
+    class DummySpark:
+        builder = DummyBuilder()
+        _instantiatedSession = None
+
+        @staticmethod
+        def getDefaultSession():  # noqa: N802 - keep pyspark naming
+            return default_session
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", object())
+
+    platform = FabricPlatform(config={})
+
+    assert platform.build_spark_session({}) is default_session
+
+
+def test_fabric_platform_handles_missing_getdefault(monkeypatch):
+    instantiated_session = object()
+
+    class DummyBuilder:
+        def appName(self, _):  # pragma: no cover - should not be called
+            raise AssertionError("builder.appName should not be invoked")
+
+    class DummySpark:
+        builder = DummyBuilder()
+        _instantiatedSession = instantiated_session
+
+        @staticmethod
+        def getActiveSession():  # noqa: N802 - keep pyspark naming
+            return None
+
+    monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySpark)
+    monkeypatch.setattr("datacore.platforms.fabric.SparkContext", object())
+
+    platform = FabricPlatform(config={})
+
+    assert platform.build_spark_session({}) is instantiated_session
 
 
 def test_prepare_spark_reuses_global_active_session(monkeypatch, active_session):


### PR DESCRIPTION
## Summary
- make Fabric Spark session reuse resilient to runtimes lacking certain SparkSession APIs
- reuse existing SparkContext safely before creating new sessions and keep structured logging
- extend Fabric platform tests to cover optional API absence and active context attachment

## Testing
- python tools/validate_examples_against_layer_schema.py
- python -m datacore.cli plan --config examples/federation/customers_enriched.yaml > plan.json
- python tools/validate_plan_against_schema.py plan.json datacore/config/schemas/plan.schema.json
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8f71c71c83208bb103d30621b2b2)