### PR TITLE
Align Fabric lakehouse storage semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,32 @@ Toda la documentación vive en `docs/`. Consulta `docs/architecture.md` para com
 
 ## Microsoft Fabric Lakehouse
 
-Para escribir en tablas administradas de Fabric sin generar carpetas "Unidentified", utiliza el backend `fabric` junto con una URI `lakehouse://<lakehouse>/tables/<esquema>/<tabla>`:
+Para leer y escribir tablas administradas de Fabric sin generar carpetas "Unidentified", utiliza el backend `fabric` junto con una URI `lakehouse://<lakehouse>/tables/<esquema>/<tabla>` y el motor resolverá automáticamente el catálogo de Fabric (`saveAsTable`/`spark.table`).
 
 ```yaml
-sink:
+source:
   type: storage
   backend: fabric
+  format: delta
   uri: "lakehouse://contoso-lh/tables/dbo/customers_raw"
-  options:
-    mode: overwrite
+
+sink:
+  type: storage
+  backend: fabric
+  format: delta
+  uri: "lakehouse://contoso-lh/tables/dbo/customers_curated"
+  mode: overwrite
 ```
 
-Si quieres dejar archivos en bruto dentro de OneLake, apunta a la ruta `Files/` y se mantendrá el comportamiento estilo archivos:
+Para trabajar con archivos crudos en `Files/`, también puedes usar el esquema `lakehouse://`. El motor los convertirá a la ruta física del Lakehouse adjunto antes de llamar a `.load`/`.save`:
 
 ```yaml
 sink:
   type: storage
   backend: fabric
-  uri: "https://onelake.dfs.fabric.microsoft.com/workspaces/<ws>/Lakehouses/<lh>/Files/raw/snapshot"
-  options:
-    mode: append
+  format: delta
+  uri: "lakehouse://contoso-lh/files/raw/sales/customers_delta"
+  mode: append
 ```
+
+> ⚠️ Si apuntas explícitamente a `https://onelake.dfs.fabric.microsoft.com/.../Tables/...` se realizará una escritura estilo archivos, lo que puede producir carpetas "Unidentified/Sin identificar" en Fabric. Usa `lakehouse://.../tables/...` para tablas administradas.

--- a/datacore/connectors/storage/fabric.py
+++ b/datacore/connectors/storage/fabric.py
@@ -24,7 +24,7 @@ def _apply_common_writer(
     df: DataFrame,
     fmt: str,
     options: dict[str, Any],
-    mode: str,
+    mode: str | None,
     partition_by: list[str] | None,
     merge_schema: bool | None,
 ):
@@ -35,7 +35,8 @@ def _apply_common_writer(
         writer = writer.option("mergeSchema", str(merge_schema).lower())
     for key, value in options.items():
         writer = writer.option(key, value)
-    return writer.mode(mode)
+    resolved_mode = mode or "append"
+    return writer.mode(resolved_mode)
 
 
 def _log_managed_table(event: str, ref: FabricLakehouseReference, *, mode: str) -> None:
@@ -95,7 +96,7 @@ def write(
     merge_schema: bool | None = None,
 ) -> None:
     ref = parse_fabric_lakehouse_uri(uri)
-    normalized_mode = str(mode).lower()
+    normalized_mode = (mode or "").lower()
 
     if ref.is_lakehouse and ref.kind == "tables" and ref.full_table_name:
         writer = df.write.format(fmt)
@@ -107,21 +108,32 @@ def write(
             writer = writer.option(key, value)
         if normalized_mode == "overwrite":
             writer = writer.mode("overwrite").option("overwriteSchema", "true")
+            effective_mode = "overwrite"
+        elif normalized_mode == "append":
+            writer = writer.mode("append")
+            effective_mode = "append"
         elif normalized_mode:
             writer = writer.mode(mode)
+            effective_mode = normalized_mode
         else:
             writer = writer.mode("append")
-        _log_managed_table("fabric_save_as_managed_table", ref, mode=normalized_mode or mode)
+            effective_mode = "append"
+        _log_managed_table(
+            "fabric_save_as_managed_table",
+            ref,
+            mode=effective_mode,
+        )
         writer.saveAsTable(ref.full_table_name)
         return
 
     if ref.is_lakehouse and ref.kind == "files" and ref.lakehouse:
         resolved = resolve_fabric_files_path(ref)
+        effective_mode = normalized_mode or (mode or "append")
         writer = _apply_common_writer(
             df,
             fmt,
             options,
-            mode,
+            effective_mode,
             partition_by,
             merge_schema,
         )
@@ -132,7 +144,7 @@ def write(
                 "backend": "fabric",
                 "lakehouse": ref.lakehouse,
                 "resolved_path": resolved,
-                "mode": mode,
+                "mode": effective_mode,
             },
         )
         writer.save(resolved)

--- a/datacore/connectors/storage/fabric.py
+++ b/datacore/connectors/storage/fabric.py
@@ -1,0 +1,149 @@
+"""Fabric Lakehouse storage connector."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
+
+from datacore.providers.fabric.uris import (
+    FabricLakehouseReference,
+    parse_fabric_lakehouse_uri,
+    resolve_fabric_files_path,
+)
+from datacore.utils.logging import get_logger
+
+from . import local
+
+
+LOGGER = get_logger(__name__)
+
+
+def _apply_common_writer(
+    df: DataFrame,
+    fmt: str,
+    options: dict[str, Any],
+    mode: str,
+    partition_by: list[str] | None,
+    merge_schema: bool | None,
+):
+    writer = df.write.format(fmt)
+    if partition_by:
+        writer = writer.partitionBy(*partition_by)
+    if merge_schema is not None:
+        writer = writer.option("mergeSchema", str(merge_schema).lower())
+    for key, value in options.items():
+        writer = writer.option(key, value)
+    return writer.mode(mode)
+
+
+def _log_managed_table(event: str, ref: FabricLakehouseReference, *, mode: str) -> None:
+    LOGGER.info(
+        "Fabric managed table operation",
+        extra={
+            "event": event,
+            "backend": "fabric",
+            "lakehouse": ref.lakehouse,
+            "schema": ref.schema,
+            "table": ref.table,
+            "mode": mode,
+        },
+    )
+
+
+def read(
+    spark: SparkSession,
+    uri: str,
+    fmt: str,
+    options: dict[str, Any],
+    *,
+    schema: StructType | None = None,
+):
+    ref = parse_fabric_lakehouse_uri(uri)
+    if ref.is_lakehouse and ref.kind == "tables" and ref.full_table_name:
+        _log_managed_table("fabric_read_managed_table", ref, mode="read")
+        return spark.table(ref.full_table_name)
+    if ref.is_lakehouse and ref.kind == "files" and ref.lakehouse:
+        resolved = resolve_fabric_files_path(ref)
+        reader = spark.read.format(fmt)
+        for key, value in options.items():
+            reader = reader.option(key, value)
+        if schema is not None:
+            reader = reader.schema(schema)
+        LOGGER.info(
+            "Fabric files read",
+            extra={
+                "event": "fabric_read_files_path",
+                "backend": "fabric",
+                "lakehouse": ref.lakehouse,
+                "resolved_path": resolved,
+            },
+        )
+        return reader.load(resolved)
+    return local.read(spark, uri, fmt, options, schema=schema)
+
+
+def write(
+    df: DataFrame,
+    uri: str,
+    fmt: str,
+    mode: str,
+    options: dict[str, Any],
+    *,
+    partition_by: list[str] | None = None,
+    merge_schema: bool | None = None,
+) -> None:
+    ref = parse_fabric_lakehouse_uri(uri)
+    normalized_mode = str(mode).lower()
+
+    if ref.is_lakehouse and ref.kind == "tables" and ref.full_table_name:
+        writer = df.write.format(fmt)
+        if partition_by:
+            writer = writer.partitionBy(*partition_by)
+        if merge_schema is not None:
+            writer = writer.option("mergeSchema", str(merge_schema).lower())
+        for key, value in options.items():
+            writer = writer.option(key, value)
+        if normalized_mode == "overwrite":
+            writer = writer.mode("overwrite").option("overwriteSchema", "true")
+        elif normalized_mode:
+            writer = writer.mode(mode)
+        else:
+            writer = writer.mode("append")
+        _log_managed_table("fabric_save_as_managed_table", ref, mode=normalized_mode or mode)
+        writer.saveAsTable(ref.full_table_name)
+        return
+
+    if ref.is_lakehouse and ref.kind == "files" and ref.lakehouse:
+        resolved = resolve_fabric_files_path(ref)
+        writer = _apply_common_writer(
+            df,
+            fmt,
+            options,
+            mode,
+            partition_by,
+            merge_schema,
+        )
+        LOGGER.info(
+            "Fabric files write",
+            extra={
+                "event": "fabric_write_files_path",
+                "backend": "fabric",
+                "lakehouse": ref.lakehouse,
+                "resolved_path": resolved,
+                "mode": mode,
+            },
+        )
+        writer.save(resolved)
+        return
+
+    local.write(
+        df,
+        uri,
+        fmt,
+        mode,
+        options,
+        partition_by=partition_by,
+        merge_schema=merge_schema,
+    )

--- a/datacore/io/readers.py
+++ b/datacore/io/readers.py
@@ -13,7 +13,7 @@ from pyspark.sql.types import StructType
 from datacore.connectors.api import graphql, rest
 from datacore.connectors import http
 from datacore.connectors.db import jdbc
-from datacore.connectors.storage import abfs, gcs, local, s3
+from datacore.connectors.storage import abfs, fabric, gcs, local, s3
 from datacore.platforms.base import PlatformBase
 from datacore.io import shortcuts
 
@@ -69,6 +69,7 @@ def _storage_connector(backend: str):
         "aws": s3,
         "azure": abfs,
         "gcp": gcs,
+        "fabric": fabric,
         "local": local,
     }
     return connectors.get(backend, local)

--- a/datacore/io/writers.py
+++ b/datacore/io/writers.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no cover - entornos sin boto3
 from pyspark.sql import DataFrame
 
 from datacore.connectors.db import jdbc
-from datacore.connectors.storage import abfs, gcs, local, s3
+from datacore.connectors.storage import abfs, fabric, gcs, local, s3
 from datacore.platforms.base import PlatformBase
 from datacore.utils.logging import get_logger
 
@@ -26,6 +26,7 @@ def _storage_connector(backend: str):
         "aws": s3,
         "azure": abfs,
         "gcp": gcs,
+        "fabric": fabric,
         "local": local,
     }
     return connectors.get(backend, local)

--- a/datacore/platforms/fabric.py
+++ b/datacore/platforms/fabric.py
@@ -19,53 +19,56 @@ class FabricPlatform(PlatformBase):
     reuse_active_session = True
 
     def build_spark_session(self, opts: dict[str, Any] | None = None) -> SparkSession:
+        opts = opts or {}
+        extra_conf = self.config.get("extra_conf", {})
+        config_items = list(opts.items()) + list(extra_conf.items())
+
+        def _log(event: str, message: str) -> None:
+            LOGGER.info(message, extra={"platform": self.name, "event": event})
+
         get_active = getattr(SparkSession, "getActiveSession", None)
         if callable(get_active):
-            active = get_active()
-            if active is not None:
-                LOGGER.info(
-                    "Reusing active SparkSession for Fabric",
-                    extra={
-                        "platform": self.name,
-                        "event": "spark_session_reuse_active",
-                    },
-                )
-                return active
+            active_session = get_active()
+            if active_session is not None:
+                _log("spark_session_reuse", "Reusing active SparkSession for Fabric")
+                return active_session
 
         get_default = getattr(SparkSession, "getDefaultSession", None)
         if callable(get_default):
-            default = get_default()
-            if default is not None:
-                LOGGER.info(
-                    "Reusing default SparkSession for Fabric",
-                    extra={
-                        "platform": self.name,
-                        "event": "spark_session_reuse_default",
-                    },
-                )
-                return default
+            default_session = get_default()
+            if default_session is not None:
+                _log("spark_session_reuse", "Reusing default SparkSession for Fabric")
+                return default_session
 
-        instantiated = getattr(SparkSession, "_instantiatedSession", None)
-        if instantiated is not None:
-            LOGGER.info(
-                "Reusing instantiated SparkSession for Fabric",
-                extra={
-                    "platform": self.name,
-                    "event": "spark_session_reuse_instantiated",
-                },
-            )
-            return instantiated
+        instantiated_session = getattr(SparkSession, "_instantiatedSession", None)
+        if instantiated_session is not None:
+            _log("spark_session_reuse", "Reusing instantiated SparkSession for Fabric")
+            return instantiated_session
 
-        active_sc = getattr(SparkContext, "_active_spark_context", None)
-        if active_sc is not None:
-            sc = SparkContext.getOrCreate()
-            session = SparkSession(sc)
-            LOGGER.info(
+        get_active_context = getattr(SparkContext, "getActive", None)
+        active_context = None
+        if callable(get_active_context):
+            active_context = get_active_context()
+        if active_context is None:
+            active_context = getattr(SparkContext, "_active_spark_context", None)
+
+        if active_context is not None:
+            session = SparkSession(active_context)
+            for key, value in config_items:
+                try:
+                    session.conf.set(key, value)
+                except Exception:  # pragma: no cover - depends on runtime support
+                    LOGGER.debug(
+                        "Could not apply Spark config when attaching to active context",
+                        extra={
+                            "platform": self.name,
+                            "event": "spark_session_attach_config_skip",
+                            "key": key,
+                        },
+                    )
+            _log(
+                "spark_session_attach_active_sparkcontext",
                 "Attached to existing active SparkContext for Fabric",
-                extra={
-                    "platform": self.name,
-                    "event": "spark_session_attach_active_sparkcontext",
-                },
             )
             return session
 
@@ -73,17 +76,11 @@ class FabricPlatform(PlatformBase):
             self.config.get("app_name", "datacore-fabric")
         )
 
-        for key, value in (opts or {}).items():
-            builder = builder.config(key, value)
-
-        for key, value in self.config.get("extra_conf", {}).items():
+        for key, value in config_items:
             builder = builder.config(key, value)
 
         session = builder.getOrCreate()
-        LOGGER.info(
-            "Creating new SparkSession for Fabric (no active context found)",
-            extra={"platform": self.name, "event": "spark_session_create"},
-        )
+        _log("spark_session_create", "Creating new SparkSession for Fabric (no active context found)")
         return session
 
     def _resolve_platform_secret(self, name: str) -> str:

--- a/datacore/providers/fabric/lakehouse.py
+++ b/datacore/providers/fabric/lakehouse.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import logging
 from time import perf_counter
-from typing import Any, Dict, Optional
-from urllib.parse import urlparse
+from typing import Any, Dict
+
+from datacore.providers.fabric.uris import (
+    parse_fabric_lakehouse_uri,
+    resolve_fabric_files_path,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -15,50 +19,6 @@ def _spark():
     from pyspark.sql import SparkSession
 
     return SparkSession.builder.getOrCreate()
-
-
-def _fabric_table_from_uri(uri: str) -> tuple[bool, Optional[tuple[str, str]]]:
-    """Return schema/table when the URI points to a Fabric Lakehouse table."""
-
-    if not uri:
-        return False, None
-
-    parsed = urlparse(uri)
-    segments: list[str] = []
-    if parsed.netloc:
-        segments.append(parsed.netloc)
-    segments.extend(seg for seg in parsed.path.split("/") if seg)
-
-    if not segments:
-        return False, None
-
-    tables_index: Optional[int] = next(
-        (idx for idx, value in enumerate(segments) if value.lower() == "tables"),
-        None,
-    )
-    if tables_index is None:
-        return False, None
-
-    remainder = segments[tables_index + 1 :]
-    if not remainder:
-        return True, None
-
-    schema: Optional[str]
-    table: Optional[str]
-    if len(remainder) == 1:
-        item = remainder[0]
-        if "." in item:
-            schema, table = item.split(".", 1)
-        else:
-            schema, table = "dbo", item
-    else:
-        schema = remainder[0] or "dbo"
-        table = remainder[1] if len(remainder) > 1 else None
-
-    if not table:
-        return True, None
-
-    return True, (schema or "dbo", table)
 
 
 def write_delta(env, df, table_uri: str, options: Dict[str, Any]) -> None:
@@ -77,52 +37,47 @@ def write_delta(env, df, table_uri: str, options: Dict[str, Any]) -> None:
         writer = writer.options(**extra)
     mode_value = str(opts.get("mode", "append"))
     normalized_mode = mode_value.lower()
-    is_tables_uri, table_identifier = _fabric_table_from_uri(table_uri)
+    ref = parse_fabric_lakehouse_uri(table_uri)
 
-    if table_identifier:
-        schema, table = table_identifier
-        LOGGER.info(
-            "Fabric Lakehouse table sink detected",
-            extra={
-                "platform": "fabric",
-                "event": "fabric_table_sink_detected",
-                "schema": schema,
-                "table": table,
-                "uri": table_uri,
-            },
-        )
+    if ref.is_lakehouse and ref.kind == "tables" and ref.full_table_name:
         if normalized_mode == "overwrite":
             writer = writer.mode("overwrite").option("overwriteSchema", "true")
         else:
-            writer = writer.mode("append") if normalized_mode == "append" else writer.mode(mode_value)
+            writer = writer.mode(mode_value)
         LOGGER.info(
-            "Usando saveAsTable para Lakehouse",
+            "Fabric managed table write",
             extra={
-                "platform": "fabric",
-                "event": "fabric_table_saveas",
-                "schema": schema,
-                "table": table,
+                "event": "fabric_save_as_managed_table",
+                "backend": "fabric",
+                "lakehouse": ref.lakehouse,
+                "schema": ref.schema,
+                "table": ref.table,
                 "mode": normalized_mode,
-                "uri": table_uri,
             },
         )
-        writer.saveAsTable(f"{schema}.{table}")
-    else:
-        if is_tables_uri:
-            LOGGER.warning(
-                "No se pudo interpretar la ruta de tabla de Fabric",
-                extra={
-                    "platform": "fabric",
-                    "event": "fabric_table_parse_failed",
-                    "uri": table_uri,
-                },
-            )
+        writer.saveAsTable(ref.full_table_name)
+    elif ref.is_lakehouse and ref.kind == "files" and ref.lakehouse:
+        resolved = resolve_fabric_files_path(ref)
         LOGGER.info(
-            "Escritura estilo archivos para Fabric",
+            "Fabric files write",
             extra={
-                "platform": "fabric",
-                "event": "fabric_file_sink",
+                "event": "fabric_write_files_path",
+                "backend": "fabric",
+                "lakehouse": ref.lakehouse,
+                "resolved_path": resolved,
+                "mode": mode_value,
+            },
+        )
+        writer = writer.mode(mode_value)
+        writer.save(resolved)
+    else:
+        LOGGER.info(
+            "Fabric raw path write",
+            extra={
+                "event": "fabric_raw_path_write",
+                "backend": "fabric",
                 "uri": table_uri,
+                "mode": mode_value,
             },
         )
         writer = writer.mode(mode_value)

--- a/datacore/providers/fabric/uris.py
+++ b/datacore/providers/fabric/uris.py
@@ -1,0 +1,108 @@
+"""Utilities to parse Fabric Lakehouse URIs."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal, Optional
+from urllib.parse import urlparse
+
+
+FabricUriKind = Literal["tables", "files", "unknown"]
+
+
+def _default_schema() -> str:
+    return os.getenv("FABRIC_DEFAULT_SCHEMA", "dbo")
+
+
+@dataclass(frozen=True)
+class FabricLakehouseReference:
+    """Structured representation of a ``lakehouse://`` URI."""
+
+    raw_uri: str
+    is_lakehouse: bool
+    lakehouse: Optional[str]
+    kind: FabricUriKind
+    schema: Optional[str]
+    table: Optional[str]
+    subpath: Optional[str]
+
+    @property
+    def full_table_name(self) -> Optional[str]:
+        if self.schema and self.table:
+            return f"{self.schema}.{self.table}"
+        return None
+
+
+def parse_fabric_lakehouse_uri(uri: str) -> FabricLakehouseReference:
+    """Parse Fabric Lakehouse URIs into structured components."""
+
+    parsed = urlparse(uri)
+    if parsed.scheme.lower() != "lakehouse":
+        return FabricLakehouseReference(
+            raw_uri=uri,
+            is_lakehouse=False,
+            lakehouse=None,
+            kind="unknown",
+            schema=None,
+            table=None,
+            subpath=None,
+        )
+
+    path_segments = [segment for segment in parsed.path.split("/") if segment]
+    lakehouse = parsed.netloc or (path_segments.pop(0) if path_segments else None)
+    kind: FabricUriKind = "unknown"
+    schema: Optional[str] = None
+    table: Optional[str] = None
+    subpath: Optional[str] = None
+
+    if path_segments:
+        candidate = path_segments.pop(0)
+        lowered = candidate.lower()
+        if lowered == "tables":
+            kind = "tables"
+            remainder = path_segments
+            if remainder:
+                if len(remainder) == 1:
+                    item = remainder[0]
+                    if "." in item:
+                        schema, table = item.split(".", 1)
+                    else:
+                        schema = _default_schema()
+                        table = item
+                else:
+                    schema = remainder[0] or _default_schema()
+                    table = remainder[1] if len(remainder) > 1 else None
+        elif lowered == "files":
+            kind = "files"
+            remainder = [segment for segment in path_segments if segment]
+            if remainder:
+                subpath = "/".join(remainder)
+    return FabricLakehouseReference(
+        raw_uri=uri,
+        is_lakehouse=True,
+        lakehouse=lakehouse,
+        kind=kind,
+        schema=schema,
+        table=table,
+        subpath=subpath,
+    )
+
+
+def resolve_fabric_files_path(ref: FabricLakehouseReference) -> str:
+    """Resolve ``lakehouse://.../files`` URIs to a physical path."""
+
+    template = os.getenv("FABRIC_LAKEHOUSE_FILES_BASE")
+    lakehouse = ref.lakehouse or "default"
+    subpath = ref.subpath or ""
+
+    if template:
+        base = template.replace("{lakehouse}", lakehouse).replace("${lakehouse}", lakehouse)
+        base = base.rstrip("/")
+        return f"{base}/{subpath}" if subpath else base
+
+    mount_base = os.getenv("FABRIC_LAKEHOUSE_MOUNT_BASE", "/lakehouse")
+    base_path = f"{mount_base.rstrip('/')}/{lakehouse}/Files"
+    if subpath:
+        return f"{base_path}/{subpath}"
+    return base_path

--- a/datacore/providers/fabric/uris.py
+++ b/datacore/providers/fabric/uris.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass
 from typing import Literal, Optional
 from urllib.parse import urlparse
 
-
-FabricUriKind = Literal["tables", "files", "unknown"]
+FabricUriKind = Literal["tables", "files"]
 
 
 def _default_schema() -> str:
@@ -22,7 +21,7 @@ class FabricLakehouseReference:
     raw_uri: str
     is_lakehouse: bool
     lakehouse: Optional[str]
-    kind: FabricUriKind
+    kind: Optional[FabricUriKind]
     schema: Optional[str]
     table: Optional[str]
     subpath: Optional[str]
@@ -43,7 +42,7 @@ def parse_fabric_lakehouse_uri(uri: str) -> FabricLakehouseReference:
             raw_uri=uri,
             is_lakehouse=False,
             lakehouse=None,
-            kind="unknown",
+            kind=None,
             schema=None,
             table=None,
             subpath=None,
@@ -51,7 +50,7 @@ def parse_fabric_lakehouse_uri(uri: str) -> FabricLakehouseReference:
 
     path_segments = [segment for segment in parsed.path.split("/") if segment]
     lakehouse = parsed.netloc or (path_segments.pop(0) if path_segments else None)
-    kind: FabricUriKind = "unknown"
+    kind: Optional[FabricUriKind] = None
     schema: Optional[str] = None
     table: Optional[str] = None
     subpath: Optional[str] = None
@@ -61,18 +60,20 @@ def parse_fabric_lakehouse_uri(uri: str) -> FabricLakehouseReference:
         lowered = candidate.lower()
         if lowered == "tables":
             kind = "tables"
-            remainder = path_segments
+            remainder = [segment for segment in path_segments if segment]
             if remainder:
                 if len(remainder) == 1:
                     item = remainder[0]
                     if "." in item:
-                        schema, table = item.split(".", 1)
+                        schema_part, table_part = item.split(".", 1)
+                        schema = schema_part or _default_schema()
+                        table = table_part or None
                     else:
                         schema = _default_schema()
                         table = item
                 else:
                     schema = remainder[0] or _default_schema()
-                    table = remainder[1] if len(remainder) > 1 else None
+                    table = remainder[-1]
         elif lowered == "files":
             kind = "files"
             remainder = [segment for segment in path_segments if segment]

--- a/docs/fabric.md
+++ b/docs/fabric.md
@@ -65,29 +65,49 @@ El módulo `datacore.providers.fabric.lakehouse` utiliza `delta-spark` para leer
 
 Los secretos referenciados como `secret://kv/<vault>/<secret>` se resuelven automáticamente mediante Azure Key Vault (`DefaultAzureCredential`). Para otros backends (`secret://sm/`, `secret://gcp/`) se delega en AWS Secrets Manager o Google Secret Manager respectivamente, devolviendo errores claros si las dependencias no están instaladas.
 
-### Escritura en tablas administradas
+### Tablas administradas
 
-Cuando el `sink` apunta a un Lakehouse de Fabric utilizando el backend `fabric` y la ruta `lakehouse://<nombre_lakehouse>/tables/<esquema>/<tabla>`, el motor escribe directamente con `saveAsTable`. Esto genera el layout Delta administrado que espera la UI de Fabric, sin carpetas intermedias "Unidentified/Sin identificar".
+Cuando un `source` o `sink` utiliza el backend `fabric` y la ruta `lakehouse://<lakehouse>/tables/<esquema>/<tabla>`, el motor resuelve automáticamente el catálogo de Fabric. Las escrituras se realizan con `saveAsTable` y las lecturas con `spark.table`, evitando el acceso directo a `Tables/` y las carpetas "Unidentified/Sin identificar".
 
 ```yaml
-sink:
+source:
   type: storage
   backend: fabric
+  format: delta
   uri: "lakehouse://contoso-lh/tables/dbo/customers_raw"
-  options:
-    mode: overwrite
-```
 
-Para rutas que apuntan a `Files/`, el comportamiento continúa siendo estilo archivos (`writer.save(path)`), útil para aterrizar datos crudos o stageados:
-
-```yaml
 sink:
   type: storage
   backend: fabric
-  uri: "https://onelake.dfs.fabric.microsoft.com/workspaces/<ws>/Lakehouses/<lh>/Files/landing/sales/"
-  options:
-    mode: append
+  format: delta
+  uri: "lakehouse://contoso-lh/tables/silver/customers_enriched"
+  mode: overwrite
 ```
+
+Si el esquema no se especifica en la URI se utilizará `dbo` por defecto o el valor definido en la variable de entorno `FABRIC_DEFAULT_SCHEMA`.
+
+### Archivos en `Files`
+
+Para trabajar con archivos crudos basta con apuntar a `lakehouse://<lakehouse>/files/<ruta>`. El conector traduce la URI al montaje del Lakehouse adjunto antes de invocar `.load`/`.save`.
+
+```yaml
+source:
+  type: storage
+  backend: fabric
+  format: csv
+  uri: "lakehouse://contoso-lh/files/raw/customers/customers.csv"
+  options:
+    header: true
+
+sink:
+  type: storage
+  backend: fabric
+  format: delta
+  uri: "lakehouse://contoso-lh/files/staging/customers_delta"
+  mode: append
+```
+
+> ⚠️ Las rutas `https://onelake.dfs.fabric.microsoft.com/.../Tables/...` se tratan como paths físicos. Usarlas puede volver a generar carpetas "Unidentified" en Fabric, por lo que se recomienda migrar a `lakehouse://.../tables/...`.
 
 ## Warehouse y SQL Endpoint
 

--- a/tests/unit/connectors/test_fabric_storage.py
+++ b/tests/unit/connectors/test_fabric_storage.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datacore.connectors.storage import fabric
+
+
+class DummyWriter:
+    def __init__(self):
+        self.format_value = None
+        self.partition_by = None
+        self.options: dict[str, object] = {}
+        self.mode_calls: list[str] = []
+        self.saved_path: str | None = None
+        self.saved_table: str | None = None
+
+    def format(self, fmt):  # type: ignore[override]
+        self.format_value = fmt
+        return self
+
+    def partitionBy(self, *cols):  # type: ignore[override]
+        self.partition_by = cols
+        return self
+
+    def option(self, key, value):  # type: ignore[override]
+        self.options[key] = value
+        return self
+
+    def mode(self, value):  # type: ignore[override]
+        self.mode_calls.append(value)
+        return self
+
+    def saveAsTable(self, table):  # type: ignore[override]
+        self.saved_table = table
+        return None
+
+    def save(self, path):  # type: ignore[override]
+        self.saved_path = path
+        return None
+
+
+class DummyDataFrame:
+    def __init__(self):
+        self.write = DummyWriter()
+
+
+class DummyReader:
+    def __init__(self):
+        self.format_value = None
+        self.options: dict[str, object] = {}
+        self.schema_value = None
+        self.loaded_path: str | None = None
+
+    def format(self, fmt):  # type: ignore[override]
+        self.format_value = fmt
+        return self
+
+    def option(self, key, value):  # type: ignore[override]
+        self.options[key] = value
+        return self
+
+    def schema(self, schema):  # type: ignore[override]
+        self.schema_value = schema
+        return self
+
+    def load(self, path):  # type: ignore[override]
+        self.loaded_path = path
+        return f"loaded:{path}"
+
+
+class DummySpark:
+    def __init__(self):
+        self.table_calls: list[str] = []
+        self.read = DummyReader()
+
+    def table(self, name):
+        self.table_calls.append(name)
+        return f"table:{name}"
+
+
+def test_write_managed_table_with_explicit_schema():
+    df = DummyDataFrame()
+    fabric.write(
+        df,
+        "lakehouse://demo/tables/dbo/customers_raw",
+        "delta",
+        "overwrite",
+        {"mergeSchema": True},
+    )
+    writer = df.write
+    assert writer.format_value == "delta"
+    assert writer.saved_table == "dbo.customers_raw"
+    assert writer.saved_path is None
+    assert "overwriteSchema" in writer.options
+    assert writer.mode_calls[-1] == "overwrite"
+
+
+def test_write_managed_table_uses_default_schema(monkeypatch):
+    monkeypatch.setenv("FABRIC_DEFAULT_SCHEMA", "finance")
+    df = DummyDataFrame()
+    fabric.write(
+        df,
+        "lakehouse://demo/tables/customers_curated",
+        "delta",
+        "append",
+        {},
+    )
+    writer = df.write
+    assert writer.saved_table == "finance.customers_curated"
+    assert writer.mode_calls[-1] == "append"
+
+
+def test_read_managed_table_uses_catalog():
+    spark = DummySpark()
+    result = fabric.read(
+        spark,
+        "lakehouse://demo/tables/dbo/customers_raw",
+        "delta",
+        {"dummy": "1"},
+        schema=None,
+    )
+    assert result == "table:dbo.customers_raw"
+    assert spark.table_calls == ["dbo.customers_raw"]
+    assert spark.read.loaded_path is None
+
+
+def test_read_files_resolves_mount():
+    spark = DummySpark()
+    df = fabric.read(
+        spark,
+        "lakehouse://demo/files/raw/customers/data.csv",
+        "csv",
+        {"header": "true"},
+        schema=None,
+    )
+    assert df == "loaded:/lakehouse/demo/Files/raw/customers/data.csv"
+    assert spark.read.format_value == "csv"
+
+
+def test_write_files_resolves_mount():
+    df = DummyDataFrame()
+    fabric.write(
+        df,
+        "lakehouse://demo/files/silver/customers",
+        "delta",
+        "overwrite",
+        {},
+    )
+    writer = df.write
+    assert writer.saved_path == "/lakehouse/demo/Files/silver/customers"
+    assert writer.saved_table is None
+    assert writer.mode_calls[-1] == "overwrite"

--- a/tests/unit/providers/fabric/test_lakehouse.py
+++ b/tests/unit/providers/fabric/test_lakehouse.py
@@ -101,7 +101,7 @@ def test_optimize_delta_with_zorder(dummy_spark):
     ]
 
 
-def test_write_delta_keeps_file_behavior_for_files_uri(dummy_spark):
+def test_write_delta_keeps_raw_behavior_for_https_uri(dummy_spark):
     df = DummyDataFrame()
     lakehouse.write_delta(
         None,
@@ -115,15 +115,23 @@ def test_write_delta_keeps_file_behavior_for_files_uri(dummy_spark):
     assert writer.mode_calls[-1] == "append"
 
 
-def test_write_delta_detects_onelake_tables_url(dummy_spark):
+def test_write_delta_resolves_lakehouse_files_uri(dummy_spark, monkeypatch):
     df = DummyDataFrame()
+    monkeypatch.setattr(
+        lakehouse,
+        "resolve_fabric_files_path",
+        lambda ref: f"/lakehouse/{ref.lakehouse}/Files/{ref.subpath}",
+    )
     lakehouse.write_delta(
         None,
         df,
-        "https://onelake.dfs.fabric.microsoft.com/workspaces/ws/Lakehouses/lh/Tables/sales/customers",
-        {"mode": "append"},
+        "lakehouse://mvp-lakehouse/files/raw/customers/data.parquet",
+        {"mode": "overwrite"},
     )
     writer = df.write
-    assert writer.save_as_table_name == "sales.customers"
-    assert writer.saved_path is None
-    assert writer.mode_calls[-1] == "append"
+    assert writer.save_as_table_name is None
+    assert (
+        writer.saved_path
+        == "/lakehouse/mvp-lakehouse/Files/raw/customers/data.parquet"
+    )
+    assert writer.mode_calls[-1] == "overwrite"

--- a/tests/unit/test_platform_sessions.py
+++ b/tests/unit/test_platform_sessions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from datacore.core.engine import _prepare_spark
@@ -106,8 +108,6 @@ def test_fabric_platform_reuses_instantiated_session(monkeypatch):
 
 
 def test_fabric_platform_attaches_active_spark_context(monkeypatch):
-    attached_session = object()
-
     class GuardBuilder:
         def appName(self, _):  # pragma: no cover - should not be called
             raise AssertionError("appName should not be used when attaching")
@@ -117,6 +117,13 @@ def test_fabric_platform_attaches_active_spark_context(monkeypatch):
 
         def getOrCreate(self):  # pragma: no cover - should not be used
             raise AssertionError("builder.getOrCreate should not be called when attaching")
+
+    class DummyConf:
+        def __init__(self):
+            self.settings: dict[str, Any] = {}
+
+        def set(self, key, value):  # noqa: D401 - mimic Spark API
+            self.settings[key] = value
 
     class DummySparkSession:
         builder = GuardBuilder()
@@ -132,29 +139,37 @@ def test_fabric_platform_attaches_active_spark_context(monkeypatch):
             return None
 
         def __new__(cls, sc):
+            instance = object.__new__(cls)
+            instance.conf = DummyConf()
             cls.created_with = sc
-            return attached_session
+            return instance
 
     class DummySparkContext:
         _active_spark_context = object()
-        get_or_create_calls = 0
-        returned_context = object()
 
         @classmethod
-        def getOrCreate(cls):  # noqa: N802 - keep pyspark naming
-            cls.get_or_create_calls += 1
-            return cls.returned_context
+        def getActive(cls):  # noqa: N802 - keep pyspark naming
+            return cls._active_spark_context
+
+        @classmethod
+        def getOrCreate(cls):  # pragma: no cover - should not be used
+            raise AssertionError("getOrCreate should not be invoked when context is active")
 
     monkeypatch.setattr("datacore.platforms.fabric.SparkSession", DummySparkSession)
     monkeypatch.setattr("datacore.platforms.fabric.SparkContext", DummySparkContext)
 
-    platform = FabricPlatform(config={})
+    platform = FabricPlatform(
+        config={"extra_conf": {"spark.sql.adaptive.enabled": "true"}}
+    )
 
-    session = platform.build_spark_session({})
+    session = platform.build_spark_session({"spark.executor.instances": "3"})
 
-    assert session is attached_session
-    assert DummySparkContext.get_or_create_calls == 1
-    assert DummySparkSession.created_with is DummySparkContext.returned_context
+    assert isinstance(session, DummySparkSession)
+    assert DummySparkSession.created_with is DummySparkContext._active_spark_context
+    assert session.conf.settings == {
+        "spark.executor.instances": "3",
+        "spark.sql.adaptive.enabled": "true",
+    }
 
 
 def test_fabric_platform_creates_new_session_when_no_context(monkeypatch):


### PR DESCRIPTION
## Summary
- add a Fabric storage connector that resolves `lakehouse://` tables via the catalog and files via the mounted lakehouse path
- centralize Fabric lakehouse URI parsing and reuse it in the delta writer plus the generic storage readers/writers
- update documentation and tests to reflect the managed table and files semantics for Fabric

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912165c99e88320b799184d0728225e)