### PR TITLE
Align Fabric Lakehouse sink with managed tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,27 @@ prodi run --layer bronze --config configs/envs/dev/layers/bronze.yml
 
 ## Documentación adicional
 Toda la documentación vive en `docs/`. Consulta `docs/architecture.md` para comprender la nueva arquitectura hexagonal y los puertos/adaptadores implementados.
+
+## Microsoft Fabric Lakehouse
+
+Para escribir en tablas administradas de Fabric sin generar carpetas "Unidentified", utiliza el backend `fabric` junto con una URI `lakehouse://<lakehouse>/tables/<esquema>/<tabla>`:
+
+```yaml
+sink:
+  type: storage
+  backend: fabric
+  uri: "lakehouse://contoso-lh/tables/dbo/customers_raw"
+  options:
+    mode: overwrite
+```
+
+Si quieres dejar archivos en bruto dentro de OneLake, apunta a la ruta `Files/` y se mantendrá el comportamiento estilo archivos:
+
+```yaml
+sink:
+  type: storage
+  backend: fabric
+  uri: "https://onelake.dfs.fabric.microsoft.com/workspaces/<ws>/Lakehouses/<lh>/Files/raw/snapshot"
+  options:
+    mode: append
+```

--- a/datacore/providers/fabric/lakehouse.py
+++ b/datacore/providers/fabric/lakehouse.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from time import perf_counter
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 
 LOGGER = logging.getLogger(__name__)
@@ -16,20 +17,116 @@ def _spark():
     return SparkSession.builder.getOrCreate()
 
 
+def _fabric_table_from_uri(uri: str) -> tuple[bool, Optional[tuple[str, str]]]:
+    """Return schema/table when the URI points to a Fabric Lakehouse table."""
+
+    if not uri:
+        return False, None
+
+    parsed = urlparse(uri)
+    segments: list[str] = []
+    if parsed.netloc:
+        segments.append(parsed.netloc)
+    segments.extend(seg for seg in parsed.path.split("/") if seg)
+
+    if not segments:
+        return False, None
+
+    tables_index: Optional[int] = next(
+        (idx for idx, value in enumerate(segments) if value.lower() == "tables"),
+        None,
+    )
+    if tables_index is None:
+        return False, None
+
+    remainder = segments[tables_index + 1 :]
+    if not remainder:
+        return True, None
+
+    schema: Optional[str]
+    table: Optional[str]
+    if len(remainder) == 1:
+        item = remainder[0]
+        if "." in item:
+            schema, table = item.split(".", 1)
+        else:
+            schema, table = "dbo", item
+    else:
+        schema = remainder[0] or "dbo"
+        table = remainder[1] if len(remainder) > 1 else None
+
+    if not table:
+        return True, None
+
+    return True, (schema or "dbo", table)
+
+
 def write_delta(env, df, table_uri: str, options: Dict[str, Any]) -> None:
     """Escribe un DataFrame en Delta y ejecuta mantenimiento opcional."""
 
     spark = _spark()
     start = perf_counter()
-    writer = df.write.format("delta").mode(options.get("mode", "append"))
+    opts: Dict[str, Any] = options or {}
+    writer = df.write.format("delta")
     extra = {
         k: str(v)
-        for k, v in (options or {}).items()
+        for k, v in opts.items()
         if k not in {"mode", "optimize", "vacuum_hours", "zorder"}
     }
     if extra:
         writer = writer.options(**extra)
-    writer.save(table_uri)
+    mode_value = str(opts.get("mode", "append"))
+    normalized_mode = mode_value.lower()
+    is_tables_uri, table_identifier = _fabric_table_from_uri(table_uri)
+
+    if table_identifier:
+        schema, table = table_identifier
+        LOGGER.info(
+            "Fabric Lakehouse table sink detected",
+            extra={
+                "platform": "fabric",
+                "event": "fabric_table_sink_detected",
+                "schema": schema,
+                "table": table,
+                "uri": table_uri,
+            },
+        )
+        if normalized_mode == "overwrite":
+            writer = writer.mode("overwrite").option("overwriteSchema", "true")
+        else:
+            writer = writer.mode("append") if normalized_mode == "append" else writer.mode(mode_value)
+        LOGGER.info(
+            "Usando saveAsTable para Lakehouse",
+            extra={
+                "platform": "fabric",
+                "event": "fabric_table_saveas",
+                "schema": schema,
+                "table": table,
+                "mode": normalized_mode,
+                "uri": table_uri,
+            },
+        )
+        writer.saveAsTable(f"{schema}.{table}")
+    else:
+        if is_tables_uri:
+            LOGGER.warning(
+                "No se pudo interpretar la ruta de tabla de Fabric",
+                extra={
+                    "platform": "fabric",
+                    "event": "fabric_table_parse_failed",
+                    "uri": table_uri,
+                },
+            )
+        LOGGER.info(
+            "Escritura estilo archivos para Fabric",
+            extra={
+                "platform": "fabric",
+                "event": "fabric_file_sink",
+                "uri": table_uri,
+            },
+        )
+        writer = writer.mode(mode_value)
+        writer.save(table_uri)
     duration = perf_counter() - start
     LOGGER.info(
         "Escritura Delta completada",

--- a/docs/fabric.md
+++ b/docs/fabric.md
@@ -65,6 +65,30 @@ El módulo `datacore.providers.fabric.lakehouse` utiliza `delta-spark` para leer
 
 Los secretos referenciados como `secret://kv/<vault>/<secret>` se resuelven automáticamente mediante Azure Key Vault (`DefaultAzureCredential`). Para otros backends (`secret://sm/`, `secret://gcp/`) se delega en AWS Secrets Manager o Google Secret Manager respectivamente, devolviendo errores claros si las dependencias no están instaladas.
 
+### Escritura en tablas administradas
+
+Cuando el `sink` apunta a un Lakehouse de Fabric utilizando el backend `fabric` y la ruta `lakehouse://<nombre_lakehouse>/tables/<esquema>/<tabla>`, el motor escribe directamente con `saveAsTable`. Esto genera el layout Delta administrado que espera la UI de Fabric, sin carpetas intermedias "Unidentified/Sin identificar".
+
+```yaml
+sink:
+  type: storage
+  backend: fabric
+  uri: "lakehouse://contoso-lh/tables/dbo/customers_raw"
+  options:
+    mode: overwrite
+```
+
+Para rutas que apuntan a `Files/`, el comportamiento continúa siendo estilo archivos (`writer.save(path)`), útil para aterrizar datos crudos o stageados:
+
+```yaml
+sink:
+  type: storage
+  backend: fabric
+  uri: "https://onelake.dfs.fabric.microsoft.com/workspaces/<ws>/Lakehouses/<lh>/Files/landing/sales/"
+  options:
+    mode: append
+```
+
 ## Warehouse y SQL Endpoint
 
 El módulo `datacore.providers.fabric.warehouse` incluye utilidades para crear o actualizar vistas (`CREATE OR ALTER VIEW` apuntando a tablas Delta) y ejecutar operaciones `COPY INTO` con opciones de tolerancia (`MAXERRORS`, patrones de archivos, particiones). Las peticiones se envían al endpoint REST del Warehouse y registran acción y destino en los logs.

--- a/examples/fabric/bronze_shortcut.yaml
+++ b/examples/fabric/bronze_shortcut.yaml
@@ -19,7 +19,7 @@ datasets:
     sink:
       type: storage
       backend: delta
-      uri: "lakehouse://tables/bronze/sales_shortcut"
+      uri: "lakehouse://contoso-lh/tables/dbo/sales_shortcut"
     incremental:
       mode: append
     orchestration:

--- a/examples/fabric/silver_federation.yaml
+++ b/examples/fabric/silver_federation.yaml
@@ -32,7 +32,7 @@ datasets:
     sink:
       type: storage
       backend: delta
-      uri: "lakehouse://tables/silver/customers_enriched"
+      uri: "lakehouse://contoso-lh/tables/silver/customers_enriched"
     incremental:
       mode: merge
       keys: ["email"]

--- a/tests/unit/providers/fabric/test_lakehouse.py
+++ b/tests/unit/providers/fabric/test_lakehouse.py
@@ -13,6 +13,8 @@ class DummyWriter:
         self.mode_value = None
         self.options_value = {}
         self.saved_path = None
+        self.save_as_table_name = None
+        self.mode_calls: list[str] = []
 
     def format(self, value):
         self.format_value = value
@@ -20,14 +22,22 @@ class DummyWriter:
 
     def mode(self, value):
         self.mode_value = value
+        self.mode_calls.append(value)
         return self
 
     def options(self, **kwargs):
         self.options_value.update(kwargs)
         return self
 
+    def option(self, key, value):
+        self.options_value[key] = value
+        return self
+
     def save(self, path):
         self.saved_path = path
+
+    def saveAsTable(self, table):
+        self.save_as_table_name = table
 
 
 class DummyDataFrame:
@@ -50,15 +60,25 @@ def dummy_spark(monkeypatch):
     return spark
 
 
-def test_write_delta_invokes_writer(dummy_spark):
+def test_write_delta_uses_save_as_table_for_lakehouse_tables(dummy_spark):
     df = DummyDataFrame()
     options = {"mode": "overwrite", "mergeSchema": True, "maxRecordsPerFile": 1000}
-    lakehouse.write_delta(None, df, "lakehouse://tables/bronze/demo", options)
+    lakehouse.write_delta(
+        None,
+        df,
+        "lakehouse://contoso-lh/tables/dbo/customers_raw",
+        options,
+    )
     writer = df.write
     assert writer.format_value == "delta"
     assert writer.mode_value == "overwrite"
-    assert writer.options_value == {"mergeSchema": "True", "maxRecordsPerFile": "1000"}
-    assert writer.saved_path == "lakehouse://tables/bronze/demo"
+    assert writer.options_value == {
+        "mergeSchema": "True",
+        "maxRecordsPerFile": "1000",
+        "overwriteSchema": "true",
+    }
+    assert writer.save_as_table_name == "dbo.customers_raw"
+    assert writer.saved_path is None
 
 
 def test_optimize_delta_generates_sql(dummy_spark):
@@ -79,3 +99,31 @@ def test_optimize_delta_with_zorder(dummy_spark):
     assert dummy_spark.sql_calls == [
         "OPTIMIZE delta.`lakehouse://tables/silver/demo` ZORDER BY (col_a, col_b)",
     ]
+
+
+def test_write_delta_keeps_file_behavior_for_files_uri(dummy_spark):
+    df = DummyDataFrame()
+    lakehouse.write_delta(
+        None,
+        df,
+        "https://onelake.dfs.fabric.microsoft.com/workspaces/ws/TablesLakehouse/Files/raw/snapshot",
+        {"mode": "append"},
+    )
+    writer = df.write
+    assert writer.save_as_table_name is None
+    assert writer.saved_path == "https://onelake.dfs.fabric.microsoft.com/workspaces/ws/TablesLakehouse/Files/raw/snapshot"
+    assert writer.mode_calls[-1] == "append"
+
+
+def test_write_delta_detects_onelake_tables_url(dummy_spark):
+    df = DummyDataFrame()
+    lakehouse.write_delta(
+        None,
+        df,
+        "https://onelake.dfs.fabric.microsoft.com/workspaces/ws/Lakehouses/lh/Tables/sales/customers",
+        {"mode": "append"},
+    )
+    writer = df.write
+    assert writer.save_as_table_name == "sales.customers"
+    assert writer.saved_path is None
+    assert writer.mode_calls[-1] == "append"


### PR DESCRIPTION
## Summary
- detect Fabric Lakehouse table URIs and persist tables with saveAsTable to avoid unidentified folders
- retain file-style writes for Files paths while documenting updated Fabric sink usage
- add unit coverage for Fabric Lakehouse table detection and OneLake URL handling

## Testing
- pytest tests/unit/providers/fabric/test_lakehouse.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e5701db083208d6ef5b56efc6d7c)